### PR TITLE
[ Hold ]Show url of http trigger with authLevel ANONYMOUS after deployment

### DIFF
--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -199,6 +199,16 @@
             <version>${azure.maven-plugin-lib.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.microsoft.azure.appservice.v2016_08_01</groupId>
+            <artifactId>azure-mgmt-appservice</artifactId>
+            <version>1.0.0-beta-1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-arm-client-runtime</artifactId>
+            <version>1.6.5</version>
+        </dependency>
+        <dependency>
             <groupId>com.microsoft.azure.functions</groupId>
             <artifactId>azure-functions-java-library</artifactId>
             <version>${azure.function.version}</version>

--- a/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/DeployMojoTest.java
+++ b/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/DeployMojoTest.java
@@ -90,6 +90,7 @@ public class DeployMojoTest extends MojoTestBase {
         doReturn(handler).when(mojoSpy).getArtifactHandler();
         doCallRealMethod().when(mojoSpy).createOrUpdateFunctionApp();
         doCallRealMethod().when(mojoSpy).getAppName();
+        doNothing().when(mojoSpy).listHttpTriggerUrls();
         final DeployTarget deployTarget = new DeployTarget(app, DeployTargetType.FUNCTION);
         doNothing().when(mojoSpy).updateFunctionApp(app);
 


### PR DESCRIPTION
Show url of http trigger with authLevel ANONYMOUS after deployment, for issue #571 

Known issue:
Maven will show warning when execute function maven goal.
`
[WARNING] The POM for com.microsoft.azure.appservice.v2016_08_01:azure-mgmt-appservice:jar:1.0.0-beta-1 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
`