### PR TITLE
Support AZURE_CONFIG_DIR as source for Azure CLI configuration

### DIFF
--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -53,7 +53,7 @@ public abstract class AbstractAzureMojo extends AbstractMojo implements Telemetr
     public static final String INIT_FAILURE = "InitFailure";
     public static final String AZURE_INIT_FAIL = "Failed to authenticate with Azure. Please check your configuration.";
     public static final String FAILURE_REASON = "failureReason";
-    private static final String CONFIGURATION_PATH = Paths.get(System.getProperty("user.home"),
+    private static final String CONFIGURATION_PATH = Paths.get(getAzureConfigDirectory()),
         ".azure", "mavenplugins.properties").toString();
     private static final String FIRST_RUN_KEY = "first.run";
     private static final String PRIVACY_STATEMENT = "\nData/Telemetry\n" +
@@ -368,6 +368,16 @@ public abstract class AbstractAzureMojo extends AbstractMojo implements Telemetr
     //endregion
 
     //region Helper methods
+
+    private static String getAzureConfigDirectory() {
+        final String azureConfigDir = System.getenv("AZURE_CONFIG_DIR");
+
+        if (azureConfigDir != null) {
+            return azureConfigDir;
+        }
+
+        return System.getProperty("user.home");
+    }
 
     protected void handleException(final Exception exception) throws MojoExecutionException {
         String message = exception.getMessage();

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/auth/AzureAuthHelper.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/auth/AzureAuthHelper.java
@@ -355,7 +355,7 @@ public class AzureAuthHelper {
     }
 
     private static JsonObject getDefaultSubscriptionObject() throws IOException {
-        final File azureProfile = Paths.get(System.getProperty("user.home"),
+        final File azureProfile = Paths.get(getAzureConfigDirectory(),
                 AZURE_FOLDER, AZURE_PROFILE_NAME).toFile();
         try (final FileInputStream fis = new FileInputStream(azureProfile);
              final Scanner scanner = new Scanner(new BOMInputStream(fis))) {
@@ -373,7 +373,7 @@ public class AzureAuthHelper {
     }
 
     private static JsonArray getAzureCliTokenList() throws IOException {
-        final File azureProfile = Paths.get(System.getProperty("user.home"),
+        final File azureProfile = Paths.get(getAzureConfigDirectory(),
                 AZURE_FOLDER, AZURE_TOKEN_NAME).toFile();
         try (final FileInputStream fis = new FileInputStream(azureProfile);
              final Scanner scanner = new Scanner(new BOMInputStream(fis))) {
@@ -384,5 +384,15 @@ public class AzureAuthHelper {
 
     private static boolean isInCloudShell() {
         return System.getenv(CLOUD_SHELL_ENV_KEY) != null;
+    }
+
+    private static String getAzureConfigDirectory() {
+        final String azureConfigDir = System.getenv("AZURE_CONFIG_DIR");
+
+        if (azureConfigDir != null) {
+            return azureConfigDir;
+        }
+
+        return System.getProperty("user.home");
     }
 }


### PR DESCRIPTION
This is a quick fix so that the Maven plugin will use [AZURE_CONFIG_DIR](https://docs.microsoft.com/en-us/cli/azure/azure-cli-configuration?view=azure-cli-latest#cli-configuration-file) if set.
