### PR TITLE
Refactoring deployment configuration in V2 schema version

### DIFF
--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.maven.AbstractAppServiceMojo;
 import com.microsoft.azure.maven.appservice.PricingTierEnum;
 import com.microsoft.azure.maven.auth.AzureAuthFailureException;
 import com.microsoft.azure.maven.webapp.configuration.ContainerSetting;
+import com.microsoft.azure.maven.webapp.configuration.Deployment;
 import com.microsoft.azure.maven.webapp.configuration.DeploymentSlotSetting;
 import com.microsoft.azure.maven.webapp.configuration.DockerImageType;
 import com.microsoft.azure.maven.webapp.configuration.RuntimeSetting;
@@ -205,6 +206,13 @@ public abstract class AbstractWebAppMojo extends AbstractAppServiceMojo {
     @Parameter(property = "runtime")
     protected RuntimeSetting runtime;
 
+    /**
+     * Deployment setting
+     * @since 2.0.0
+     */
+    @Parameter(property = "deployment")
+    protected Deployment deployment;
+
     //endregion
 
     //region Getter
@@ -313,6 +321,10 @@ public abstract class AbstractWebAppMojo extends AbstractAppServiceMojo {
 
     public RuntimeSetting getRuntime() {
         return runtime;
+    }
+
+    public Deployment getDeployment() {
+        return deployment;
     }
 
     public void setRuntime(final RuntimeSetting runtime) {

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/configuration/Deployment.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/configuration/Deployment.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.maven.webapp.configuration;
+
+import org.apache.maven.model.Resource;
+import java.util.Collections;
+import java.util.List;
+
+public class Deployment {
+    protected List<Resource> resources = Collections.emptyList();
+
+    public List<Resource> getResources() {
+        return this.resources;
+    }
+
+    public void setResources(final List<Resource> value) {
+        this.resources = value;
+    }
+}

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerUtils.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerUtils.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.maven.webapp.handlers;
+
+import com.google.common.io.Files;
+import com.microsoft.azure.maven.deploytarget.DeployTarget;
+import com.microsoft.azure.maven.webapp.deploytarget.DeploymentSlotDeployTarget;
+import com.microsoft.azure.maven.webapp.deploytarget.WebAppDeployTarget;
+import org.apache.maven.model.Resource;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.codehaus.plexus.util.StringUtils;
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class ArtifactHandlerUtils {
+    /**
+     * Interfaces WebApp && DeploymentSlot define their own warDeploy API separately.
+     * Ideally, it should be defined in their base interface WebAppBase.
+     * {@link com.microsoft.azure.management.appservice.WebAppBase}
+     * Comparing to abstracting an adapter for WebApp && DeploymentSlot, we choose a lighter solution:
+     * work around to get the real implementation of warDeploy.
+     */
+    public static Runnable getRealWarDeployExecutor(final DeployTarget target, final File war, final String path)
+        throws MojoExecutionException {
+        if (target instanceof WebAppDeployTarget) {
+            return new Runnable() {
+                @Override
+                public void run() {
+                    ((WebAppDeployTarget) target).warDeploy(war, path);
+                }
+            };
+        }
+
+        if (target instanceof DeploymentSlotDeployTarget) {
+            return new Runnable() {
+                @Override
+                public void run() {
+                    ((DeploymentSlotDeployTarget) target).warDeploy(war, path);
+                }
+            };
+        }
+        throw new MojoExecutionException(
+            "The type of deploy target is unknown, supported types are WebApp and DeploymentSlot.");
+    }
+
+    public static String getContextPathFromFileName(final String stagingDirectoryPath,
+                                                    final String filePath) throws MojoExecutionException {
+        if (StringUtils.isEmpty(stagingDirectoryPath)) {
+            throw new MojoExecutionException(
+                "Can not get the context path because the staging directory path is null or empty. .");
+        }
+        if (StringUtils.isEmpty(filePath)) {
+            throw new MojoExecutionException("Can not get the context path because the file path is null or empty");
+        }
+        return Paths.get(stagingDirectoryPath).relativize(Paths.get(filePath).getParent()).toString();
+    }
+
+    public static void getArtifactsRecursively(final File directory, final List<File> allFiles) {
+        final File[] files = directory.listFiles();
+        if (files == null || files.length == 0) {
+            return;
+        }
+        for (final File file : files) {
+            if (file.isDirectory()) {
+                getArtifactsRecursively(file, allFiles);
+            } else {
+                allFiles.add(file);
+            }
+        }
+    }
+
+    public static boolean isDeployingOnlyWarArtifacts(final List<Resource> resources) {
+        File tempDirectory;
+        File[] tempFiles;
+        for (final Resource resource : resources) {
+            tempDirectory = new File(resource.getTargetPath());
+            tempFiles = tempDirectory.listFiles();
+            if (tempFiles != null && tempFiles.length != 0) {
+                for (final File file : tempFiles) {
+                    if (!"war".equalsIgnoreCase(Files.getFileExtension(file.getName()))) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerUtils.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerUtils.java
@@ -10,12 +10,13 @@ import com.google.common.io.Files;
 import com.microsoft.azure.maven.deploytarget.DeployTarget;
 import com.microsoft.azure.maven.webapp.deploytarget.DeploymentSlotDeployTarget;
 import com.microsoft.azure.maven.webapp.deploytarget.WebAppDeployTarget;
-import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.util.StringUtils;
 import java.io.File;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class ArtifactHandlerUtils {
     /**
@@ -74,20 +75,32 @@ public class ArtifactHandlerUtils {
         }
     }
 
-    public static boolean isDeployingOnlyWarArtifacts(final List<Resource> resources) {
-        File tempDirectory;
-        File[] tempFiles;
-        for (final Resource resource : resources) {
-            tempDirectory = new File(resource.getTargetPath());
-            tempFiles = tempDirectory.listFiles();
-            if (tempFiles != null && tempFiles.length != 0) {
-                for (final File file : tempFiles) {
-                    if (!"war".equalsIgnoreCase(Files.getFileExtension(file.getName()))) {
-                        return false;
-                    }
-                }
+    public static boolean isDeployingOnlyWarArtifacts(final List<File> allArtifacts) {
+        for (final File artifacts : allArtifacts) {
+            if (!"war".equalsIgnoreCase(Files.getFileExtension(artifacts.getName()))) {
+                return false;
             }
         }
         return true;
+    }
+
+    public static boolean isMixingWarArtifactWithOtherArtifacts(final List<File> allArtifacts) {
+        final List<String> fileExtensions = new ArrayList<String>();
+        boolean isWarArtifactExists = false;
+        final String warExtension = "war";
+        for (final File artifacts : allArtifacts) {
+            final String fileExtension = Files.getFileExtension(artifacts.getName()).toLowerCase(Locale.ENGLISH);
+            if (!isWarArtifactExists && warExtension.equals(fileExtension)) {
+                isWarArtifactExists = true;
+            }
+            if (!fileExtensions.contains(fileExtension)) {
+                fileExtensions.add(fileExtension);
+            }
+        }
+        if (!isWarArtifactExists) {
+            return false;
+        }
+        fileExtensions.remove(warExtension);
+        return fileExtensions.size() != 0;
     }
 }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerUtils.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerUtils.java
@@ -49,8 +49,7 @@ public class ArtifactHandlerUtils {
             "The type of deploy target is unknown, supported types are WebApp and DeploymentSlot.");
     }
 
-    public static boolean performActionWithRetry(final Runnable runnable, final int maxRetryTimes,
-                                                 final Log log, final String retryMessage) {
+    public static boolean performActionWithRetry(final Runnable runnable, final int maxRetryTimes, final Log log) {
         int retryCount = 0;
         while (retryCount < maxRetryTimes) {
             retryCount += 1;
@@ -58,8 +57,8 @@ public class ArtifactHandlerUtils {
                 runnable.run();
                 return true;
             } catch (Exception e) {
-                log.info(String.format("%s: %s, retrying immediately(%d/%d)...",
-                    retryMessage, e.getMessage(), retryCount, maxRetryTimes));
+                log.info(String.format("Exception occurred during deploying: %s, retry immediately(%d/%d)...",
+                    e.getMessage(), retryCount, maxRetryTimes));
             }
         }
         return false;

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerUtils.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerUtils.java
@@ -57,7 +57,7 @@ public class ArtifactHandlerUtils {
                 runnable.run();
                 return true;
             } catch (Exception e) {
-                log.info(String.format("Exception occurred during deploying: %s, retry immediately(%d/%d)...",
+                log.info(String.format("Exception occurred during deployment: %s, retry immediately(%d/%d)...",
                     e.getMessage(), retryCount, maxRetryTimes));
             }
         }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/HandlerFactoryImpl.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/HandlerFactoryImpl.java
@@ -28,6 +28,7 @@ import com.microsoft.azure.maven.webapp.handlers.v1.PrivateRegistryRuntimeHandle
 import com.microsoft.azure.maven.webapp.handlers.v1.PublicDockerHubRuntimeHandlerImpl;
 import com.microsoft.azure.maven.webapp.handlers.v1.WarArtifactHandlerImpl;
 import com.microsoft.azure.maven.webapp.handlers.v1.WindowsRuntimeHandlerImpl;
+import com.microsoft.azure.maven.webapp.handlers.v2.ArtifactHandlerV2;
 import com.microsoft.azure.maven.webapp.handlers.v2.LinuxRuntimeHandlerImplV2;
 import com.microsoft.azure.maven.webapp.handlers.v2.PrivateDockerHubRuntimeHandlerImplV2;
 import com.microsoft.azure.maven.webapp.handlers.v2.PrivateRegistryRuntimeHandlerImplV2;
@@ -200,9 +201,8 @@ public class HandlerFactoryImpl extends HandlerFactory {
         }
     }
 
-    protected ArtifactHandler getV2ArtifactHandler(AbstractWebAppMojo mojo) throws MojoExecutionException {
-        // todo
-        throw new MojoExecutionException("Unimplemented for schema version: " + mojo.getSchemaVersion());
+    protected ArtifactHandler getV2ArtifactHandler(AbstractWebAppMojo mojo) {
+        return new ArtifactHandlerV2(mojo);
     }
 
     protected ArtifactHandler getArtifactHandlerFromPackaging(final AbstractWebAppMojo mojo)

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/v2/ArtifactHandlerV2.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/v2/ArtifactHandlerV2.java
@@ -39,7 +39,7 @@ public class ArtifactHandlerV2 implements ArtifactHandler {
         final Deployment deployment =  mojo.getDeployment();
         final List<Resource> resources = deployment.getResources();
         if (resources == null || resources.size() < 1) {
-            mojo.getLog().warn("The <deployment> element is not well configured in pom.xml, skip deployment.");
+            mojo.getLog().warn("No <resources> is found in <deployment> element in pom.xml, skip deployment.");
             return;
         }
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/v2/ArtifactHandlerV2.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/v2/ArtifactHandlerV2.java
@@ -23,6 +23,7 @@ import static com.microsoft.azure.maven.webapp.handlers.ArtifactHandlerUtils.get
 import static com.microsoft.azure.maven.webapp.handlers.ArtifactHandlerUtils.getContextPathFromFileName;
 import static com.microsoft.azure.maven.webapp.handlers.ArtifactHandlerUtils.getRealWarDeployExecutor;
 import static com.microsoft.azure.maven.webapp.handlers.ArtifactHandlerUtils.isDeployingOnlyWarArtifacts;
+import static com.microsoft.azure.maven.webapp.handlers.ArtifactHandlerUtils.isMixingWarArtifactWithOtherArtifacts;
 
 public class ArtifactHandlerV2 implements ArtifactHandler {
     private AbstractWebAppMojo mojo;
@@ -61,9 +62,14 @@ public class ArtifactHandlerV2 implements ArtifactHandler {
                     stagingDirectory.getAbsolutePath()));
         }
 
-        if (isDeployingOnlyWarArtifacts(resources)) {
+        if (isDeployingOnlyWarArtifacts(allArtifacts)) {
             publishArtifactsViaWarDeploy(target, stagingDirectoryPath, allArtifacts);
         } else {
+            if (isMixingWarArtifactWithOtherArtifacts(allArtifacts)) {
+                mojo.getLog().warn(
+                    "Deploying war artifact together with other kinds of artifacts is not suggested," +
+                        " it will cause the content be overwritten or path incorrect issues.");
+            }
             publishArtifactsViaZipDeploy(target, stagingDirectoryPath);
         }
     }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/v2/ArtifactHandlerV2.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/v2/ArtifactHandlerV2.java
@@ -84,8 +84,7 @@ public class ArtifactHandlerV2 implements ArtifactHandler {
                 target.zipDeploy(zipFile);
             }
         };
-        final String retryMessage = "Exception occurred when deploying the zip package.";
-        final boolean deploySuccess = performActionWithRetry(runnable, MAX_RETRY_TIMES, mojo.getLog(), retryMessage);
+        final boolean deploySuccess = performActionWithRetry(runnable, MAX_RETRY_TIMES, mojo.getLog());
         if (!deploySuccess) {
             throw new MojoExecutionException(
                 String.format("The zip deploy failed after %d times of retry.", MAX_RETRY_TIMES + 1));
@@ -111,8 +110,7 @@ public class ArtifactHandlerV2 implements ArtifactHandler {
 
         // Add retry logic here to avoid Kudu's socket timeout issue.
         // More details: https://github.com/Microsoft/azure-maven-plugins/issues/339
-        final String retryMessage = "Exception occurred when deploying war file to server";
-        final boolean deploySuccess = performActionWithRetry(executor, MAX_RETRY_TIMES, mojo.getLog(), retryMessage);
+        final boolean deploySuccess = performActionWithRetry(executor, MAX_RETRY_TIMES, mojo.getLog());
         if (!deploySuccess) {
             throw new MojoExecutionException(
                 String.format("Failed to deploy war file after %d times of retry.", MAX_RETRY_TIMES + 1));

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/v2/ArtifactHandlerV2.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/v2/ArtifactHandlerV2.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.maven.webapp.handlers.v2;
+
+import com.microsoft.azure.maven.Utils;
+import com.microsoft.azure.maven.artifacthandler.ArtifactHandler;
+import com.microsoft.azure.maven.deploytarget.DeployTarget;
+import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
+import com.microsoft.azure.maven.webapp.configuration.Deployment;
+import org.apache.maven.model.Resource;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.zeroturnaround.zip.ZipUtil;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.microsoft.azure.maven.webapp.handlers.ArtifactHandlerUtils.getArtifactsRecursively;
+import static com.microsoft.azure.maven.webapp.handlers.ArtifactHandlerUtils.getContextPathFromFileName;
+import static com.microsoft.azure.maven.webapp.handlers.ArtifactHandlerUtils.getRealWarDeployExecutor;
+import static com.microsoft.azure.maven.webapp.handlers.ArtifactHandlerUtils.isDeployingOnlyWarArtifacts;
+
+public class ArtifactHandlerV2 implements ArtifactHandler {
+    private AbstractWebAppMojo mojo;
+    private static final int DEFAULT_MAX_RETRY_TIMES = 3;
+
+    public ArtifactHandlerV2(final AbstractWebAppMojo mojo) {
+        this.mojo = mojo;
+    }
+
+    public void assureDeploymentResourcesNotEmpty() throws MojoExecutionException {
+        final Deployment deployment = mojo.getDeployment();
+        final List<Resource> resources = deployment.getResources();
+        if (resources == null || resources.size() < 1) {
+            throw new MojoExecutionException("The element <resources> inside deployment has to be set to do deploy.");
+        }
+    }
+
+    @Override
+    public void publish(final DeployTarget target) throws MojoExecutionException, IOException {
+        assureDeploymentResourcesNotEmpty();
+
+        final Deployment deployment = mojo.getDeployment();
+        final List<Resource> resources = deployment.getResources();
+        final String stagingDirectoryPath = mojo.getDeploymentStagingDirectoryPath();
+        Utils.copyResources(mojo.getProject(), mojo.getSession(), mojo.getMavenResourcesFiltering(),
+            resources, stagingDirectoryPath);
+
+        final List<File> allArtifacts = new ArrayList<File>();
+        final File stagingDirectory = new File(stagingDirectoryPath);
+        getArtifactsRecursively(stagingDirectory, allArtifacts);
+
+        if (allArtifacts.size() == 0) {
+            throw new MojoExecutionException(
+                String.format(
+                    "There is no artifact to deploy in staging directory: '%s'",
+                    stagingDirectory.getAbsolutePath()));
+        }
+
+        if (isDeployingOnlyWarArtifacts(resources)) {
+            publishArtifactsViaWarDeploy(target, stagingDirectoryPath, allArtifacts);
+        } else {
+            publishArtifactsViaZipDeploy(target, stagingDirectoryPath);
+        }
+    }
+
+    protected void publishArtifactsViaZipDeploy(final DeployTarget target,
+                                                final String stagingDirectoryPath) throws MojoExecutionException {
+        final File stagingDirectory = new File(stagingDirectoryPath);
+        final File zipFile = new File(stagingDirectoryPath + ".zip");
+        ZipUtil.pack(stagingDirectory, zipFile);
+        mojo.getLog().info(String.format("Deploying the zip package %s...", zipFile.getName()));
+
+        // Add retry logic here to avoid Kudu's socket timeout issue.
+        // More details: https://github.com/Microsoft/azure-maven-plugins/issues/339
+        int retryCount = 0;
+        while (retryCount < DEFAULT_MAX_RETRY_TIMES) {
+            retryCount += 1;
+            try {
+                target.zipDeploy(zipFile);
+                return;
+            } catch (Exception e) {
+                mojo.getLog().debug(
+                    String.format("Exception occurred when deploying the zip package: %s, " +
+                        "retrying immediately (%d/%d)", e.getMessage(), retryCount, DEFAULT_MAX_RETRY_TIMES));
+            }
+        }
+
+        throw new MojoExecutionException(String.format("The zip deploy failed after %d times of retry.", retryCount));
+    }
+
+    protected void publishArtifactsViaWarDeploy(final DeployTarget target, final String stagingDirectoryPath,
+                                                final List<File> warArtifacts) throws MojoExecutionException {
+        if (warArtifacts == null || warArtifacts.size() == 0) {
+            throw new MojoExecutionException(
+                String.format("There is no war artifacts to deploy in staging path %s.", stagingDirectoryPath));
+        }
+        for (final File warArtifact : warArtifacts) {
+            final String contextPath = getContextPathFromFileName(stagingDirectoryPath, warArtifact.getAbsolutePath());
+            publishWarArtifact(target, warArtifact, contextPath);
+        }
+    }
+
+    public void publishWarArtifact(final DeployTarget target, final File warArtifact,
+                                   final String contextPath) throws MojoExecutionException {
+        final Runnable executor = getRealWarDeployExecutor(target, warArtifact, contextPath);
+        mojo.getLog().info(String.format("Deploying the war file %s...", warArtifact.getName()));
+
+        // Add retry logic here to avoid Kudu's socket timeout issue.
+        // More details: https://github.com/Microsoft/azure-maven-plugins/issues/339
+        int retryCount = 0;
+        while (retryCount < DEFAULT_MAX_RETRY_TIMES) {
+            retryCount++;
+            try {
+                executor.run();
+                return;
+            } catch (Exception e) {
+                mojo.getLog().debug(String.format("Exception occurred when deploying war file to server: %s, " +
+                    "retrying immediately (%d/%d)", e.getMessage(), retryCount, DEFAULT_MAX_RETRY_TIMES));
+            }
+        }
+        throw new MojoExecutionException(
+            String.format("Failed to deploy war file after %d times of retry.", retryCount));
+    }
+}

--- a/build-tools/src/main/resources/findbugs/findbugs-exclude.xml
+++ b/build-tools/src/main/resources/findbugs/findbugs-exclude.xml
@@ -11,15 +11,15 @@
     <Bug pattern="OBL_UNSATISFIED_OBLIGATION"/>
     <Match>
         <Or>
-            <Class name = "com.microsoft.azure.maven.webapp.handlers.v1.WarArtifactHandlerImpl$1" />
-            <Class name = "com.microsoft.azure.maven.webapp.handlers.v1.WarArtifactHandlerImpl$2" />
+            <Class name = "com.microsoft.azure.maven.webapp.handlers.ArtifactHandlerUtils$1" />
+            <Class name = "com.microsoft.azure.maven.webapp.handlers.ArtifactHandlerUtils$2" />
         </Or>
         <Bug pattern = "SIC_INNER_SHOULD_BE_STATIC_ANON" />
     </Match>
     <Match>
         <Or>
-            <Class name = "com.microsoft.azure.maven.webapp.handlers.v1.WarArtifactHandlerImpl$1" />
-            <Class name = "com.microsoft.azure.maven.webapp.handlers.v1.WarArtifactHandlerImpl$2" />
+            <Class name = "com.microsoft.azure.maven.webapp.handlers.ArtifactHandlerUtils$1" />
+            <Class name = "com.microsoft.azure.maven.webapp.handlers.ArtifactHandlerUtils$2" />
         </Or>
         <Bug pattern = "BC_UNCONFIRMED_CAST" />
     </Match>

--- a/build-tools/src/main/resources/findbugs/findbugs-exclude.xml
+++ b/build-tools/src/main/resources/findbugs/findbugs-exclude.xml
@@ -23,4 +23,8 @@
         </Or>
         <Bug pattern = "BC_UNCONFIRMED_CAST" />
     </Match>
+    <Match>
+        <Class name = "com.microsoft.azure.maven.webapp.handlers.v2.ArtifactHandlerV2$1" />
+        <Bug pattern = "SIC_INNER_SHOULD_BE_STATIC_ANON" />
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Add the `<deployment>` configuration in V2 schema version. It is a required configuration if users specify the schema version to V2. And we create the artifact handler from the schema version.

`<deployment>` configuration has only a list of `Resources`, the deployment type becomes transparent to users, the artifact will be deployed via war deploy or zip deploy depends on the type of the artifacts.
- If users are deploying only war artifacts, we use war deploy, the `targetPath` configuration is the relative path to `webapps` for users convenience
- If users are deploying mixing artifacts, which is not suggested, a warning message will pop up for the possible incorrect path resolving and overriding caused by zip deploy