### PR TITLE
fix NoClassDefFoundError from application insights

### DIFF
--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -20,7 +20,7 @@
         <maven.plugin-testing.version>3.3.0</maven.plugin-testing.version>
         <codehaus.plexus-utils.version>3.0.20</codehaus.plexus-utils.version>
         <azure.version>1.1.2</azure.version>
-        <azure.ai.version>1.0.8</azure.ai.version>
+        <azure.ai.version>1.0.9</azure.ai.version>
         <azure.maven-plugin-lib.version>0.1.4</azure.maven-plugin-lib.version>
         <azure.function.version>1.0-SNAPSHOT</azure.function.version>
         <azure.storage.version>5.4.0</azure.storage.version>

--- a/azure-maven-plugin-lib/pom.xml
+++ b/azure-maven-plugin-lib/pom.xml
@@ -22,7 +22,7 @@
         <azure.version>1.1.2</azure.version>
         <azure.client-runtime.version>1.0.4</azure.client-runtime.version>
         <azure.client-auth.version>1.0.4</azure.client-auth.version>
-        <azure.ai.version>1.0.8</azure.ai.version>
+        <azure.ai.version>1.0.9</azure.ai.version>
         <common-net.version>3.6</common-net.version>
         <junit.version>4.12</junit.version>
         <mockito.version>2.4.0</mockito.version>

--- a/azure-webapp-maven-plugin/pom.xml
+++ b/azure-webapp-maven-plugin/pom.xml
@@ -19,7 +19,7 @@
         <maven.plugin-tools.version>3.2</maven.plugin-tools.version>
         <maven.plugin-testing.version>3.3.0</maven.plugin-testing.version>
         <codehaus.plexus-utils.version>3.0.20</codehaus.plexus-utils.version>
-        <azure.ai.version>1.0.8</azure.ai.version>
+        <azure.ai.version>1.0.9</azure.ai.version>
         <azure.maven-plugin-lib.version>0.1.4</azure.maven-plugin-lib.version>
         <junit.version>4.12</junit.version>
         <mockito.version>2.4.0</mockito.version>


### PR DESCRIPTION
Sometimes, NoClassDefFoundError will be thrown from Application Insights Java SDK even after Maven build is completed successfully.
An issue has been filed at https://github.com/Microsoft/ApplicationInsights-Java/issues/416
Before this issue is fixed, set default uncaught exception handler for all threads as work around.