### PR TITLE
Check the region only when creating web app

### DIFF
--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParser.java
@@ -17,7 +17,6 @@ import com.microsoft.azure.maven.webapp.configuration.RuntimeSetting;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.util.StringUtils;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -51,7 +50,7 @@ public class V2ConfigurationParser extends ConfigurationParser {
     @Override
     protected Region getRegion() throws MojoExecutionException {
         final String region = mojo.getRegion();
-        if (!Arrays.asList(Region.values()).contains(region)) {
+        if (Region.findByLabelOrName(region) == null) {
             throw new MojoExecutionException("The value of <region> is not supported, please correct it in pom.xml.");
         }
         return Region.fromName(region);

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParser.java
@@ -51,7 +51,7 @@ public class V2ConfigurationParser extends ConfigurationParser {
     @Override
     protected Region getRegion() throws MojoExecutionException {
         final String region = mojo.getRegion();
-        if (Arrays.asList(Region.values()).contains(region)) {
+        if (!Arrays.asList(Region.values()).contains(region)) {
             throw new MojoExecutionException("The value of <region> is not supported, please correct it in pom.xml.");
         }
         return Region.fromName(region);

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParser.java
@@ -51,9 +51,6 @@ public class V2ConfigurationParser extends ConfigurationParser {
     @Override
     protected Region getRegion() throws MojoExecutionException {
         final String region = mojo.getRegion();
-        if (StringUtils.isEmpty(region)) {
-            throw new MojoExecutionException("Please config the <region> in pom.xml.");
-        }
         if (Arrays.asList(Region.values()).contains(region)) {
             throw new MojoExecutionException("The value of <region> is not supported, please correct it in pom.xml.");
         }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParser.java
@@ -50,7 +50,7 @@ public class V2ConfigurationParser extends ConfigurationParser {
     @Override
     protected Region getRegion() throws MojoExecutionException {
         final String region = mojo.getRegion();
-        if (Region.findByLabelOrName(region) == null) {
+        if (!StringUtils.isEmpty(region) && Region.findByLabelOrName(region) == null) {
             throw new MojoExecutionException("The value of <region> is not supported, please correct it in pom.xml.");
         }
         return Region.fromName(region);

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParserTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParserTest.java
@@ -76,17 +76,11 @@ public class V2ConfigurationParserTest {
 
     @Test
     public void getRegion() throws MojoExecutionException {
-        try {
-            parser.getRegion();
-        } catch (MojoExecutionException e) {
-            assertEquals(e.getMessage(), "Please config the <region> in pom.xml.");
-        }
-
         doReturn("unknown-region").when(mojo).getRegion();
         try {
             parser.getRegion();
         } catch (MojoExecutionException e) {
-            assertEquals(e.getMessage(), "The value of <region> is not correct, please correct it in pom.xml.");
+            assertEquals(e.getMessage(), "The value of <region> is not supported, please correct it in pom.xml.");
         }
 
         doReturn(Region.US_WEST.name()).when(mojo).getRegion();


### PR DESCRIPTION
Remove the `createOrUpdateWebApp`, separate the create Web App logic and update Web App logic and move them into the `doExecute()` for better readability.

Only when creating a new Web App , the region is required.