### PR TITLE
use <linuxRuntime> to set the linux runtime

### DIFF
--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
@@ -125,9 +125,18 @@ public abstract class AbstractWebAppMojo extends AbstractAzureMojo {
     protected String javaWebContainer;
 
     /**
+     * Below is the list of supported Linux runtime:
+     * <ul>
+     *     <li>tomcat 8.5-jre8</li>
+     *     <li>tomcat 9.0-jre8</li>
+     * </ul>
+     */
+    @Parameter(property = "webapp.linuxRuntime")
+    protected String linuxRuntime;
+
+    /**
      * Settings of docker container image within Web App. This only applies to Linux-based Web App.<br/>
      * Below are the supported sub-element within {@code <containerSettings>}:<br/>
-     * {@code <useBuiltInImage>} specifies whether built-in images are used in Web App on Linux.<br/>
      * {@code <imageName>} specifies docker image name to use in Web App on Linux<br/>
      * {@code <serverId>} specifies credentials to access docker image. Use it when you are using private Docker Hub
      * image or private registry.<br/>
@@ -215,6 +224,10 @@ public abstract class AbstractWebAppMojo extends AbstractAzureMojo {
 
     public JavaVersion getJavaVersion() {
         return StringUtils.isEmpty(javaVersion) ? null : JavaVersion.fromString(javaVersion);
+    }
+
+    public String getLinuxRuntime() {
+        return linuxRuntime;
     }
 
     public WebContainer getJavaWebContainer() {

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/WebAppUtils.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/WebAppUtils.java
@@ -52,10 +52,6 @@ public class WebAppUtils {
             return DockerImageType.NONE;
         }
 
-        if (containerSetting.isUseBuiltinImage()) {
-            return DockerImageType.BUILT_IN;
-        }
-
         final boolean isCustomRegistry = StringUtils.isNotEmpty(containerSetting.getRegistryUrl());
         final boolean isPrivate = StringUtils.isNotEmpty(containerSetting.getServerId());
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/configuration/ContainerSetting.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/configuration/ContainerSetting.java
@@ -15,17 +15,7 @@ import java.net.URL;
  */
 public class ContainerSetting {
     /**
-     * Whether to use built-in blessed image
-     */
-    private boolean useBuiltinImage;
-
-    /**
-     * Image name used for Web App on Linux or Web App for container.<br/>
-     * Below is the list of supported built-in image:
-     * <ul>
-     *     <li>tomcat 8.5-jre8</li>
-     *     <li>tomcat 9.0-jre8</li>
-     * </ul>
+     * Image name used for Web App on Linux or Web App for container.
      */
     private String imageName;
 
@@ -81,13 +71,5 @@ public class ContainerSetting {
                 StringUtils.isEmpty(getStartUpFile()) &&
                 StringUtils.isEmpty(getServerId()) &&
                 StringUtils.isEmpty(getRegistryUrl());
-    }
-
-    public boolean isUseBuiltinImage() {
-        return useBuiltinImage;
-    }
-
-    public void setUseBuiltinImage(boolean useBuiltinImage) {
-        this.useBuiltinImage = useBuiltinImage;
     }
 }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/configuration/DockerImageType.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/configuration/DockerImageType.java
@@ -11,6 +11,5 @@ public enum DockerImageType {
     PUBLIC_DOCKER_HUB,
     PRIVATE_DOCKER_HUB,
     PRIVATE_REGISTRY,
-    UNKNOWN,
-    BUILT_IN
+    UNKNOWN
 }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/HandlerFactoryImpl.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/HandlerFactoryImpl.java
@@ -29,7 +29,7 @@ public class HandlerFactoryImpl extends HandlerFactory {
         final ContainerSetting containerSetting = mojo.getContainerSettings();
 
         // No runtime setting is specified
-        if (javaVersion == null && linuxRuntime == null && (containerSetting == null || containerSetting.isEmpty())) {
+        if (javaVersion == null && linuxRuntime == null && isContainerSettingEmpty(containerSetting)) {
             return new NullRuntimeHandlerImpl();
         }
 
@@ -62,7 +62,7 @@ public class HandlerFactoryImpl extends HandlerFactory {
     }
 
     @Override
-    public SettingsHandler getSettingsHandler(final AbstractWebAppMojo mojo) throws MojoExecutionException {
+    public SettingsHandler getSettingsHandler(final AbstractWebAppMojo mojo) {
         return new SettingsHandlerImpl(mojo);
     }
 
@@ -81,7 +81,11 @@ public class HandlerFactoryImpl extends HandlerFactory {
 
     private boolean isDuplicatedRuntimeDefined(final JavaVersion javaVersion, final String linuxRuntime,
                                                final ContainerSetting containerSetting) {
-        return javaVersion != null ? linuxRuntime != null || (containerSetting != null && containerSetting.isEmpty()) :
-                linuxRuntime != null && (containerSetting != null && containerSetting.isEmpty());
+        return javaVersion != null ? linuxRuntime != null || !isContainerSettingEmpty(containerSetting) :
+                linuxRuntime != null && !isContainerSettingEmpty(containerSetting);
+    }
+
+    private boolean isContainerSettingEmpty(final ContainerSetting containerSetting) {
+        return containerSetting == null || containerSetting.isEmpty();
     }
 }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/LinuxRuntimeHandlerImpl.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/LinuxRuntimeHandlerImpl.java
@@ -15,14 +15,14 @@ import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.WebAppUtils;
 
-public class BuiltInImageRuntimeHandlerImpl implements RuntimeHandler {
+public class LinuxRuntimeHandlerImpl implements RuntimeHandler {
 
     private static final String NOT_SUPPORTED_IMAGE = "The image: '%s' is not supported.";
     private static final String IMAGE_NOT_GIVEN = "Image name is not specified.";
 
     private AbstractWebAppMojo mojo;
 
-    public BuiltInImageRuntimeHandlerImpl(AbstractWebAppMojo mojo) {
+    public LinuxRuntimeHandlerImpl(AbstractWebAppMojo mojo) {
         this.mojo = mojo;
     }
 
@@ -30,14 +30,14 @@ public class BuiltInImageRuntimeHandlerImpl implements RuntimeHandler {
     public WebApp.DefinitionStages.WithCreate defineAppWithRuntime() throws Exception {
         return WebAppUtils.defineApp(mojo)
                 .withNewLinuxPlan(mojo.getPricingTier())
-                .withBuiltInImage(this.getJavaRunTimeStack(mojo.getContainerSettings().getImageName()));
+                .withBuiltInImage(this.getJavaRunTimeStack(mojo.getLinuxRuntime()));
     }
 
     @Override
     public WebApp.Update updateAppRuntime(WebApp app) throws Exception {
         WebAppUtils.assureLinuxWebApp(app);
 
-        return app.update().withBuiltInImage(this.getJavaRunTimeStack(mojo.getContainerSettings().getImageName()));
+        return app.update().withBuiltInImage(this.getJavaRunTimeStack(mojo.getLinuxRuntime()));
     }
 
     private RuntimeStack getJavaRunTimeStack(String imageName) throws MojoExecutionException {

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/NullRuntimeHandlerImpl.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/NullRuntimeHandlerImpl.java
@@ -14,7 +14,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 
 public class NullRuntimeHandlerImpl implements RuntimeHandler {
     public static final String NO_RUNTIME_CONFIG = "No runtime stack is specified in pom.xml; " +
-            "use <javaVersion> or <containerSettings> to configure runtime stack.";
+            "use <javaVersion>, <linuxRuntime> or <containerSettings> to configure runtime stack.";
 
     @Override
     public WithCreate defineAppWithRuntime() throws Exception {

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/WebAppUtilsTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/WebAppUtilsTest.java
@@ -75,10 +75,6 @@ public class WebAppUtilsTest {
         containerSetting.setImageName("imageName");
         assertEquals(DockerImageType.PUBLIC_DOCKER_HUB, WebAppUtils.getDockerImageType(containerSetting));
 
-        containerSetting.setUseBuiltinImage(true);
-        assertEquals(DockerImageType.BUILT_IN, WebAppUtils.getDockerImageType(containerSetting));
-        containerSetting.setUseBuiltinImage(false);
-
         containerSetting.setServerId("serverId");
         assertEquals(DockerImageType.PRIVATE_DOCKER_HUB, WebAppUtils.getDockerImageType(containerSetting));
 


### PR DESCRIPTION
According to the feedback. We should not overload the container setting but using a new setting tag which is parallel with `<javaVersion>` and `<containerSetting>`

So now:
`<javaVersion>` -> Web App on Windows
`<linuxRuntime>` -> Web App on Linux
`<containerSetting>` Web App for containers