### PR TITLE
Fix AI SDK may break down in Java11

### DIFF
--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -28,7 +28,7 @@
         <maven.plugin-tools.version>3.2</maven.plugin-tools.version>
         <maven.plugin-testing.version>3.3.0</maven.plugin-testing.version>
         <codehaus.plexus-utils.version>3.0.20</codehaus.plexus-utils.version>
-        <azure.maven-plugin-lib.version>1.2.7</azure.maven-plugin-lib.version>
+        <azure.maven-plugin-lib.version>1.2.8-SNAPSHOT</azure.maven-plugin-lib.version>
         <azure.function.version>1.3.0</azure.function.version>
         <reflections.version>0.9.11</reflections.version>
         <junit.version>4.12</junit.version>
@@ -282,7 +282,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.4</version>
+                <version>3.6.0</version>
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
@@ -19,8 +19,8 @@ import java.io.File;
 
 public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
 
-    private static final String JDK_VERSION_ERROR = "Local JDK version %s does not meet the requirement of the " +
-            "Maven plugin for Azure Functions. The supported version is JDK 8";
+    private static final String JDK_VERSION_ERROR = "Azure Functions only support JDK 8, which is lower than local " +
+        "JDK version %s";
 
     //region Properties
     /**
@@ -106,7 +106,7 @@ public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
     public void checkJavaVersion() throws MojoExecutionException {
         final String javaVersion = System.getProperty("java.version");
         if (!javaVersion.startsWith("1.8")){
-            throw new MojoExecutionException(String.format(JDK_VERSION_ERROR, javaVersion));
+            super.warning(String.format(JDK_VERSION_ERROR, javaVersion));
         }
     }
 

--- a/azure-functions-maven-plugin/src/main/resources/ApplicationInsights.xml
+++ b/azure-functions-maven-plugin/src/main/resources/ApplicationInsights.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings" schemaVersion="2014-05-30">
+<ApplicationInsights>
     <!-- The key from the portal: -->
     <InstrumentationKey>${azure.ai.ikey}</InstrumentationKey>
 

--- a/azure-maven-plugin-lib/pom.xml
+++ b/azure-maven-plugin-lib/pom.xml
@@ -33,6 +33,7 @@
         <common-net.version>3.6</common-net.version>
         <junit.version>4.12</junit.version>
         <mockito.version>2.22.0</mockito.version>
+        <jaxb.version>2.3.2</jaxb.version>
         <zeroturnaround.zip.version>1.13</zeroturnaround.zip.version>
     </properties>
 
@@ -144,6 +145,18 @@
             <groupId>org.zeroturnaround</groupId>
             <artifactId>zt-zip</artifactId>
             <version>${zeroturnaround.zip.version}</version>
+        </dependency>
+
+        <!-- JAXB For Application Insight Issue -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>${jaxb.version}</version>
         </dependency>
 
         <!-- TEST -->

--- a/azure-webapp-maven-plugin/pom.xml
+++ b/azure-webapp-maven-plugin/pom.xml
@@ -241,7 +241,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.4</version>
+                <version>3.6.0</version>
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>

--- a/azure-webapp-maven-plugin/src/main/resources/ApplicationInsights.xml
+++ b/azure-webapp-maven-plugin/src/main/resources/ApplicationInsights.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings" schemaVersion="2014-05-30">
+<ApplicationInsights>
     <!-- The key from the portal: -->
     <InstrumentationKey>${azure.ai.ikey}</InstrumentationKey>
 


### PR DESCRIPTION
Add jaxb to dependencies, fix AI SDK break down within Java11 , for issue #162 

Existing issue:
Jaxb can't process xml attributes within Java11, it will throw exception when process ApplicationInsight.xml
`unexpected element (uri:"http://schemas.microsoft.com/ApplicationInsights/2013/Settings", local:"ApplicationInsights"). Expected elements are <{}ApplicationInsights>`, so removed attributes of `ApplicationInsights` node, this may affect later ai settings for we need to specify funnel name to set Flush Interval time.