### PR TITLE
Let user decide if to proceed when mix deploy war artifact

### DIFF
--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/artifacthandler/ArtifactHandlerBase.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/artifacthandler/ArtifactHandlerBase.java
@@ -20,6 +20,7 @@ import java.util.List;
 public abstract class ArtifactHandlerBase implements ArtifactHandler {
     protected static final String DEPLOY_START = "Trying to deploy artifact to %s...";
     protected static final String DEPLOY_FINISH = "Successfully deployed the artifact to https://%s";
+    protected static final String DEPLOY_ABORT = "Deployment is aborted.";
     protected MavenProject project;
     protected MavenSession session;
     protected MavenResourcesFiltering filtering;

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/artifacthandler/ArtifactHandlerBase.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/artifacthandler/ArtifactHandlerBase.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.util.List;
 
 public abstract class ArtifactHandlerBase implements ArtifactHandler {
+    protected static final String DEPLOY_START = "Trying to deploy artifact to %s...";
+    protected static final String DEPLOY_FINISH = "Successfully deployed the artifact to https://%s";
     protected MavenProject project;
     protected MavenSession session;
     protected MavenResourcesFiltering filtering;

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/artifacthandler/ZIPArtifactHandlerImpl.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/artifacthandler/ZIPArtifactHandlerImpl.java
@@ -49,6 +49,7 @@ public class ZIPArtifactHandlerImpl extends ArtifactHandlerBase {
         assureStagingDirectoryNotEmpty();
 
         final File zipFile = getZipFile();
+        log.info(String.format(DEPLOY_START, target.getName()));
 
         // Add retry logic here to avoid Kudu's socket timeout issue.
         // More details: https://github.com/Microsoft/azure-maven-plugins/issues/339
@@ -57,6 +58,7 @@ public class ZIPArtifactHandlerImpl extends ArtifactHandlerBase {
             retryCount += 1;
             try {
                 target.zipDeploy(zipFile);
+                log.info(String.format(DEPLOY_FINISH, target.getDefaultHostName()));
                 return;
             } catch (Exception e) {
                 log.debug(

--- a/azure-maven-plugin-lib/src/test/java/com/microsoft/azure/maven/artifacthandler/ZIPArtifactHandlerImplTest.java
+++ b/azure-maven-plugin-lib/src/test/java/com/microsoft/azure/maven/artifacthandler/ZIPArtifactHandlerImplTest.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.maven.AbstractAppServiceMojo;
 import com.microsoft.azure.maven.appservice.DeployTargetType;
 import com.microsoft.azure.maven.deploytarget.DeployTarget;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -47,16 +49,19 @@ public class ZIPArtifactHandlerImplTest {
     }
 
     private void buildHandler() {
-        handler = builder.stagingDirectoryPath(mojo.getDeploymentStagingDirectoryPath()).build();
+        handler = builder.stagingDirectoryPath(mojo.getDeploymentStagingDirectoryPath()).log(mojo.getLog()).build();
         handlerSpy = spy(handler);
     }
 
     @Test
     public void publish() throws MojoExecutionException, IOException {
-        buildHandler();
         final WebApp app = mock(WebApp.class);
         final DeployTarget target = new DeployTarget(app, DeployTargetType.WEBAPP);
         final File file = mock(File.class);
+        final Log log = mock(Log.class);
+        doReturn(log).when(mojo).getLog();
+        doNothing().when(log).info(anyString());
+        buildHandler();
 
         doReturn(file).when(handlerSpy).getZipFile();
         doNothing().when(app).zipDeploy(file);
@@ -75,6 +80,9 @@ public class ZIPArtifactHandlerImplTest {
 
     @Test
     public void publishThrowException() throws MojoExecutionException, IOException {
+        final Log log = mock(Log.class);
+        doReturn(log).when(mojo).getLog();
+        doNothing().when(log).info(anyString());
         buildHandler();
         final WebApp app = mock(WebApp.class);
         final DeployTarget target = new DeployTarget(app, DeployTargetType.WEBAPP);

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/DeployMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/DeployMojo.java
@@ -31,8 +31,6 @@ import java.util.concurrent.TimeUnit;
  */
 @Mojo(name = "deploy", defaultPhase = LifecyclePhase.DEPLOY)
 public class DeployMojo extends AbstractWebAppMojo {
-    public static final String DEPLOY_START = "Trying to deploy artifact to %s...";
-    public static final String DEPLOY_FINISH = "Successfully deployed the artifact to https://%s";
     public static final String WEBAPP_NOT_EXIST = "Target Web App doesn't exist. Creating a new one...";
     public static final String WEBAPP_CREATED = "Successfully created Web App.";
     public static final String CREATE_DEPLOYMENT_SLOT = "Target Deployment Slot doesn't exist. Creating a new one...";
@@ -134,12 +132,7 @@ public class DeployMojo extends AbstractWebAppMojo {
             } else {
                 target = new WebAppDeployTarget(app);
             }
-
-            getLog().info(String.format(DEPLOY_START, target.getName()));
-
             getFactory().getArtifactHandler(this).publish(target);
-
-            getLog().info(String.format(DEPLOY_FINISH, target.getDefaultHostName()));
         } finally {
             util.afterDeployArtifacts();
         }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerImplV2.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerImplV2.java
@@ -27,7 +27,6 @@ import static com.microsoft.azure.maven.webapp.handlers.ArtifactHandlerUtils.per
 public class ArtifactHandlerImplV2 extends ArtifactHandlerBase {
     private static final int MAX_RETRY_TIMES = 3;
     private static final String ALWAYS_DEPLOY_PROPERTY = "alwaysDeploy";
-    private static final String ALWAYS_SKIP_DEPLOY_PROPERTY = "alwaysSkipDeploy";
 
     public static class Builder extends ArtifactHandlerBase.Builder<ArtifactHandlerImplV2.Builder> {
         @Override
@@ -87,21 +86,18 @@ public class ArtifactHandlerImplV2 extends ArtifactHandlerBase {
         if ("true".equalsIgnoreCase(System.getProperty(ALWAYS_DEPLOY_PROPERTY))) {
             return true;
         }
-        if ("true".equalsIgnoreCase(System.getProperty(ALWAYS_SKIP_DEPLOY_PROPERTY))) {
-            return false;
-        }
-        log.info(String.format("To get rid of the prompt message, you could set the property %s to true " +
-            "to always proceed with the deploy, or set the property %s to true to always skip the deploy.",
-            ALWAYS_DEPLOY_PROPERTY, ALWAYS_SKIP_DEPLOY_PROPERTY));
+
+        log.info(String.format("To get rid of the following message, set the property %s to true to always proceed " +
+            "with the deploy.", ALWAYS_DEPLOY_PROPERTY));
 
         final Scanner scanner = new Scanner(System.in, "UTF-8");
         while (true) {
             log.warn("Deploying war along with other kinds of artifacts might make the web app inaccessible, " +
                 "are you sure to proceed (y/n)?");
             final String input = scanner.nextLine();
-            if ("Y".equalsIgnoreCase(input)) {
+            if ("y".equalsIgnoreCase(input)) {
                 return true;
-            } else if ("N".equalsIgnoreCase(input)) {
+            } else if ("n".equalsIgnoreCase(input)) {
                 return false;
             }
         }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerImplV2.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerImplV2.java
@@ -97,7 +97,7 @@ public class ArtifactHandlerImplV2 extends ArtifactHandlerBase {
         final Scanner scanner = new Scanner(System.in, "UTF-8");
         while (true) {
             log.warn("Deploying war along with other kinds of artifacts might make the web app inaccessible, " +
-                "are you sure to proceed? Input y/Y to proceed or n/N to abort:");
+                "are you sure to proceed (y/n)?");
             final String input = scanner.nextLine();
             if ("Y".equalsIgnoreCase(input)) {
                 return true;

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerImplV2.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerImplV2.java
@@ -74,7 +74,7 @@ public class ArtifactHandlerImplV2 extends ArtifactHandlerBase {
             return;
         }
 
-        if (isProceedWithMixDeploy()) {
+        if (isDeployMixedArtifactsConfirmed()) {
             publishArtifactsViaZipDeploy(target, stagingDirectoryPath);
             log.info(String.format(DEPLOY_FINISH, target.getDefaultHostName()));
         } else {
@@ -82,7 +82,7 @@ public class ArtifactHandlerImplV2 extends ArtifactHandlerBase {
         }
     }
 
-    protected boolean isProceedWithMixDeploy() {
+    protected boolean isDeployMixedArtifactsConfirmed() {
         if ("true".equalsIgnoreCase(System.getProperty(ALWAYS_DEPLOY_PROPERTY))) {
             return true;
         }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/WarArtifactHandlerImpl.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/WarArtifactHandlerImpl.java
@@ -70,7 +70,8 @@ public class WarArtifactHandlerImpl extends ArtifactHandlerBase {
         assureWarFileExisted(war);
 
         final Runnable warDeployExecutor = ArtifactHandlerUtils.getRealWarDeployExecutor(target, war, getContextPath());
-        
+        log.info(String.format(DEPLOY_START, target.getName()));
+
         // Add retry logic here to avoid Kudu's socket timeout issue.
         // More details: https://github.com/Microsoft/azure-maven-plugins/issues/339
         int retryCount = 0;
@@ -80,6 +81,7 @@ public class WarArtifactHandlerImpl extends ArtifactHandlerBase {
             retryCount++;
             try {
                 warDeployExecutor.run();
+                log.info(String.format(DEPLOY_FINISH, target.getDefaultHostName()));
                 return;
             } catch (Exception e) {
                 log.debug(String.format(UPLOAD_FAILURE, e.getMessage(), retryCount, DEFAULT_MAX_RETRY_TIMES));

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerImplV2Test.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/ArtifactHandlerImplV2Test.java
@@ -71,6 +71,9 @@ public class ArtifactHandlerImplV2Test {
 
         final String stagingDirectoryPath = "dummy";
         doReturn(stagingDirectoryPath).when(mojo).getDeploymentStagingDirectoryPath();
+        final Log log = mock(Log.class);
+        doReturn(log).when(mojo).getLog();
+        doNothing().when(log).info(anyString());
 
         buildHandler();
         doNothing().when(handlerSpy).copyArtifactsToStagingDirectory(resources, stagingDirectoryPath);
@@ -104,6 +107,10 @@ public class ArtifactHandlerImplV2Test {
 
         final String stagingDirectoryPath = "dummy";
         doReturn(stagingDirectoryPath).when(mojo).getDeploymentStagingDirectoryPath();
+        final Log log = mock(Log.class);
+        doReturn(log).when(mojo).getLog();
+        doNothing().when(log).info(anyString());
+
         buildHandler();
         doNothing().when(handlerSpy).copyArtifactsToStagingDirectory(resources, stagingDirectoryPath);
 


### PR DESCRIPTION
When users mix the war package with another kind of artifact, we will prompt a message for users to be aware of the consequences. This also provides an option for users to abort the deployment. Also, system properties `alwaysDeploy` and `alwaysSkipDeploy` are provided for users to process/abort deployment in silence.