### PR TITLE
Move Parent element after artifact

### DIFF
--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -3,20 +3,20 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>com.microsoft.azure</groupId>
-        <artifactId>azure-maven-plugins-pom</artifactId>
-        <version>1.0.0</version>
-        <relativePath>../azure-maven-plugins-pom</relativePath>
-    </parent>
-
-    <groupId>com.microsoft.azure</groupId>
+	<groupId>com.microsoft.azure</groupId>
     <artifactId>azure-functions-maven-plugin</artifactId>
     <version>1.0.0-beta-8-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
     <name>Maven Plugin for Azure Functions</name>
     <description>Maven Plugin for Azure Functions</description>
     <url>https://github.com/microsoft/azure-maven-plugins</url>
+    
+    <parent>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>azure-maven-plugins-pom</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../azure-maven-plugins-pom</relativePath>
+    </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Rearranging parent and artifact to help with version string parsing

@Flanker32 /@jdneo - I ran into this when trying to add CI for azure-functions-java-library and following pattern you used to get the version string from pom [here](https://github.com/Microsoft/azure-maven-plugins/blob/develop/appveyor_function_e2e.yml#L34) 

This change will help with keeping ci build scripts consistent