### PR TITLE
Fix hint for webapp:config

### DIFF
--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/queryer/MavenPluginQueryer.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/queryer/MavenPluginQueryer.java
@@ -6,10 +6,12 @@
 
 package com.microsoft.azure.maven.queryer;
 
+import org.apache.commons.collections4.BidiMap;
 import org.apache.maven.plugin.MojoFailureException;
 import org.codehaus.plexus.util.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -33,6 +35,14 @@ public abstract class MavenPluginQueryer {
         }
         final ArrayList<String> options = new ArrayList<>(optionSet);
         return assureInputFromUser(attribute, defaultValueForAttribute, options, prompt);
+    }
+
+    public String assureInputFromUser(String attribute, String defaultValue,
+                                      BidiMap<String, String> options, String prompt) throws MojoFailureException {
+        final String defaultDisplayName = options.getKey(defaultValue);
+        final List<String> displayNames = new ArrayList<>(options.keySet());
+        Collections.sort(displayNames);
+        return options.get(assureInputFromUser(attribute, defaultDisplayName, displayNames, prompt));
     }
 
     protected boolean validateInputByOptions(String input, List<String> options) {

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
@@ -251,7 +251,10 @@ public class ConfigMojo extends AbstractWebAppMojo {
         final String defaultJavaVersion = configuration.getLinuxJavaVersionOrDefault();
         final String javaVersion = queryer.assureInputFromUser("javaVersion",
             defaultJavaVersion, RuntimeStackUtils.getValidJavaVersions(), null);
-
+        // For project which package is jar, use java se runtime
+        if (isJarProject()) {
+            return builder.runtimeStack(RuntimeStackUtils.getRuntimeStack(javaVersion));
+        }
         final String defaultLinuxRuntimeStack = configuration.getLinuxRuntimeStackOrDefault();
         final String runtimeStack = queryer.assureInputFromUser("runtimeStack",
             defaultLinuxRuntimeStack, RuntimeStackUtils.getValidWebContainer(javaVersion), null);
@@ -264,7 +267,11 @@ public class ConfigMojo extends AbstractWebAppMojo {
         final String defaultJavaVersion = configuration.getJavaVersionOrDefault();
         final String javaVersion = queryer.assureInputFromUser("javaVersion",
             defaultJavaVersion, getAvailableJavaVersion(), null);
-
+        // For project which package is jar, use java se runtime
+        if (isJarProject()) {
+            return builder.javaVersion(JavaVersion.fromString(javaVersion))
+                    .webContainer(WebAppConfiguration.DEFAULT_WINDOWS_WEB_CONTAINER);
+        }
         final String defaultWebContainer = configuration.getWebContainerOrDefault();
         final String webContainer = queryer.assureInputFromUser("webContainer",
             defaultWebContainer, getAvailableWebContainer(), null);
@@ -321,5 +328,9 @@ public class ConfigMojo extends AbstractWebAppMojo {
 
     private String getDefaultValue(String defaultValue, String fallBack) {
         return StringUtils.isNotEmpty(defaultValue) ? defaultValue : fallBack;
+    }
+
+    private boolean isJarProject(){
+        return getProject().getPackaging().equalsIgnoreCase("jar");
     }
 }


### PR DESCRIPTION
Fix hint for `webapp:config`, including
1. Use display name in java version selection(Java 8, Java 11).
![image](https://user-images.githubusercontent.com/12445236/59660986-6aabfe00-91dc-11e9-87fb-c26681a887dd.png)

2. Select Java SE runtime directly if the `<packing>` of project is `jar`.(For windows, use tomcat 8.5 as the default web container as there is no Java SE web container for windows app service), and remove Java SE runtime if the `<packaging>` is not `jar`.
![image](https://user-images.githubusercontent.com/12445236/59661063-9202cb00-91dc-11e9-9bf3-e9c092df9ec4.png)


For issue #667 ,