### PR TITLE
Refactoring artifact handlers

### DIFF
--- a/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/DeployMojoTest.java
+++ b/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/DeployMojoTest.java
@@ -32,7 +32,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import java.util.function.Consumer;
 
 import static org.junit.Assert.assertEquals;
@@ -222,6 +221,8 @@ public class DeployMojoTest extends MojoTestBase {
 
     @Test
     public void getMSDeployArtifactHandler() throws MojoExecutionException {
+        doReturn("azure-functions-maven-plugin").when(mojoSpy).getPluginName();
+        doReturn("test-path").when(mojoSpy).getBuildDirectoryAbsolutePath();
         doReturn(DeploymentType.MSDEPLOY).when(mojoSpy).getDeploymentType();
         final ArtifactHandler handler = mojoSpy.getArtifactHandler();
 
@@ -231,6 +232,8 @@ public class DeployMojoTest extends MojoTestBase {
 
     @Test
     public void getFTPArtifactHandler() throws MojoExecutionException {
+        doReturn("azure-functions-maven-plugin").when(mojoSpy).getPluginName();
+        doReturn("test-path").when(mojoSpy).getBuildDirectoryAbsolutePath();
         doReturn(DeploymentType.FTP).when(mojoSpy).getDeploymentType();
         final ArtifactHandler handler = mojoSpy.getArtifactHandler();
 
@@ -240,6 +243,8 @@ public class DeployMojoTest extends MojoTestBase {
 
     @Test
     public void getZIPArtifactHandler() throws MojoExecutionException {
+        doReturn("azure-functions-maven-plugin").when(mojoSpy).getPluginName();
+        doReturn("test-path").when(mojoSpy).getBuildDirectoryAbsolutePath();
         doReturn(DeploymentType.ZIP).when(mojoSpy).getDeploymentType();
         final ArtifactHandler handler = mojoSpy.getArtifactHandler();
 

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/artifacthandler/ArtifactHandlerBase.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/artifacthandler/ArtifactHandlerBase.java
@@ -6,25 +6,87 @@
 
 package com.microsoft.azure.maven.artifacthandler;
 
-import com.microsoft.azure.maven.AbstractAppServiceMojo;
 import com.microsoft.azure.maven.Utils;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
-
-import javax.annotation.Nonnull;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.filtering.MavenResourcesFiltering;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-public abstract class ArtifactHandlerBase<T extends AbstractAppServiceMojo> implements ArtifactHandler {
-    protected T mojo;
+public abstract class ArtifactHandlerBase implements ArtifactHandler {
+    protected MavenProject project;
+    protected MavenSession session;
+    protected MavenResourcesFiltering filtering;
+    protected List<Resource> resources;
+    protected String stagingDirectoryPath;
+    protected String buildDirectoryAbsolutePath;
+    protected Log log;
 
-    public ArtifactHandlerBase(@Nonnull final T mojo) {
-        this.mojo = mojo;
+    public abstract static class Builder<T extends Builder<T>> {
+        private MavenProject project;
+        private MavenSession session;
+        private MavenResourcesFiltering filtering;
+        private List<Resource> resources;
+        private String stagingDirectoryPath;
+        private String buildDirectoryAbsolutePath;
+        private Log log;
+
+        protected abstract T self();
+
+        public abstract ArtifactHandlerBase build();
+
+        public T project(final MavenProject value) {
+            this.project = value;
+            return self();
+        }
+
+        public T session(final MavenSession value) {
+            this.session = value;
+            return self();
+        }
+
+        public T filtering(final MavenResourcesFiltering value) {
+            this.filtering = value;
+            return self();
+        }
+
+        public T resources(final List<Resource> value) {
+            this.resources = value;
+            return self();
+        }
+
+        public T stagingDirectoryPath(final String value) {
+            this.stagingDirectoryPath = value;
+            return self();
+        }
+
+        public T buildDirectoryAbsolutePath(final String value) {
+            this.buildDirectoryAbsolutePath = value;
+            return self();
+        }
+
+        public T log(final Log value) {
+            this.log = value;
+            return self();
+        }
+    }
+
+    protected ArtifactHandlerBase(Builder<?> builder) {
+        this.project = builder.project;
+        this.session = builder.session;
+        this.filtering = builder.filtering;
+        this.resources = builder.resources;
+        this.stagingDirectoryPath = builder.stagingDirectoryPath;
+        this.buildDirectoryAbsolutePath = builder.buildDirectoryAbsolutePath;
+        this.log = builder.log;
     }
 
     protected void assureStagingDirectoryNotEmpty() throws MojoExecutionException {
-        final File stagingDirectory = new File(mojo.getDeploymentStagingDirectoryPath());
+        final File stagingDirectory = new File(stagingDirectoryPath);
         final File[] files = stagingDirectory.listFiles();
         if (!stagingDirectory.exists() || !stagingDirectory.isDirectory() || files == null || files.length == 0) {
             throw new MojoExecutionException(String.format("Staging directory: '%s' is empty.",
@@ -33,12 +95,10 @@ public abstract class ArtifactHandlerBase<T extends AbstractAppServiceMojo> impl
     }
 
     protected void prepareResources() throws IOException, MojoExecutionException {
-        final List<Resource> resources = this.mojo.getResources();
         if (resources == null || resources.isEmpty()) {
             throw new MojoExecutionException("<resources> is empty. Please make sure it is configured in pom.xml.");
         }
 
-        Utils.copyResources(mojo.getProject(), mojo.getSession(),
-            mojo.getMavenResourcesFiltering(), resources, mojo.getDeploymentStagingDirectoryPath());
+        Utils.copyResources(project, session, filtering, resources, stagingDirectoryPath);
     }
 }

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/artifacthandler/FTPArtifactHandlerImpl.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/artifacthandler/FTPArtifactHandlerImpl.java
@@ -10,20 +10,29 @@ import com.microsoft.azure.management.appservice.DeploymentSlot;
 import com.microsoft.azure.management.appservice.FunctionApp;
 import com.microsoft.azure.management.appservice.PublishingProfile;
 import com.microsoft.azure.management.appservice.WebApp;
-import com.microsoft.azure.maven.AbstractAppServiceMojo;
 import com.microsoft.azure.maven.FTPUploader;
 import com.microsoft.azure.maven.deploytarget.DeployTarget;
 import org.apache.maven.plugin.MojoExecutionException;
-
-import javax.annotation.Nonnull;
 import java.io.IOException;
 
 public class FTPArtifactHandlerImpl extends ArtifactHandlerBase {
     private static final String DEFAULT_WEBAPP_ROOT = "/site/wwwroot";
     private static final int DEFAULT_MAX_RETRY_TIMES = 3;
 
-    public FTPArtifactHandlerImpl(@Nonnull final AbstractAppServiceMojo mojo) {
-        super(mojo);
+    public static class Builder extends ArtifactHandlerBase.Builder<Builder> {
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        @Override
+        public FTPArtifactHandlerImpl build() {
+            return new FTPArtifactHandlerImpl(this);
+        }
+    }
+
+    private FTPArtifactHandlerImpl(final Builder builder) {
+        super(builder);
     }
 
     protected boolean isResourcesPreparationRequired(final DeployTarget target) {
@@ -53,12 +62,12 @@ public class FTPArtifactHandlerImpl extends ArtifactHandlerBase {
         uploader.uploadDirectoryWithRetries(serverUrl,
             profile.ftpUsername(),
             profile.ftpPassword(),
-            mojo.getDeploymentStagingDirectoryPath(),
+            stagingDirectoryPath,
             DEFAULT_WEBAPP_ROOT,
             DEFAULT_MAX_RETRY_TIMES);
     }
 
     protected FTPUploader getUploader() {
-        return new FTPUploader(mojo.getLog());
+        return new FTPUploader(log);
     }
 }

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/artifacthandler/ZIPArtifactHandlerImpl.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/artifacthandler/ZIPArtifactHandlerImpl.java
@@ -7,21 +7,30 @@
 package com.microsoft.azure.maven.artifacthandler;
 
 import com.microsoft.azure.management.appservice.FunctionApp;
-import com.microsoft.azure.maven.AbstractAppServiceMojo;
 import com.microsoft.azure.maven.deploytarget.DeployTarget;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.zeroturnaround.zip.ZipUtil;
-
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 
-public class ZIPArtifactHandlerImpl<T extends AbstractAppServiceMojo> extends ArtifactHandlerBase<T> {
+public class ZIPArtifactHandlerImpl extends ArtifactHandlerBase {
     private static final int DEFAULT_MAX_RETRY_TIMES = 3;
     private static final String LOCAL_SETTINGS_FILE = "local.settings.json";
 
-    public ZIPArtifactHandlerImpl(@Nonnull final T mojo) {
-        super(mojo);
+    public static class Builder extends ArtifactHandlerBase.Builder<ZIPArtifactHandlerImpl.Builder> {
+        @Override
+        protected ZIPArtifactHandlerImpl.Builder self() {
+            return this;
+        }
+
+        @Override
+        public ZIPArtifactHandlerImpl build() {
+            return new ZIPArtifactHandlerImpl(this);
+        }
+    }
+
+    protected ZIPArtifactHandlerImpl(final Builder builder) {
+        super(builder);
     }
 
     /**
@@ -50,7 +59,7 @@ public class ZIPArtifactHandlerImpl<T extends AbstractAppServiceMojo> extends Ar
                 target.zipDeploy(zipFile);
                 return;
             } catch (Exception e) {
-                mojo.getLog().debug(
+                log.debug(
                     String.format("Exception occurred when deploying the zip package: %s, " +
                         "retrying immediately (%d/%d)", e.getMessage(), retryCount, DEFAULT_MAX_RETRY_TIMES));
             }
@@ -60,7 +69,6 @@ public class ZIPArtifactHandlerImpl<T extends AbstractAppServiceMojo> extends Ar
     }
 
     protected File getZipFile() {
-        final String stagingDirectoryPath = mojo.getDeploymentStagingDirectoryPath();
         final File zipFile = new File(stagingDirectoryPath + ".zip");
         final File stagingDirectory = new File(stagingDirectoryPath);
 

--- a/azure-maven-plugin-lib/src/test/java/com/microsoft/azure/maven/artifacthandler/FTPArtifactHandlerImplTest.java
+++ b/azure-maven-plugin-lib/src/test/java/com/microsoft/azure/maven/artifacthandler/FTPArtifactHandlerImplTest.java
@@ -21,7 +21,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import java.io.IOException;
 
 import static org.junit.Assert.assertFalse;
@@ -39,17 +38,26 @@ public class FTPArtifactHandlerImplTest {
     @Mock
     private AbstractAppServiceMojo mojo;
 
+    private FTPArtifactHandlerImpl.Builder builder = new FTPArtifactHandlerImpl.Builder();
+
     private FTPArtifactHandlerImpl handler = null;
 
+    private FTPArtifactHandlerImpl handlerSpy;
+
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         MockitoAnnotations.initMocks(this);
-        handler = new FTPArtifactHandlerImpl(mojo);
+    }
+
+    private void buildHandler() {
+        handler = builder.stagingDirectoryPath((mojo.getDeploymentStagingDirectoryPath())).build();
+        handlerSpy = spy(handler);
     }
 
     @Test
     public void publishWebApp() throws IOException, MojoExecutionException {
-        final FTPArtifactHandlerImpl handlerSpy = spy(handler);
+        buildHandler();
+
         final WebApp app = mock(WebApp.class);
         final DeployTarget target = new DeployTarget(app, DeployTargetType.WEBAPP);
 
@@ -69,7 +77,8 @@ public class FTPArtifactHandlerImplTest {
 
     @Test
     public void publishWebAppDeploymentSlot() throws IOException, MojoExecutionException {
-        final FTPArtifactHandlerImpl handlerSpy = spy(handler);
+        buildHandler();
+
         final DeploymentSlot slot = mock(DeploymentSlot.class);
         final DeployTarget target = new DeployTarget(slot, DeployTargetType.SLOT);
 
@@ -89,7 +98,8 @@ public class FTPArtifactHandlerImplTest {
 
     @Test
     public void publishFunctionApp() throws IOException, MojoExecutionException {
-        final FTPArtifactHandlerImpl handlerSpy = spy(handler);
+        buildHandler();
+
         final FunctionApp app = mock(FunctionApp.class);
         final DeployTarget target = new DeployTarget(app, DeployTargetType.FUNCTION);
 
@@ -108,7 +118,7 @@ public class FTPArtifactHandlerImplTest {
 
     @Test
     public void isResourcesPreparationRequired() {
-        final FTPArtifactHandlerImpl handlerSpy = spy(handler);
+        buildHandler();
 
         DeployTarget target = new DeployTarget(mock(WebApp.class), DeployTargetType.WEBAPP);
         assertTrue(handlerSpy.isResourcesPreparationRequired(target));
@@ -125,14 +135,14 @@ public class FTPArtifactHandlerImplTest {
         final String ftpUrl = "ftp.azurewebsites.net/site/wwwroot";
         final PublishingProfile profile = mock(PublishingProfile.class);
         final WebApp app = mock(WebApp.class);
-        final FTPArtifactHandlerImpl handlerSpy = spy(handler);
         final DeployTarget deployTarget = new DeployTarget(app, DeployTargetType.WEBAPP);
         final FTPUploader uploader = mock(FTPUploader.class);
-        doReturn(uploader).when(handlerSpy).getUploader();
         doReturn(ftpUrl).when(profile).ftpUrl();
         doReturn(profile).when(app).getPublishingProfile();
         doReturn("").when(mojo).getDeploymentStagingDirectoryPath();
 
+        buildHandler();
+        doReturn(uploader).when(handlerSpy).getUploader();
         handlerSpy.uploadDirectoryToFTP(deployTarget);
 
         verify(app, times(1)).getPublishingProfile();

--- a/azure-maven-plugin-lib/src/test/java/com/microsoft/azure/maven/artifacthandler/ZIPArtifactHandlerImplTest.java
+++ b/azure-maven-plugin-lib/src/test/java/com/microsoft/azure/maven/artifacthandler/ZIPArtifactHandlerImplTest.java
@@ -36,17 +36,24 @@ public class ZIPArtifactHandlerImplTest {
     @Mock
     private AbstractAppServiceMojo mojo;
 
+    private ZIPArtifactHandlerImpl.Builder builder = new ZIPArtifactHandlerImpl.Builder();
+
     private ZIPArtifactHandlerImpl handler;
+    private ZIPArtifactHandlerImpl handlerSpy;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        handler = new ZIPArtifactHandlerImpl(mojo);
+    }
+
+    private void buildHandler() {
+        handler = builder.stagingDirectoryPath(mojo.getDeploymentStagingDirectoryPath()).build();
+        handlerSpy = spy(handler);
     }
 
     @Test
     public void publish() throws MojoExecutionException, IOException {
-        final ZIPArtifactHandlerImpl handlerSpy = spy(handler);
+        buildHandler();
         final WebApp app = mock(WebApp.class);
         final DeployTarget target = new DeployTarget(app, DeployTargetType.WEBAPP);
         final File file = mock(File.class);
@@ -68,7 +75,7 @@ public class ZIPArtifactHandlerImplTest {
 
     @Test
     public void publishThrowException() throws MojoExecutionException, IOException {
-        final ZIPArtifactHandlerImpl handlerSpy = spy(handler);
+        buildHandler();
         final WebApp app = mock(WebApp.class);
         final DeployTarget target = new DeployTarget(app, DeployTargetType.WEBAPP);
         final File file = mock(File.class);
@@ -86,7 +93,7 @@ public class ZIPArtifactHandlerImplTest {
 
     @Test
     public void publishThrowResourceNotConfiguredException() throws IOException {
-        final ZIPArtifactHandlerImpl handlerSpy = spy(handler);
+        buildHandler();
         final WebApp app = mock(WebApp.class);
         final DeployTarget target = new DeployTarget(app, DeployTargetType.WEBAPP);
 
@@ -100,18 +107,16 @@ public class ZIPArtifactHandlerImplTest {
 
     @Test
     public void getZipFile() {
-        final ZIPArtifactHandlerImpl handlerSpy = spy(handler);
         final File zipTestDirectory = new File("src/test/resources/ziptest");
         doReturn(zipTestDirectory.getAbsolutePath()).when(mojo).getDeploymentStagingDirectoryPath();
-
+        buildHandler();
         assertEquals(zipTestDirectory.getAbsolutePath() + ".zip", handlerSpy.getZipFile().getAbsolutePath());
     }
 
     @Test(expected = ZipException.class)
     public void getZipFileThrowException() {
-        final ZIPArtifactHandlerImpl handlerSpy = spy(handler);
         doReturn("").when(mojo).getDeploymentStagingDirectoryPath();
-
+        buildHandler();
         handlerSpy.getZipFile();
     }
 }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/v1/NONEArtifactHandlerImpl.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/v1/NONEArtifactHandlerImpl.java
@@ -6,19 +6,29 @@
 
 package com.microsoft.azure.maven.webapp.handlers.v1;
 
-import com.microsoft.azure.maven.artifacthandler.ArtifactHandler;
+import com.microsoft.azure.maven.artifacthandler.ArtifactHandlerBase;
 import com.microsoft.azure.maven.deploytarget.DeployTarget;
-import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 
-public class NONEArtifactHandlerImpl implements ArtifactHandler {
-    private AbstractWebAppMojo mojo;
+public class NONEArtifactHandlerImpl extends ArtifactHandlerBase {
 
-    public NONEArtifactHandlerImpl(final AbstractWebAppMojo mojo) {
-        this.mojo = mojo;
+    public static class Builder extends ArtifactHandlerBase.Builder<NONEArtifactHandlerImpl.Builder> {
+        @Override
+        protected NONEArtifactHandlerImpl.Builder self() {
+            return this;
+        }
+
+        @Override
+        public NONEArtifactHandlerImpl build() {
+            return new NONEArtifactHandlerImpl(this);
+        }
+    }
+
+    protected NONEArtifactHandlerImpl(Builder builder) {
+        super(builder);
     }
 
     @Override
     public void publish(DeployTarget deployTarget) {
-        this.mojo.getLog().info("The value of <deploymentType> is NONE, skip deployment.");
+        log.info("The value of <deploymentType> is NONE, skip deployment.");
     }
 }

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/HandlerFactoryImplTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/HandlerFactoryImplTest.java
@@ -151,7 +151,7 @@ public class HandlerFactoryImplTest {
 
         final HandlerFactoryImpl factory = new HandlerFactoryImpl();
 
-        assertTrue(factory.getArtifactHandlerFromPackaging(mojo) instanceof JarArtifactHandlerImpl);
+        assertTrue(factory.getArtifactHandlerBuilderFromPackaging(mojo).build() instanceof JarArtifactHandlerImpl);
     }
 
     @Test(expected = MojoExecutionException.class)
@@ -160,7 +160,7 @@ public class HandlerFactoryImplTest {
         doReturn(project).when(mojo).getProject();
         doReturn("unknown").when(project).getPackaging();
         final HandlerFactoryImpl factory = new HandlerFactoryImpl();
-        factory.getArtifactHandlerFromPackaging(mojo);
+        factory.getArtifactHandlerBuilderFromPackaging(mojo);
     }
 
     @Test

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/v1/JarArtifactHandlerImplTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/v1/JarArtifactHandlerImplTest.java
@@ -11,7 +11,6 @@ import com.microsoft.azure.maven.deploytarget.DeployTarget;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.deploytarget.DeploymentSlotDeployTarget;
 import com.microsoft.azure.maven.webapp.deploytarget.WebAppDeployTarget;
-import org.apache.maven.model.Build;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.junit.Before;
@@ -20,7 +19,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import java.io.File;
 import java.io.IOException;
 
@@ -36,22 +34,27 @@ public class JarArtifactHandlerImplTest {
     @Mock
     private AbstractWebAppMojo mojo;
 
-    private JarArtifactHandlerImpl handler = null;
-
-    private JarArtifactHandlerImpl handlerSpy = null;
+    private JarArtifactHandlerImpl handler;
+    private JarArtifactHandlerImpl handlerSpy;
 
     @Before
-    public void setUp() {
+    public void setup() {
         MockitoAnnotations.initMocks(this);
-        handler = new JarArtifactHandlerImpl(mojo);
+    }
+
+    private void buildHandler() {
+        handler = (JarArtifactHandlerImpl) new JarArtifactHandlerImpl.Builder().jarFile(mojo.getJarFile())
+            .project(mojo.getProject())
+            .stagingDirectoryPath(mojo.getDeploymentStagingDirectoryPath())
+            .build();
         handlerSpy = spy(handler);
     }
 
     @Test
     public void publish() throws Exception {
         final DeployTarget deployTarget = new WebAppDeployTarget(this.mojo.getWebApp());
+        buildHandler();
         doNothing().when(handlerSpy).publish(deployTarget);
-
         handlerSpy.publish(deployTarget);
         verify(handlerSpy).publish(deployTarget);
     }
@@ -60,7 +63,7 @@ public class JarArtifactHandlerImplTest {
     public void publishToDeploymentSlot() throws Exception {
         final DeploymentSlot slot = mock(DeploymentSlot.class);
         final DeployTarget deployTarget = new DeploymentSlotDeployTarget(slot);
-
+        buildHandler();
         doNothing().when(handlerSpy).publish(deployTarget);
 
         handlerSpy.publish(deployTarget);
@@ -80,25 +83,25 @@ public class JarArtifactHandlerImplTest {
     @Test
     public void getJarFile() {
         doReturn("test.jar").when(mojo).getJarFile();
+        buildHandler();
         assertEquals("test.jar", handlerSpy.getJarFile().getName());
 
-        doReturn("").when(mojo).getJarFile();
-        doReturn("").when(mojo).getBuildDirectoryAbsolutePath();
         final MavenProject project = mock(MavenProject.class);
         doReturn(project).when(mojo).getProject();
-        final Build build = mock(Build.class);
-        doReturn(build).when(project).getBuild();
-        doReturn("test").when(build).getFinalName();
+        buildHandler();
+        assertEquals("test.jar", handlerSpy.getJarFile().getName());
         assertEquals("test.jar", handlerSpy.getJarFile().getName());
     }
 
     @Test(expected = MojoExecutionException.class)
     public void assureJarFileExistedWhenFileExtWrong() throws MojoExecutionException {
+        buildHandler();
         handlerSpy.assureJarFileExisted(new File("test.jar"));
     }
 
     @Test(expected = MojoExecutionException.class)
     public void assureJarFileExistedWhenFileNotExist() throws MojoExecutionException {
+        buildHandler();
         final File fileMock = mock(File.class);
 
         doReturn("test.jar").when(fileMock).getName();
@@ -112,6 +115,7 @@ public class JarArtifactHandlerImplTest {
 
         doReturn("test.jar").when(fileMock).getName();
         doReturn(false).when(fileMock).exists();
+        buildHandler();
         handlerSpy.assureJarFileExisted(fileMock);
     }
 
@@ -121,7 +125,7 @@ public class JarArtifactHandlerImplTest {
         doReturn("test.jar").when(file).getName();
         doReturn(true).when(file).exists();
         doReturn(true).when(file).isFile();
-
+        buildHandler();
         handlerSpy.assureJarFileExisted(file);
 
         verify(file).getName();

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/v2/ArtifactHandlerImplV2Test.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/v2/ArtifactHandlerImplV2Test.java
@@ -50,7 +50,14 @@ public class ArtifactHandlerImplV2Test {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        handler = new ArtifactHandlerImplV2(mojo);
+    }
+
+    public void buildHandler() {
+        handler = new ArtifactHandlerImplV2.Builder()
+            .stagingDirectoryPath(mojo.getDeploymentStagingDirectoryPath())
+            .log(mojo.getLog())
+            .resources(mojo.getDeployment().getResources())
+            .build();
         handlerSpy = spy(handler);
     }
 
@@ -64,6 +71,8 @@ public class ArtifactHandlerImplV2Test {
 
         final String stagingDirectoryPath = "dummy";
         doReturn(stagingDirectoryPath).when(mojo).getDeploymentStagingDirectoryPath();
+
+        buildHandler();
         doNothing().when(handlerSpy).copyArtifactsToStagingDirectory(resources, stagingDirectoryPath);
 
         final List<File> allArtifacts = new ArrayList<File>();
@@ -73,6 +82,7 @@ public class ArtifactHandlerImplV2Test {
         final WebApp app = mock(WebApp.class);
         final DeployTarget target = new DeployTarget(app, DeployTargetType.WEBAPP);
         doNothing().when(handlerSpy).publishArtifactsViaWarDeploy(target, stagingDirectoryPath, allArtifacts);
+
         handlerSpy.publish(target);
 
         verify(handlerSpy, times(1)).publish(target);
@@ -94,6 +104,7 @@ public class ArtifactHandlerImplV2Test {
 
         final String stagingDirectoryPath = "dummy";
         doReturn(stagingDirectoryPath).when(mojo).getDeploymentStagingDirectoryPath();
+        buildHandler();
         doNothing().when(handlerSpy).copyArtifactsToStagingDirectory(resources, stagingDirectoryPath);
 
         final List<File> allArtifacts = new ArrayList<File>();
@@ -121,9 +132,8 @@ public class ArtifactHandlerImplV2Test {
         final Log log = mock(Log.class);
         doReturn(log).when(mojo).getLog();
         final DeployTarget target = mock(DeployTarget.class);
-
+        buildHandler();
         handlerSpy.publish(target);
-
         verify(mojo, times(1)).getLog();
         verify(handlerSpy, times(1)).publish(target);
         verifyNoMoreInteractions(handlerSpy);
@@ -134,7 +144,9 @@ public class ArtifactHandlerImplV2Test {
         final DeployTarget target = mock(DeployTarget.class);
         final String stagingDirectoryPath = "";
         final List<File> warArtifacts = null;
-
+        final Deployment deployment = mock(Deployment.class);
+        doReturn(deployment).when(mojo).getDeployment();
+        buildHandler();
         handlerSpy.publishArtifactsViaWarDeploy(target, stagingDirectoryPath, warArtifacts);
     }
 
@@ -147,8 +159,10 @@ public class ArtifactHandlerImplV2Test {
         final List<File> artifacts = new ArrayList<>();
         final File artifact = new File(Paths.get(stagingDirectory, "dummypath", "dummy.war").toString());
         artifacts.add(artifact);
+        final Deployment deployment = mock(Deployment.class);
+        doReturn(deployment).when(mojo).getDeployment();
+        buildHandler();
         doNothing().when(handlerSpy).publishWarArtifact(target, artifact, "dummypath");
-
         handlerSpy.publishArtifactsViaWarDeploy(target, stagingDirectory, artifacts);
         verify(handlerSpy, times(1)).
             publishArtifactsViaWarDeploy(target, stagingDirectory, artifacts);
@@ -167,10 +181,13 @@ public class ArtifactHandlerImplV2Test {
         final Log log = mock(Log.class);
         doReturn(log).when(mojo).getLog();
         doNothing().when(log).info(anyString());
+        final Deployment deployment = mock(Deployment.class);
+        doReturn(deployment).when(mojo).getDeployment();
 
+        buildHandler();
         handlerSpy.publishArtifactsViaZipDeploy(target, stagingDirectoryPath);
 
-        verify(mojo, times(2)).getLog();
+        verify(mojo, times(1)).getLog();
         verify(handlerSpy, times(1)).publishArtifactsViaZipDeploy(target, stagingDirectoryPath);
         verifyNoMoreInteractions(handlerSpy);
     }
@@ -185,7 +202,10 @@ public class ArtifactHandlerImplV2Test {
         final Log log = mock(Log.class);
         doReturn(log).when(mojo).getLog();
         doNothing().when(log).info(anyString());
+        final Deployment deployment = mock(Deployment.class);
+        doReturn(deployment).when(mojo).getDeployment();
 
+        buildHandler();
         handlerSpy.publishWarArtifact(target, warArtifact, contextPath);
 
         verify(handlerSpy, times(1)).publishWarArtifact(target, warArtifact, contextPath);
@@ -203,6 +223,9 @@ public class ArtifactHandlerImplV2Test {
         final Log log = mock(Log.class);
         doReturn(log).when(mojo).getLog();
         doNothing().when(log).info(anyString());
+        final Deployment deployment = mock(Deployment.class);
+        doReturn(deployment).when(mojo).getDeployment();
+        buildHandler();
         handlerSpy.publishWarArtifact(target, warArtifact, contextPath);
     }
 }

--- a/build-tools/src/main/resources/findbugs/findbugs-exclude.xml
+++ b/build-tools/src/main/resources/findbugs/findbugs-exclude.xml
@@ -9,6 +9,7 @@
     <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
     <Bug pattern="OS_OPEN_STREAM_EXCEPTION_PATH"/>
     <Bug pattern="OBL_UNSATISFIED_OBLIGATION"/>
+    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"/>
     <Match>
         <Or>
             <Class name = "com.microsoft.azure.maven.webapp.handlers.ArtifactHandlerUtils$1" />


### PR DESCRIPTION
Artifact handlers depend on Mojo is not a good practice for:
- the validation of the mojo scatters everywhere
- the logic to processing the mojo scatters everywhere

Updating the artifact handlers to depend on types what SDK needs, to prepare for the configuration layer refactoring we are going to do.