### PR TITLE
fix integration tests failure

### DIFF
--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
@@ -260,7 +260,7 @@ public abstract class AbstractWebAppMojo extends AbstractAzureMojo {
      * Deployment Slot. It will be created if it does not exist.
      * It requires the web app exists already.
      */
-    @Parameter(property = "webapp.deploymentSlotSetting", required = false)
+    @Parameter
     protected DeploymentSlotSetting deploymentSlotSetting;
 
     //endregion


### PR DESCRIPTION
The system property given by ```property``` in maven-plugin-3.x or expression in maven-plugin-2.x enables users to override the default value from the command line via -DaSystemProperty=value.  From https://maven.apache.org/developers/mojo-api-specification.html

However, it will construct a empty (not NULL) object for complex data types.

We need the deploymentSlotSetting be null if it is not configured.