### PR TITLE
Update web app default pricing tier to P1V2

### DIFF
--- a/azure-functions-maven-plugin/README.md
+++ b/azure-functions-maven-plugin/README.md
@@ -147,9 +147,9 @@ Read more at [Azure App Service Plan Pricing](https://azure.microsoft.com/en-us/
 - `S1`
 - `S2`
 - `S3`
-- `P1`
-- `P2`
-- `P3`
+- `P1V2`
+- `P2V2`
+- `P3V2`
 
 ## How-To
 

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
@@ -35,9 +35,9 @@ public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
      *     <li>S1</li>
      *     <li>S2</li>
      *     <li>S3</li>
-     *     <li>P1</li>
-     *     <li>P2</li>
-     *     <li>P3</li>
+     *     <li>P1V2</li>
+     *     <li>P2V2</li>
+     *     <li>P3V2</li>
      * </ul>
      */
     @Parameter(property = "functions.pricingTier")

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
@@ -67,7 +67,7 @@ public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
 
     //region Getter
 
-    public PricingTier getPricingTier() {
+    public PricingTier getPricingTier() throws MojoExecutionException {
         return pricingTier == null ? null : pricingTier.toPricingTier();
     }
 

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/appservice/PricingTierEnum.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/appservice/PricingTierEnum.java
@@ -7,6 +7,7 @@
 package com.microsoft.azure.maven.appservice;
 
 import com.microsoft.azure.management.appservice.PricingTier;
+import org.apache.maven.plugin.MojoExecutionException;
 
 public enum PricingTierEnum {
     F1("F1"),
@@ -44,7 +45,7 @@ public enum PricingTierEnum {
         this.pricingTier = pricingTier;
     }
 
-    public PricingTier toPricingTier() {
+    public PricingTier toPricingTier() throws MojoExecutionException {
         switch (pricingTier) {
             case "F1":
                 return PricingTier.FREE_F1;
@@ -64,13 +65,14 @@ public enum PricingTierEnum {
                 return PricingTier.STANDARD_S3;
             // workaround to define the pricing tier with constructor since SDK has not updated the latest values
             // https://github.com/Azure/azure-libraries-for-java/issues/660
+            case "P1V2":
+                return new PricingTier("Premium", "P1V2");
             case "P2V2":
                 return new PricingTier("Premium", "P2V2");
             case "P3V2":
                 return new PricingTier("Premium", "P3V2");
-            case "P1V2":
             default:
-                return new PricingTier("Premium", "P1V2");
+                throw new MojoExecutionException("Unknown value of the pricingTier, please correct it in pom.xml.");
         }
     }
 }

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/appservice/PricingTierEnum.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/appservice/PricingTierEnum.java
@@ -25,12 +25,18 @@ public enum PricingTierEnum {
     s2("S2"),
     S3("S3"),
     s3("S3"),
-    P1("P1"),
-    p1("P1"),
-    P2("P2"),
-    p2("P2"),
-    P3("P3"),
-    p3("P3");
+    P1V2("P1V2"),
+    p1v2("P1V2"),
+    p1V2("P1V2"),
+    P1v2("P1V2"),
+    P2V2("P2V2"),
+    P2v2("P2V2"),
+    p2V2("P2V2"),
+    p2v2("P2V2"),
+    P3V2("P3V2"),
+    p3V2("P3V2"),
+    P3v2("P3V2"),
+    p3v2("P3V2");
 
     private final String pricingTier;
 
@@ -50,19 +56,21 @@ public enum PricingTierEnum {
                 return PricingTier.BASIC_B2;
             case "B3":
                 return PricingTier.BASIC_B3;
+            case "S1":
+                return PricingTier.STANDARD_S1;
             case "S2":
                 return PricingTier.STANDARD_S2;
             case "S3":
                 return PricingTier.STANDARD_S3;
-            case "P1":
-                return PricingTier.PREMIUM_P1;
-            case "P2":
-                return PricingTier.PREMIUM_P2;
-            case "P3":
-                return PricingTier.PREMIUM_P3;
-            case "S1":
+            // workaround to define the pricing tier with constructor since SDK has not updated the latest values
+            // https://github.com/Azure/azure-libraries-for-java/issues/660
+            case "P2V2":
+                return new PricingTier("Premium", "P2V2");
+            case "P3V2":
+                return new PricingTier("Premium", "P3V2");
+            case "P1V2":
             default:
-                return PricingTier.STANDARD_S1;
+                return new PricingTier("Premium", "P1V2");
         }
     }
 }

--- a/azure-webapp-maven-plugin/README.md
+++ b/azure-webapp-maven-plugin/README.md
@@ -379,6 +379,6 @@ All valid pricing tiers are listed as below. Read more at [Azure App Service Pla
 - `S1`
 - `S2`
 - `S3`
-- `P1`
-- `P2`
-- `P3`
+- `P1V2`
+- `P2V2`
+- `P3V2`

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
@@ -246,7 +246,7 @@ public abstract class AbstractWebAppMojo extends AbstractAppServiceMojo {
         return region;
     }
 
-    public PricingTier getPricingTier() {
+    public PricingTier getPricingTier() throws MojoExecutionException {
         return pricingTier == null ? new PricingTier("Premium", "P1V2") : pricingTier.toPricingTier();
     }
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
@@ -53,12 +53,12 @@ public abstract class AbstractWebAppMojo extends AbstractAppServiceMojo {
      *     <li>S1</li>
      *     <li>S2</li>
      *     <li>S3</li>
-     *     <li>P1</li>
-     *     <li>P2</li>
-     *     <li>P3</li>
+     *     <li>P1V2</li>
+     *     <li>P2V2</li>
+     *     <li>P3V2</li>
      * </ul>
      */
-    @Parameter(property = "webapp.pricingTier", defaultValue = "S1")
+    @Parameter(property = "webapp.pricingTier", defaultValue = "P1V2")
     protected PricingTierEnum pricingTier;
 
     /**
@@ -247,7 +247,7 @@ public abstract class AbstractWebAppMojo extends AbstractAppServiceMojo {
     }
 
     public PricingTier getPricingTier() {
-        return pricingTier == null ? PricingTier.STANDARD_S1 : pricingTier.toPricingTier();
+        return pricingTier == null ? new PricingTier("Premium", "P1V2") : pricingTier.toPricingTier();
     }
 
     public JavaVersion getJavaVersion() {

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/DeployMojoTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/DeployMojoTest.java
@@ -130,7 +130,7 @@ public class DeployMojoTest {
 
         assertEquals("westeurope", mojo.getRegion());
 
-        assertEquals(PricingTier.STANDARD_S1, mojo.getPricingTier());
+        assertEquals(new PricingTier("Premium", "P1V2"), mojo.getPricingTier());
 
         assertEquals(null, mojo.getJavaVersion());
 

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/HandlerFactoryImplTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/HandlerFactoryImplTest.java
@@ -50,7 +50,7 @@ public class HandlerFactoryImplTest {
         doReturn("").when(config).getAppName();
         doReturn("").when(config).getResourceGroup();
         doReturn(Region.US_EAST).when(config).getRegion();
-        doReturn(PricingTier.STANDARD_S1).when(config).getPricingTier();
+        doReturn(new PricingTier("Premium", "P1V2")).when(config).getPricingTier();
         doReturn("").when(config).getServicePlanName();
         doReturn("").when(config).getServicePlanResourceGroup();
 

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/ConfigurationParserTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/ConfigurationParserTest.java
@@ -150,7 +150,7 @@ public class ConfigurationParserTest {
         doReturn(session).when(mojo).getSession();
         doReturn("test-staging-path").when(mojo).getDeploymentStagingDirectoryPath();
         doReturn("test-build-directory-path").when(mojo).getBuildDirectoryAbsolutePath();
-        doReturn(PricingTier.STANDARD_S1).when(mojo).getPricingTier();
+        doReturn(new PricingTier("Premium", "P1V2")).when(mojo).getPricingTier();
 
         doReturn(OperatingSystemEnum.Windows).when(parserSpy).getOs();
         WebAppConfiguration webAppConfiguration = parserSpy.getWebAppConfiguration();
@@ -158,7 +158,7 @@ public class ConfigurationParserTest {
         assertEquals("appName", webAppConfiguration.getAppName());
         assertEquals("resourceGroupName", webAppConfiguration.getResourceGroup());
         assertEquals(Region.EUROPE_WEST, webAppConfiguration.getRegion());
-        assertEquals(PricingTier.STANDARD_S1, webAppConfiguration.getPricingTier());
+        assertEquals(new PricingTier("Premium", "P1V2"), webAppConfiguration.getPricingTier());
         assertEquals(null, webAppConfiguration.getServicePlanName());
         assertEquals(null, webAppConfiguration.getServicePlanResourceGroup());
         assertEquals(OperatingSystemEnum.Windows, webAppConfiguration.getOs());


### PR DESCRIPTION
The SDK has issues about the supported pricing tiers https://github.com/Azure/azure-libraries-for-java/issues/660. We add our workaround to generate the V2 kind of pricing tiers with constructors and use the P1V2 as default pricing tier for Azure Web App.

Furthermore, throw exceptions when users specify an invalid configuration of the pricing tier in the pom file.