### PR TITLE
Mockito upgrade

### DIFF
--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -32,7 +32,7 @@
         <azure.function.version>1.0.0-beta-5</azure.function.version>
         <reflections.version>0.9.11</reflections.version>
         <junit.version>4.12</junit.version>
-        <mockito.version>2.4.0</mockito.version>
+        <mockito.version>2.22.0</mockito.version>
         <spring-test.version>4.1.6.RELEASE</spring-test.version>
         <semver.version>0.9.0</semver.version>
     </properties>

--- a/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/RunMojoTest.java
+++ b/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/RunMojoTest.java
@@ -70,15 +70,12 @@ public class RunMojoTest extends MojoTestBase {
     @Test
     public void checkRuntimeExistence() throws Exception {
         final RunMojo mojo = getMojoFromPom();
-        final RunMojo mojoSpy = spy(mojo);
         final CommandHandler commandHandlerMock = mock(CommandHandlerImpl.class);
-        doNothing().when(commandHandlerMock).runCommandWithReturnCodeCheck(anyString(), anyBoolean(),
-            anyString(), ArgumentMatchers.anyList(), anyString());
-        mojoSpy.checkRuntimeExistence(commandHandlerMock);
+        mojo.checkRuntimeExistence(commandHandlerMock);
 
         verify(commandHandlerMock, times(1))
             .runCommandWithReturnCodeCheck(
-                mojoSpy.getCheckRuntimeCommand(),
+                mojo.getCheckRuntimeCommand(),
                 false,
                 null,
                 CommandUtils.getDefaultValidReturnCodes(),

--- a/azure-maven-plugin-lib/pom.xml
+++ b/azure-maven-plugin-lib/pom.xml
@@ -32,7 +32,7 @@
         <azure.ai.version>1.0.9</azure.ai.version>
         <common-net.version>3.6</common-net.version>
         <junit.version>4.12</junit.version>
-        <mockito.version>2.4.0</mockito.version>
+        <mockito.version>2.22.0</mockito.version>
         <zeroturnaround.zip.version>1.13</zeroturnaround.zip.version>
     </properties>
 

--- a/azure-maven-plugin-lib/src/test/java/com/microsoft/azure/maven/AbstractAzureMojoTest.java
+++ b/azure-maven-plugin-lib/src/test/java/com/microsoft/azure/maven/AbstractAzureMojoTest.java
@@ -193,7 +193,6 @@ public class AbstractAzureMojoTest {
         assertEquals("Unknown", mojo.getAuthType());
 
         doReturn("serverId").when(authenticationSetting).getServerId();
-        doReturn(null).when(authenticationSetting).getFile();
         assertEquals("ServerId", mojo.getAuthType());
 
         doReturn(null).when(authenticationSetting).getServerId();

--- a/azure-maven-plugin-lib/src/test/java/com/microsoft/azure/maven/artifacthandler/FTPArtifactHandlerImplTest.java
+++ b/azure-maven-plugin-lib/src/test/java/com/microsoft/azure/maven/artifacthandler/FTPArtifactHandlerImplTest.java
@@ -53,7 +53,6 @@ public class FTPArtifactHandlerImplTest {
         final WebApp app = mock(WebApp.class);
         final DeployTarget target = new DeployTarget(app, DeployTargetType.WEBAPP);
 
-        doReturn("").when(mojo).getDeploymentStagingDirectoryPath();
         doNothing().when(handlerSpy).assureStagingDirectoryNotEmpty();
         doNothing().when(handlerSpy).prepareResources();
         doNothing().when(handlerSpy).uploadDirectoryToFTP(target);
@@ -74,7 +73,6 @@ public class FTPArtifactHandlerImplTest {
         final DeploymentSlot slot = mock(DeploymentSlot.class);
         final DeployTarget target = new DeployTarget(slot, DeployTargetType.SLOT);
 
-        doReturn("").when(mojo).getDeploymentStagingDirectoryPath();
         doNothing().when(handlerSpy).assureStagingDirectoryNotEmpty();
         doNothing().when(handlerSpy).prepareResources();
         doNothing().when(handlerSpy).uploadDirectoryToFTP(target);
@@ -95,9 +93,7 @@ public class FTPArtifactHandlerImplTest {
         final FunctionApp app = mock(FunctionApp.class);
         final DeployTarget target = new DeployTarget(app, DeployTargetType.FUNCTION);
 
-        doReturn("").when(mojo).getDeploymentStagingDirectoryPath();
         doNothing().when(handlerSpy).assureStagingDirectoryNotEmpty();
-        doNothing().when(handlerSpy).prepareResources();
         doNothing().when(handlerSpy).uploadDirectoryToFTP(target);
 
         handlerSpy.publish(target);

--- a/azure-maven-plugin-lib/src/test/java/com/microsoft/azure/maven/auth/AzureAuthHelperTest.java
+++ b/azure-maven-plugin-lib/src/test/java/com/microsoft/azure/maven/auth/AzureAuthHelperTest.java
@@ -229,11 +229,6 @@ public class AzureAuthHelperTest {
         final AzureAuthHelper helperSpy = spy(helper);
         when(settings.getServer(any(String.class))).thenReturn(server);
 
-        /**
-         * ApplicationTokenCredentials is null
-         */
-        doReturn(null).when(helperSpy).getAppTokenCredentialsFromServer(server);
-
         auth = helper.getAuthObjFromServerId(settings, "serverId");
 
         assertNull(auth);
@@ -365,14 +360,6 @@ public class AzureAuthHelperTest {
         /**
          * certificate exists
          */
-        when(configuration.getChild(CLIENT_ID)).thenReturn(clientIdNode);
-        when(clientIdNode.getValue()).thenReturn(CLIENT_ID);
-        when(configuration.getChild(TENANT_ID)).thenReturn(tenantIdNode);
-        when(tenantIdNode.getValue()).thenReturn(TENANT_ID);
-        when(configuration.getChild(KEY)).thenReturn(null);
-        when(configuration.getChild(CERTIFICATE)).thenReturn(certificateNode);
-        when(certificateNode.getValue()).thenReturn("/certificate.txt");
-//        assertTrue(helper.getAppTokenCredentialsFromServer(server) instanceof ApplicationTokenCredentials);
         clearInvocations(configuration);
     }
 }

--- a/azure-webapp-maven-plugin/pom.xml
+++ b/azure-webapp-maven-plugin/pom.xml
@@ -31,7 +31,7 @@
         <azure.ai.version>1.0.9</azure.ai.version>
         <azure.maven-plugin-lib.version>1.2.1-SNAPSHOT</azure.maven-plugin-lib.version>
         <junit.version>4.12</junit.version>
-        <mockito.version>2.4.0</mockito.version>
+        <mockito.version>2.22.0</mockito.version>
         <spring-test.version>4.1.6.RELEASE</spring-test.version>
     </properties>
 

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/DeployMojoTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/DeployMojoTest.java
@@ -204,12 +204,9 @@ public class DeployMojoTest {
     @Test
     public void getNUllDeploymentSlot() throws Exception {
         final DeployMojo mojo = getMojoFromPom("/pom-linux.xml");
-        final DeployMojo mojoSpy = spy(mojo);
         final WebApp app = mock(WebApp.class);
 
-        doReturn(app).when(mojoSpy).getWebApp();
-
-        assertNull(mojoSpy.getDeploymentSlot(app, ""));
+        assertNull(mojo.getDeploymentSlot(app, ""));
     }
 
     @Test
@@ -218,7 +215,6 @@ public class DeployMojoTest {
         final DeployMojo mojoSpy = spy(mojo);
         final WebApp app = mock(WebApp.class);
 
-        doReturn(app).when(mojoSpy).getWebApp();
         doReturn(mock(DeploymentSlot.class)).when(mojoSpy).getDeploymentSlot(app, "");
 
         mojoSpy.getDeploymentSlot(app, "");

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/DeploymentSlotHandlerTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/DeploymentSlotHandlerTest.java
@@ -121,14 +121,9 @@ public class DeploymentSlotHandlerTest {
 
     @Test(expected = MojoExecutionException.class)
     public void createDeploymentSlotFromOtherDeploymentSlotThrowException() throws MojoExecutionException {
-        final DeploymentSlotHandler handlerSpy = spy(handler);
         final WebApp app = mock(WebApp.class);
-        final Log logMock = mock(Log.class);
 
-        doReturn(logMock).when(mojo).getLog();
-        doReturn(null).when(mojo).getDeploymentSlot(app, "otherSlot");
-
-        handlerSpy.createDeploymentSlot(app, "", "otherSlot");
+        handler.createDeploymentSlot(app, "", "otherSlot");
     }
 
     @Test(expected = MojoExecutionException.class)

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/v1/JarArtifactHandlerImplTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/v1/JarArtifactHandlerImplTest.java
@@ -112,7 +112,6 @@ public class JarArtifactHandlerImplTest {
 
         doReturn("test.jar").when(fileMock).getName();
         doReturn(false).when(fileMock).exists();
-        doReturn(false).when(fileMock).isFile();
         handlerSpy.assureJarFileExisted(fileMock);
     }
 

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/v1/WarArtifactHandlerImplTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/v1/WarArtifactHandlerImplTest.java
@@ -107,7 +107,7 @@ public class WarArtifactHandlerImplTest {
         doReturn(log).when(mojo).getLog();
         doNothing().when(log).info(anyString());
         doReturn(app).when(mojo).getWebApp();
-        doThrow(Exception.class).when(app).warDeploy(file, "");
+        doThrow(RuntimeException.class).when(app).warDeploy(file, "");
 
         handlerSpy.publish(new WebAppDeployTarget(app));
     }


### PR DESCRIPTION
Upgrade the Mockito dependency to the latest available version on maven-central, 2.22.0 in order to consume its latest bugfixes and performance improvements and in order to make a potential upgrade to JUnit Jupiter easier.

By default, Mockito 2.22.0 is stricter than the previously used 2.4.0. Besides upgrading, this PR contains a minimal set of clean-ups (e.g., removing redundant spying) required to run the test-suite without error. While these changes suggest some future similar changes can also be performed, they are out of scope for this PR.