### PR TITLE
Fix AI SDK may step into endless loop when maven goal execute too quick

### DIFF
--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -312,7 +312,7 @@ public abstract class AbstractAzureMojo extends AbstractMojo implements Telemetr
             }
         } catch (Exception e) {
             handleException(e);
-        }finally{
+        } finally {
             // When maven goal executes too quick, The HTTPClient of AI SDK may not fully initialized and will step
             // into endless loop when close, we need to call it in main thread.
             // Refer here for detail codes: https://github.com/Microsoft/ApplicationInsights-Java/blob/master/core/src

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -293,12 +293,6 @@ public abstract class AbstractAzureMojo extends AbstractMojo implements Telemetr
             // An issue has been filed at https://github.com/Microsoft/ApplicationInsights-Java/issues/416
             // Before this issue is fixed, set default uncaught exception handler for all threads as work around.
             Thread.setDefaultUncaughtExceptionHandler(new DefaultUncaughtExceptionHandler());
-            // When maven goal executes too quick, The HTTPClient of AI SDK may not fully initialized and will step
-            // into endless loop
-            // Refer here for detail codes: https://github.com/Microsoft/ApplicationInsights-Java/blob/master/core/src
-            // /main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java#L103
-            // So we initialize it in the main thread and call getHttpClient to make sure HTTPClient was created
-            ApacheSenderFactory.INSTANCE.create().getHttpClient();
 
             final Properties prop = new Properties();
             if (isFirstRun(prop)) {
@@ -318,6 +312,12 @@ public abstract class AbstractAzureMojo extends AbstractMojo implements Telemetr
             }
         } catch (Exception e) {
             handleException(e);
+        }finally{
+            // When maven goal executes too quick, The HTTPClient of AI SDK may not fully initialized and will step
+            // into endless loop when close, we need to call it in main thread.
+            // Refer here for detail codes: https://github.com/Microsoft/ApplicationInsights-Java/blob/master/core/src
+            // /main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java#L103
+            ApacheSenderFactory.INSTANCE.create().close();
         }
     }
 

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -406,6 +406,14 @@ public abstract class AbstractAzureMojo extends AbstractMojo implements Telemetr
         @Override
         public void uncaughtException(Thread t, Throwable e) {
             debug("uncaughtException: " + e);
+            // Work around for Application Insights Java SDK:
+            // Related issues: https://github.com/Microsoft/azure-maven-plugins/issues/341
+            // When maven goal executes too quick, AI SDK may not fully initialized and will step into endless loop
+            // Refer here for detail codes: https://github.com/Microsoft/ApplicationInsights-Java/blob/master/core/src
+            // /main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java#L103
+            // As ShutdownHook(SDKShutdownActivity.ShutdownAction) will call this method and we have no other way to
+            // stop a shutdown hook thread, call Runtime.halt() here and this should be removed once AI issue fixed.
+            Runtime.getRuntime().halt(0);
         }
     }
 


### PR DESCRIPTION
Shutdown JVM when AI SDK step into endless loop, for issue #341 #568 