### PR TITLE
Support runOnStartup in TimerTrigger

### DIFF
--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -29,7 +29,7 @@
         <maven.plugin-testing.version>3.3.0</maven.plugin-testing.version>
         <codehaus.plexus-utils.version>3.0.20</codehaus.plexus-utils.version>
         <azure.maven-plugin-lib.version>1.2.2-SNAPSHOT</azure.maven-plugin-lib.version>
-        <azure.function.version>1.0.0-beta-5</azure.function.version>
+        <azure.function.version>1.0.0-beta-6</azure.function.version>
         <reflections.version>0.9.11</reflections.version>
         <junit.version>4.12</junit.version>
         <mockito.version>2.4.0</mockito.version>

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/bindings/TimerBinding.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/bindings/TimerBinding.java
@@ -15,15 +15,24 @@ public class TimerBinding extends BaseBinding {
     public static final String TIMER_TRIGGER = "timerTrigger";
 
     private String schedule;
+    
+    private boolean runOnStartup;
 
     public TimerBinding(final TimerTrigger timerTrigger) {
         super(timerTrigger.name(), TIMER_TRIGGER, Direction.IN, timerTrigger.dataType());
 
         schedule = timerTrigger.schedule();
+        
+        runOnStartup = timerTrigger.runOnStartup();
     }
 
     @JsonGetter
     public String getSchedule() {
         return schedule;
     }
+    
+    @JsonGetter
+    public boolean isRunOnStartup() {
+        return runOnStartup;
+    }    
 }

--- a/azure-functions-maven-plugin/src/main/resources/bindings.json
+++ b/azure-functions-maven-plugin/src/main/resources/bindings.json
@@ -26,6 +26,13 @@
               "errorText": "$timerTrigger_schedule_errorText"
             }
           ]
+        }, {
+          "name": "runOnStartup",
+          "value": "boolean",
+          "defaultValue": true,
+          "required": false,
+          "label": "$timerTrigger_runOnStartup_label",
+          "help": "$timerTrigger_runOnStartup_help"
         }
       ]
     },

--- a/azure-functions-maven-plugin/src/main/resources/resources.json
+++ b/azure-functions-maven-plugin/src/main/resources/resources.json
@@ -8,6 +8,8 @@
     "timerTrigger_schedule_label": "Schedule",
     "timerTrigger_schedule_help": "Enter a cron expression of the format '{second} {minute} {hour} {day} {month} {day of week}' to specify the schedule.",
     "timerTrigger_schedule_errorText": "Invalid Cron Expression. Please consult the <a target='_blank' href='https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/'>documentation</a> to learn more.",
+    "timerTrigger_runOnStartup_label": "Run on startup",
+    "timerTrigger_runOnStartup_help": "If true, the function is invoked when the runtime starts. For example, the runtime starts when the function app wakes up after going idle due to inactivity. when the function app restarts due to function changes, and when the function app scales out. So runOnStartup should rarely if ever be set to true, especially in production.",
     "QueueTrigger_description": "A function that will be run whenever a message is added to a specified Azure Storage queue",
     "queueTrigger_displayName": "Azure Queue Storage",
     "queueTrigger_queueName_label": "Queue name",

--- a/azure-functions-maven-plugin/src/main/resources/templates.json
+++ b/azure-functions-maven-plugin/src/main/resources/templates.json
@@ -111,7 +111,8 @@
             "name": "myTimer",
             "type": "timerTrigger",
             "direction": "in",
-            "schedule": "0 */5 * * * *"
+            "schedule": "0 */5 * * * *",
+            "runOnStartup":  "false"
           }
         ]
       },

--- a/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/handlers/AnnotationHandlerImplTest.java
+++ b/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/handlers/AnnotationHandlerImplTest.java
@@ -107,7 +107,8 @@ public class AnnotationHandlerImplTest {
         @NotificationHubOutput(name = "$return", hubName = "hub", connection = "conn")
         @SendGridOutput(name = "$return", apiKey = "key", to = "to", from = "from", subject = "sub", text = "text")
         @TwilioSmsOutput(name = "$return", accountSid = "sid", authToken = "auth", to = "to", from = "from", body = "b")
-        public String timerTriggerMethod(@TimerTrigger(name = "timer", schedule = "") String timer,
+        public String timerTriggerMethod(@TimerTrigger(name = "timer", schedule = "", runOnStartup = false) String
+                                                     timer,
                                          @CosmosDBOutput(name = "in1",
                                                  databaseName = "db",
                                                  collectionName = "col",


### PR DESCRIPTION
Add support for the 'runOnStartup' flag in the TimerTrigger annotation.

Notice that this PR depends on https://github.com/Azure/azure-functions-java-library/pull/58 where the TimerTrigger annotation is modified.