### PR TITLE
Can add function non-interactively

### DIFF
--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-functions-maven-plugin</artifactId>
-    <version>0.1.6-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
     <name>Maven Plugin for Azure Functions</name>
     <description>Maven Plugin for Azure Functions</description>

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AddMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AddMojo.java
@@ -242,7 +242,7 @@ public class AddMojo extends AbstractFunctionMojo {
             info(format("Trigger specific parameter [%s]", property));
 
             assureInputFromUser(format("Enter value for %s: ", property),
-                    null,
+                    System.getProperty(property),
                     str -> isNotEmpty(str),
                     "Input should be a non-empty string.",
                     str -> params.put(property, str));


### PR DESCRIPTION
For example, if user want to add TimerTrigger function non-interactively:

```
mvn azure-functions:add -Dfunctions.package=com.function -Dfunctions.name=NewFunction -Dfunctions.template=TimerTrigger -Dschedule=value
```