### PR TITLE
add batch mode for add function

### DIFF
--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-functions-maven-plugin</artifactId>
-    <version>0.1.6-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
     <name>Maven Plugin for Azure Functions</name>
     <description>Maven Plugin for Azure Functions</description>

--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -24,7 +24,7 @@
         <codehaus.plexus-utils.version>3.0.20</codehaus.plexus-utils.version>
         <azure.ai.version>1.0.9</azure.ai.version>
         <azure.maven-plugin-lib.version>0.1.6-SNAPSHOT</azure.maven-plugin-lib.version>
-        <azure.function.version>1.0.0-beta-1</azure.function.version>
+        <azure.function.version>[1.0.0-beta-1,1.0.0)</azure.function.version>
         <azure.storage.version>5.4.0</azure.storage.version>
         <reflections.version>0.9.11</reflections.version>
         <zeroturnaround.zip.version>1.12</zeroturnaround.zip.version>

--- a/azure-functions-maven-plugin/src/it/http-trigger/pom.xml
+++ b/azure-functions-maven-plugin/src/it/http-trigger/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-functions-java-core</artifactId>
-            <version>1.0.0-beta-1</version>
+            <version>[1.0.0-beta-1,1.0.0)</version>
         </dependency>
 
         <!-- Test -->

--- a/azure-functions-maven-plugin/src/it/http-trigger/src/main/java/com/microsoft/azure/Function.java
+++ b/azure-functions-maven-plugin/src/it/http-trigger/src/main/java/com/microsoft/azure/Function.java
@@ -21,7 +21,7 @@ public class Function {
         context.getLogger().info("Java HTTP trigger processed a HTTP request.");
 
         // Parse query parameter
-        String name = request.getQueryParameters().get("name");
+        String name = request.getQueryParameters().get("name").toString();
 
         if (name == null) {
             // Get request body

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AddMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AddMojo.java
@@ -8,7 +8,6 @@ package com.microsoft.azure.maven.function;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.maven.function.template.FunctionTemplate;
-
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -421,13 +420,13 @@ public class AddMojo extends AbstractFunctionMojo {
             info(FOUND_VALID_VALUE);
             setter.accept(input);
             return;
+        }
+
+        if (required) {
+            throw new MojoFailureException(String.format("invalid input: %s", input));
         } else {
-            if (required) {
-                throw new MojoFailureException(String.format("invalid input: %s", input));
-            } else {
-                out.printf("The input is invalid. Use empty string.%n");
-                setter.accept("");
-            }
+            out.printf("The input is invalid. Use empty string.%n");
+            setter.accept("");
         }
     }
 

--- a/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/AddMojoTest.java
+++ b/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/AddMojoTest.java
@@ -6,6 +6,8 @@
 
 package com.microsoft.azure.maven.function;
 
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.settings.Settings;
 import org.codehaus.plexus.util.ReflectionUtils;
 import org.junit.Test;
 
@@ -51,17 +53,32 @@ public class AddMojoTest extends MojoTestBase {
     }
 
     @Test
-    public void assureInputFromUser() throws Exception {
+    public void assureInputFromUserInteractively() throws Exception {
         final AddMojo mojo = getMojoFromPom();
         final AddMojo mojoSpy = spy(mojo);
         final Scanner scanner = mock(Scanner.class);
+        final Settings settings = mock(Settings.class);
         doReturn("2").when(scanner).nextLine();
         doReturn(scanner).when(mojoSpy).getScanner();
+        doReturn(settings).when(mojoSpy).getSettings();
+        doReturn(true).when(settings).isInteractiveMode();
 
         final Set<String> set = new HashSet<>();
-        mojoSpy.assureInputFromUser("property", "", Arrays.asList("a0", "a1", "a2"), str -> set.add(str));
+        mojoSpy.assureInputFromUser("property", "", Arrays.asList("a0", "a1", "a2"), set::add, true);
 
         assertTrue(set.contains("a2"));
+    }
+
+    @Test(expected = MojoFailureException.class)
+    public void assureInputFromUserNonInteractively() throws Exception{
+        final AddMojo mojo = getMojoFromPom();
+        final AddMojo mojoSpy = spy(mojo);
+        final Settings settings = mock(Settings.class);
+        doReturn(settings).when(mojoSpy).getSettings();
+        doReturn(false).when(settings).isInteractiveMode();
+
+        final Set<String> set = new HashSet<>();
+        mojoSpy.assureInputFromUser("property", "", Arrays.asList("a0", "a1", "a2"), set::add, true);
     }
 
     private AddMojo getMojoFromPom() throws Exception {

--- a/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/AddMojoTest.java
+++ b/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/AddMojoTest.java
@@ -9,6 +9,7 @@ package com.microsoft.azure.maven.function;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.settings.Settings;
 import org.codehaus.plexus.util.ReflectionUtils;
+import org.codehaus.plexus.util.StringUtils;
 import org.junit.Test;
 
 import java.io.File;
@@ -53,32 +54,37 @@ public class AddMojoTest extends MojoTestBase {
     }
 
     @Test
-    public void assureInputFromUserInteractively() throws Exception {
+    public void assureInputFromUser() throws Exception {
         final AddMojo mojo = getMojoFromPom();
         final AddMojo mojoSpy = spy(mojo);
         final Scanner scanner = mock(Scanner.class);
-        final Settings settings = mock(Settings.class);
         doReturn("2").when(scanner).nextLine();
         doReturn(scanner).when(mojoSpy).getScanner();
-        doReturn(settings).when(mojoSpy).getSettings();
-        doReturn(true).when(settings).isInteractiveMode();
 
         final Set<String> set = new HashSet<>();
-        mojoSpy.assureInputFromUser("property", "", Arrays.asList("a0", "a1", "a2"), set::add, true);
+        mojoSpy.assureInputFromUser("property", "", Arrays.asList("a0", "a1", "a2"), set::add);
 
         assertTrue(set.contains("a2"));
     }
 
     @Test(expected = MojoFailureException.class)
-    public void assureInputFromUserNonInteractively() throws Exception{
+    public void assureInputInBatchModeWhenRequired() throws Exception{
         final AddMojo mojo = getMojoFromPom();
         final AddMojo mojoSpy = spy(mojo);
-        final Settings settings = mock(Settings.class);
-        doReturn(settings).when(mojoSpy).getSettings();
-        doReturn(false).when(settings).isInteractiveMode();
 
         final Set<String> set = new HashSet<>();
-        mojoSpy.assureInputFromUser("property", "", Arrays.asList("a0", "a1", "a2"), set::add, true);
+        mojoSpy.assureInputInBatchMode("", StringUtils::isNotEmpty, set::add, true);
+    }
+
+    @Test
+    public void assureInputInBatchModeWhenNotRequired() throws Exception{
+        final AddMojo mojo = getMojoFromPom();
+        final AddMojo mojoSpy = spy(mojo);
+
+        final Set<String> set = new HashSet<>();
+        mojoSpy.assureInputInBatchMode("a0", StringUtils::isNotEmpty, set::add, true);
+
+        assertTrue(set.contains("a0"));
     }
 
     private AddMojo getMojoFromPom() throws Exception {


### PR DESCRIPTION
This PR add the batch mode for maven add function goal.

When calling ```assureInputFromUser()``` for each property, we add a boolean param to the method to specify whether this property is required or not.

If the user is in batch mode and the property is required, the maven goal will throw MojoFailureException when the input in invalid, if is not required, we will use empty string to replace it.

If the user is in interactive mode, the experice is not changed as previous.