### PR TITLE
downgrade reflections version to 0.9.10

### DIFF
--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/AnnotationHandlerImpl.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/AnnotationHandlerImpl.java
@@ -38,7 +38,7 @@ public class AnnotationHandlerImpl implements AnnotationHandler {
         return new Reflections(
                 new ConfigurationBuilder()
                         .addUrls(url)
-                        .addScanners(new MethodAnnotationsScanner())
+                        .setScanners(new MethodAnnotationsScanner())
                         .addClassLoader(getClassLoader(url)))
                 .getMethodsAnnotatedWith(FunctionName.class);
     }


### PR DESCRIPTION
This will fix #76 , https://github.com/Azure/azure-functions-java-worker/issues/43

Root cause is a bug in the Reflection v0.9.11: https://github.com/ronmamo/reflections/issues/190, when using `SubTypesScanner`. 

Since we are only interesting in the method annotation, and don't care the hierarchy.

So we use `setScanner` instead of `addScanner` which will remove the `SubTypesScanner`.