### PR TITLE
binding goals to maven lifecycle by default

### DIFF
--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/BuildMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/BuildMojo.java
@@ -71,8 +71,10 @@ public class BuildMojo extends AbstractFunctionMojo {
     protected void outputJsonFile(final Map<String, FunctionConfiguration> configMap) throws IOException {
         final ObjectMapper mapper = new ObjectMapper();
         for (final Map.Entry<String, FunctionConfiguration> config : configMap.entrySet()) {
+            getLog().info("Starting processing function: " + config.getKey());
             final File file = getFunctionJsonFile(config.getKey());
             mapper.writerWithDefaultPrettyPrinter().writeValue(file, config.getValue());
+            getLog().info("Successfully write to " + file.getAbsolutePath());
         }
     }
 

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/BuildMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/BuildMojo.java
@@ -74,7 +74,7 @@ public class BuildMojo extends AbstractFunctionMojo {
             getLog().info("Starting processing function: " + config.getKey());
             final File file = getFunctionJsonFile(config.getKey());
             mapper.writerWithDefaultPrettyPrinter().writeValue(file, config.getValue());
-            getLog().info("Successfully write to " + file.getAbsolutePath());
+            getLog().info("Successfully saved to " + file.getAbsolutePath());
         }
     }
 

--- a/azure-functions-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/azure-functions-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,52 @@
+<component-set>
+    <components>
+        <component>
+            <!--
+                This lifecycle mapping is based on the jar lifecycle mapping;
+                differences highlighted below
+            -->
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>azure-functions</role-hint>
+            <implementation>
+                org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping
+            </implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>
+                                org.apache.maven.plugins:maven-resources-plugin:resources
+                            </process-resources>
+                            <compile>
+                                org.apache.maven.plugins:maven-compiler-plugin:compile
+                            </compile>
+                            <process-test-resources>
+                                org.apache.maven.plugins:maven-resources-plugin:testResources
+                            </process-test-resources>
+                            <test-compile>
+                                org.apache.maven.plugins:maven-compiler-plugin:testCompile
+                            </test-compile>
+                            <test>
+                                org.apache.maven.plugins:maven-surefire-plugin:test
+                            </test>
+                            <package>
+                                org.apache.maven.plugins:maven-jar-plugin:jar,
+                                <!-- Added -->
+                                ${project.groupId}:${project.artifactId}:build
+                            </package>
+                            <install>
+                                org.apache.maven.plugins:maven-install-plugin:install
+                            </install>
+                            <deploy>
+                                org.apache.maven.plugins:maven-deploy-plugin:deploy,
+                                <!-- Added -->
+                                ${project.groupId}:${project.artifactId}:deploy
+                            </deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+    </components>
+</component-set>


### PR DESCRIPTION
With the `components.xml` in this PR, goals from functions Maven plugin will be automatically executed with maven phases.
For example, `mvn package` will invoke `azure-functions:build`automatically.
`mvn deploy` will invoke `azure-functions:deploy` automatically.

>NOTE:
>Still considering whether I should rename goal `build` to `package`. Please ignore naming for now.