### PR TITLE
Catch parser's exception when azure-webapp:config

### DIFF
--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
@@ -24,6 +24,8 @@ import com.microsoft.azure.maven.webapp.parser.ConfigurationParser;
 import com.microsoft.azure.maven.webapp.parser.V1ConfigurationParser;
 import com.microsoft.azure.maven.webapp.parser.V2ConfigurationParser;
 import com.microsoft.azure.maven.webapp.utils.WebAppUtils;
+import com.microsoft.azure.maven.webapp.validator.V1ConfigurationValidator;
+import com.microsoft.azure.maven.webapp.validator.V2ConfigurationValidator;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -353,9 +355,9 @@ public abstract class AbstractWebAppMojo extends AbstractAppServiceMojo {
 
         switch (schemaVersion.toLowerCase(Locale.ENGLISH)) {
             case "v1":
-                return new V1ConfigurationParser(this);
+                return new V1ConfigurationParser(this, new V1ConfigurationValidator(this));
             case "v2":
-                return new V2ConfigurationParser(this);
+                return new V2ConfigurationParser(this, new V2ConfigurationValidator(this));
             default:
                 throw new MojoExecutionException(SchemaVersion.UNKNOWN_SCHEMA_VERSION);
         }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
@@ -241,7 +241,7 @@ public abstract class AbstractWebAppMojo extends AbstractAppServiceMojo {
     }
 
     public String getAppName() {
-        return appName;
+        return appName == null ? "" : appName;
     }
 
     public DeploymentSlotSetting getDeploymentSlotSetting() {

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
@@ -35,8 +35,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static com.microsoft.azure.maven.webapp.validator.ConfigurationValidator.APP_NAME_PATTERN;
-import static com.microsoft.azure.maven.webapp.validator.ConfigurationValidator.RESOURCE_GROUP_PATTERN;
+import static com.microsoft.azure.maven.webapp.validator.AbstractConfigurationValidator.APP_NAME_PATTERN;
+import static com.microsoft.azure.maven.webapp.validator.AbstractConfigurationValidator.RESOURCE_GROUP_PATTERN;
 
 /**
  * Init or edit the configuration of azure webapp maven plugin.

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
@@ -21,6 +21,7 @@ import com.microsoft.azure.maven.webapp.configuration.SchemaVersion;
 import com.microsoft.azure.maven.webapp.handlers.WebAppPomHandler;
 import com.microsoft.azure.maven.webapp.parser.V2NoValidationConfigurationParser;
 import com.microsoft.azure.maven.webapp.utils.RuntimeStackUtils;
+import com.microsoft.azure.maven.webapp.validator.V2ConfigurationValidator;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -33,6 +34,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static com.microsoft.azure.maven.webapp.validator.ConfigurationValidator.APP_NAME_PATTERN;
+import static com.microsoft.azure.maven.webapp.validator.ConfigurationValidator.RESOURCE_GROUP_PATTERN;
 
 /**
  * Init or edit the configuration of azure webapp maven plugin.
@@ -60,7 +64,7 @@ public class ConfigMojo extends AbstractWebAppMojo {
 
         try {
             final WebAppConfiguration configuration = pomHandler.getConfiguration() == null ? null :
-                getWebAppConfiguration();
+                    getWebAppConfigurationWithoutValidation();
             if (isV1Configuration(configuration)) {
                 warning(CONFIG_ONLY_SUPPORT_V2);
             } else {
@@ -169,15 +173,16 @@ public class ConfigMojo extends AbstractWebAppMojo {
         throws MojoFailureException, MojoExecutionException {
         final WebAppConfiguration.Builder builder = configuration.getBuilderFromConfiguration();
 
-        final String defaultAppName = getDefaultValue(configuration.appName, getProject().getArtifactId());
+        final String defaultAppName =
+                getDefaultValue(configuration.appName, getProject().getArtifactId(), APP_NAME_PATTERN);
         final String appName = queryer.assureInputFromUser("appName", defaultAppName,
-            NOT_EMPTY_REGEX, null, null);
+                APP_NAME_PATTERN, null, null);
 
         final String defaultResourceGroup = getDefaultValue(configuration.resourceGroup,
-            String.format("%s-rg", appName));
+                String.format("%s-rg", appName), RESOURCE_GROUP_PATTERN);
         final String resourceGroup = queryer.assureInputFromUser("resourceGroup",
             defaultResourceGroup,
-            NOT_EMPTY_REGEX, null, null);
+                RESOURCE_GROUP_PATTERN, null, null);
 
         final String defaultRegion = configuration.getRegionOrDefault();
         final String region = queryer.assureInputFromUser("region", defaultRegion, NOT_EMPTY_REGEX,
@@ -331,12 +336,15 @@ public class ConfigMojo extends AbstractWebAppMojo {
         return StringUtils.isNotEmpty(defaultValue) ? defaultValue : fallBack;
     }
 
+    private String getDefaultValue(String defaultValue, String fallBack, String pattern) {
+        return StringUtils.isNotEmpty(defaultValue) && defaultValue.matches(pattern) ? defaultValue : fallBack;
+    }
+
     private boolean isJarProject(){
         return getProject().getPackaging().equalsIgnoreCase("jar");
     }
 
-    @Override
-    public WebAppConfiguration getWebAppConfiguration() throws MojoExecutionException {
-        return new V2NoValidationConfigurationParser(this).getWebAppConfiguration();
+    public WebAppConfiguration getWebAppConfigurationWithoutValidation() throws MojoExecutionException {
+        return new V2NoValidationConfigurationParser(this, new V2ConfigurationValidator(this)).getWebAppConfiguration();
     }
 }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
@@ -19,6 +19,7 @@ import com.microsoft.azure.maven.webapp.configuration.DeploymentSlotSetting;
 import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.configuration.SchemaVersion;
 import com.microsoft.azure.maven.webapp.handlers.WebAppPomHandler;
+import com.microsoft.azure.maven.webapp.parser.V2NoValidationConfigurationParser;
 import com.microsoft.azure.maven.webapp.utils.RuntimeStackUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -332,5 +333,10 @@ public class ConfigMojo extends AbstractWebAppMojo {
 
     private boolean isJarProject(){
         return getProject().getPackaging().equalsIgnoreCase("jar");
+    }
+
+    @Override
+    public WebAppConfiguration getWebAppConfiguration() throws MojoExecutionException {
+        return new V2NoValidationConfigurationParser(this).getWebAppConfiguration();
     }
 }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/configuration/RuntimeSetting.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/configuration/RuntimeSetting.java
@@ -40,20 +40,20 @@ public class RuntimeSetting {
     }
 
     public JavaVersion getJavaVersion() {
-        return StringUtils.isEmpty(javaVersion) ? null : JavaVersion.fromString(javaVersion);
+        return (StringUtils.isEmpty(javaVersion) || !checkJavaVersion(javaVersion)) ?
+                null : JavaVersion.fromString(javaVersion);
     }
 
-    public RuntimeStack getLinuxRuntime() throws MojoExecutionException {
+    public RuntimeStack getLinuxRuntime() {
         // todo: add unit tests
         final RuntimeStack result = RuntimeStackUtils.getRuntimeStack(javaVersion, webContainer);
-        if (result == null) {
-            throw new MojoExecutionException(String.format("Unsupported values for linux runtime, please refer %s " +
-                "more information", RUNTIME_CONFIG_REFERENCE));
-        }
         return result;
     }
 
     public WebContainer getWebContainer() {
+        if (!checkWebContainer(webContainer)) {
+            return null;
+        }
         if (StringUtils.isEmpty(webContainer)) {
             return WebContainer.TOMCAT_8_5_NEWEST;
         }
@@ -76,5 +76,23 @@ public class RuntimeSetting {
         return StringUtils.isEmpty(this.os) && StringUtils.isEmpty(this.javaVersion) &&
             StringUtils.isEmpty(this.webContainer) && StringUtils.isEmpty(image) &&
             StringUtils.isEmpty(this.serverId) && StringUtils.isEmpty(this.registryUrl);
+    }
+
+    protected boolean checkJavaVersion(String value) {
+        for (final JavaVersion javaVersion : JavaVersion.values()) {
+            if (javaVersion.toString().equals(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected boolean checkWebContainer(String value) {
+        for (final WebContainer webContainer : WebContainer.values()) {
+            if (webContainer.toString().equals(value)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/configuration/RuntimeSetting.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/configuration/RuntimeSetting.java
@@ -46,8 +46,7 @@ public class RuntimeSetting {
 
     public RuntimeStack getLinuxRuntime() {
         // todo: add unit tests
-        final RuntimeStack result = RuntimeStackUtils.getRuntimeStack(javaVersion, webContainer);
-        return result;
+        return RuntimeStackUtils.getRuntimeStack(javaVersion, webContainer);
     }
 
     public WebContainer getWebContainer() {

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/ConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/ConfigurationParser.java
@@ -13,7 +13,7 @@ import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.WebAppConfiguration;
 import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
-import com.microsoft.azure.maven.webapp.validator.ConfigurationValidator;
+import com.microsoft.azure.maven.webapp.validator.AbstractConfigurationValidator;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
 
@@ -21,9 +21,9 @@ import java.util.List;
 
 public abstract class ConfigurationParser {
     protected final AbstractWebAppMojo mojo;
-    protected final ConfigurationValidator validator;
+    protected final AbstractConfigurationValidator validator;
 
-    protected ConfigurationParser(final AbstractWebAppMojo mojo, final ConfigurationValidator validator) {
+    protected ConfigurationParser(final AbstractWebAppMojo mojo, final AbstractConfigurationValidator validator) {
         this.mojo = mojo;
         this.validator = validator;
     }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/ConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/ConfigurationParser.java
@@ -13,39 +13,28 @@ import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.WebAppConfiguration;
 import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.webapp.validator.ConfigurationValidator;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.codehaus.plexus.util.StringUtils;
+
 import java.util.List;
 
 public abstract class ConfigurationParser {
     protected final AbstractWebAppMojo mojo;
+    protected final ConfigurationValidator validator;
 
-    protected ConfigurationParser(final AbstractWebAppMojo mojo) {
+    protected ConfigurationParser(final AbstractWebAppMojo mojo, final ConfigurationValidator validator) {
         this.mojo = mojo;
+        this.validator = validator;
     }
 
     protected String getAppName() throws MojoExecutionException {
-        final String appName = mojo.getAppName();
-        if (StringUtils.isEmpty(appName)) {
-            throw new MojoExecutionException("Please config the <appName> in pom.xml.");
-        }
-        if (appName.startsWith("-") || !appName.matches("[a-zA-Z0-9\\-]{2,60}")) {
-            throw new MojoExecutionException("The <appName> only allow alphanumeric characters, " +
-                "hyphens and cannot start or end in a hyphen.");
-        }
+        validate(validator.validateAppName());
         return mojo.getAppName();
     }
 
     protected String getResourceGroup() throws MojoExecutionException {
-        final String resourceGroupName = mojo.getResourceGroup();
-        if (StringUtils.isEmpty(resourceGroupName)) {
-            throw new MojoExecutionException("Please config the <resourceGroup> in pom.xml.");
-        }
-        if (resourceGroupName.endsWith(".") || !resourceGroupName.matches("[a-zA-Z0-9\\.\\_\\-\\(\\)]{1,90}")) {
-            throw new MojoExecutionException("The <resourceGroup> only allow alphanumeric characters, periods, " +
-                "underscores, hyphens and parenthesis and cannot end in a period.");
-        }
+        validate(validator.validateResourceGroup());
         return mojo.getResourceGroup();
     }
 
@@ -68,6 +57,12 @@ public abstract class ConfigurationParser {
     protected abstract WebContainer getWebContainer() throws MojoExecutionException;
 
     protected abstract List<Resource> getResources() throws MojoExecutionException;
+
+    protected void validate(String errorMessage) throws MojoExecutionException {
+        if (errorMessage != null) {
+            throw new MojoExecutionException(errorMessage);
+        }
+    }
 
     public WebAppConfiguration getWebAppConfiguration() throws MojoExecutionException {
         WebAppConfiguration.Builder builder = new WebAppConfiguration.Builder();
@@ -98,7 +93,7 @@ public abstract class ConfigurationParser {
             .servicePlanName(mojo.getAppServicePlanName())
             .servicePlanResourceGroup(mojo.getAppServicePlanResourceGroup())
             .deploymentSlotSetting(mojo.getDeploymentSlotSetting())
-            .os(getOs())
+            .os(os)
             .mavenSettings(mojo.getSettings())
             .resources(getResources())
             .stagingDirectoryPath(mojo.getDeploymentStagingDirectoryPath())

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V1ConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V1ConfigurationParser.java
@@ -14,7 +14,7 @@ import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.configuration.ContainerSetting;
 import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.utils.RuntimeStackUtils;
-import com.microsoft.azure.maven.webapp.validator.ConfigurationValidator;
+import com.microsoft.azure.maven.webapp.validator.AbstractConfigurationValidator;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.util.StringUtils;
@@ -27,7 +27,7 @@ public class V1ConfigurationParser extends ConfigurationParser {
     private static final String RUNTIME_NOT_EXIST = "The configuration of <linuxRuntime> in pom.xml is not correct. " +
         "Please refer https://aka.ms/maven_webapp_runtime_v1 for more information";
 
-    public V1ConfigurationParser(AbstractWebAppMojo mojo, ConfigurationValidator validator) {
+    public V1ConfigurationParser(AbstractWebAppMojo mojo, AbstractConfigurationValidator validator) {
         super(mojo, validator);
     }
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V1ConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V1ConfigurationParser.java
@@ -14,26 +14,26 @@ import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.configuration.ContainerSetting;
 import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.utils.RuntimeStackUtils;
+import com.microsoft.azure.maven.webapp.validator.ConfigurationValidator;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.util.StringUtils;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class V1ConfigurationParser extends ConfigurationParser {
-    private static final String RUNTIME_CONFIG_CONFLICT = "Conflict settings found. <javaVersion>, <linuxRuntime>" +
-        "and <containerSettings> should not be set at the same time.";
+
     private static final String RUNTIME_NOT_EXIST = "The configuration of <linuxRuntime> in pom.xml is not correct. " +
         "Please refer https://aka.ms/maven_webapp_runtime_v1 for more information";
 
-    public V1ConfigurationParser(AbstractWebAppMojo mojo) {
-        super(mojo);
+    public V1ConfigurationParser(AbstractWebAppMojo mojo, ConfigurationValidator validator) {
+        super(mojo, validator);
     }
 
     @Override
     public OperatingSystemEnum getOs() throws MojoExecutionException {
+        validate(validator.validateOs());
         final String linuxRuntime = mojo.getLinuxRuntime();
         final JavaVersion javaVersion = mojo.getJavaVersion();
         final ContainerSetting containerSetting = mojo.getContainerSettings();
@@ -49,29 +49,21 @@ public class V1ConfigurationParser extends ConfigurationParser {
         if (!isContainerSettingEmpty) {
             osList.add(OperatingSystemEnum.Docker);
         }
-
-        if (osList.size() > 1) {
-            throw new MojoExecutionException(RUNTIME_CONFIG_CONFLICT);
-        }
         return osList.size() > 0 ? osList.get(0) : null;
     }
 
     @Override
     protected Region getRegion() throws MojoExecutionException {
+        validate(validator.validateRegion());
         if (StringUtils.isEmpty(mojo.getRegion())) {
             return Region.EUROPE_WEST;
-        }
-        if (!Arrays.asList(Region.values()).contains(Region.fromName(mojo.getRegion()))) {
-            throw new MojoExecutionException("The value of <region> is not correct, please correct it in pom.xml.");
         }
         return Region.fromName(mojo.getRegion());
     }
 
     @Override
     public RuntimeStack getRuntimeStack() throws MojoExecutionException {
-        if (mojo.getLinuxRuntime() == null) {
-            throw new MojoExecutionException("Please configure the <linuxRuntime> in pom.xml.");
-        }
+        validate(validator.validateRuntimeStack());
         final String linuxRuntime = mojo.getLinuxRuntime();
         // JavaSE runtime
         final RuntimeStack javaSERuntimeStack = RuntimeStackUtils.getRuntimeStack(linuxRuntime);
@@ -90,13 +82,8 @@ public class V1ConfigurationParser extends ConfigurationParser {
 
     @Override
     public String getImage() throws MojoExecutionException {
+        validate(validator.validateImage());
         final ContainerSetting containerSetting = mojo.getContainerSettings();
-        if (containerSetting == null) {
-            throw new MojoExecutionException("Please config the <containerSettings> in pom.xml.");
-        }
-        if (StringUtils.isEmpty(containerSetting.getImageName())) {
-            throw new MojoExecutionException("Please config the <imageName> of <containerSettings> in pom.xml.");
-        }
         return containerSetting.getImageName();
     }
 
@@ -125,17 +112,13 @@ public class V1ConfigurationParser extends ConfigurationParser {
 
     @Override
     public WebContainer getWebContainer() throws MojoExecutionException {
-        if (mojo.getJavaWebContainer() == null) {
-            throw new MojoExecutionException("The configuration of <javaWebContainer> in pom.xml is not correct.");
-        }
+        validate(validator.validateWebContainer());
         return mojo.getJavaWebContainer();
     }
 
     @Override
     public JavaVersion getJavaVersion() throws MojoExecutionException {
-        if (mojo.getJavaVersion() == null) {
-            throw new MojoExecutionException("The configuration of <javaVersion> in pom.xml is not correct.");
-        }
+        validate(validator.validateJavaVersion());
         return mojo.getJavaVersion();
     }
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParser.java
@@ -14,7 +14,7 @@ import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.configuration.Deployment;
 import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.configuration.RuntimeSetting;
-import com.microsoft.azure.maven.webapp.validator.ConfigurationValidator;
+import com.microsoft.azure.maven.webapp.validator.AbstractConfigurationValidator;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
 
@@ -23,7 +23,7 @@ import java.util.Locale;
 
 public class V2ConfigurationParser extends ConfigurationParser {
 
-    public V2ConfigurationParser(AbstractWebAppMojo mojo, ConfigurationValidator validator) {
+    public V2ConfigurationParser(AbstractWebAppMojo mojo, AbstractConfigurationValidator validator) {
         super(mojo, validator);
     }
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParser.java
@@ -14,25 +14,26 @@ import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.configuration.Deployment;
 import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.configuration.RuntimeSetting;
+import com.microsoft.azure.maven.webapp.validator.ConfigurationValidator;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.codehaus.plexus.util.StringUtils;
+
 import java.util.List;
 import java.util.Locale;
 
 public class V2ConfigurationParser extends ConfigurationParser {
-    public V2ConfigurationParser(AbstractWebAppMojo mojo) {
-        super(mojo);
+
+    public V2ConfigurationParser(AbstractWebAppMojo mojo, ConfigurationValidator validator) {
+        super(mojo, validator);
     }
 
     @Override
     protected OperatingSystemEnum getOs() throws MojoExecutionException {
+        validate(validator.validateOs());
         final RuntimeSetting runtime = mojo.getRuntime();
         final String os = runtime.getOs();
         if (runtime.isEmpty()) {
             return null;
-        } else if (StringUtils.isEmpty(os)) {
-            throw new MojoExecutionException("Pleas configure the <os> of <runtime> in pom.xml.");
         }
         switch (os.toLowerCase(Locale.ENGLISH)) {
             case "windows":
@@ -42,22 +43,20 @@ public class V2ConfigurationParser extends ConfigurationParser {
             case "docker":
                 return OperatingSystemEnum.Docker;
             default:
-                throw new MojoExecutionException("The value of <os> is not correct, supported values are: windows, " +
-                    "linux and docker.");
+                return null;
         }
     }
 
     @Override
     protected Region getRegion() throws MojoExecutionException {
+        validate(validator.validateRegion());
         final String region = mojo.getRegion();
-        if (!StringUtils.isEmpty(region) && Region.findByLabelOrName(region) == null) {
-            throw new MojoExecutionException("The value of <region> is not supported, please correct it in pom.xml.");
-        }
         return Region.fromName(region);
     }
 
     @Override
     protected RuntimeStack getRuntimeStack() throws MojoExecutionException {
+        validate(validator.validateRuntimeStack());
         final RuntimeSetting runtime = mojo.getRuntime();
         if (runtime == null || runtime.isEmpty()) {
             return null;
@@ -67,13 +66,8 @@ public class V2ConfigurationParser extends ConfigurationParser {
 
     @Override
     protected String getImage() throws MojoExecutionException {
+        validate(validator.validateImage());
         final RuntimeSetting runtime = mojo.getRuntime();
-        if (runtime == null) {
-            throw new MojoExecutionException("Please configure the <runtime> in pom.xml.");
-        }
-        if (StringUtils.isEmpty(runtime.getImage())) {
-            throw new MojoExecutionException("Please config the <image> of <runtime> in pom.xml.");
-        }
         return runtime.getImage();
     }
 
@@ -102,22 +96,15 @@ public class V2ConfigurationParser extends ConfigurationParser {
 
     @Override
     protected WebContainer getWebContainer() throws MojoExecutionException {
+        validate(validator.validateWebContainer());
         final RuntimeSetting runtime = mojo.getRuntime();
-        if (runtime == null) {
-            throw new MojoExecutionException("Pleas config the <runtime> in pom.xml.");
-        }
         return runtime.getWebContainer();
     }
 
     @Override
     protected JavaVersion getJavaVersion() throws MojoExecutionException {
+        validate(validator.validateJavaVersion());
         final RuntimeSetting runtime = mojo.getRuntime();
-        if (runtime == null) {
-            throw new MojoExecutionException("Pleas config the <runtime> in pom.xml.");
-        }
-        if (runtime.getJavaVersion() == null) {
-            throw new MojoExecutionException("The configuration <javaVersion> in pom.xml is not correct.");
-        }
         return runtime.getJavaVersion();
     }
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2NoValidationConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2NoValidationConfigurationParser.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.maven.webapp.parser;
+
+import com.microsoft.azure.management.appservice.JavaVersion;
+import com.microsoft.azure.management.appservice.RuntimeStack;
+import com.microsoft.azure.management.appservice.WebContainer;
+import com.microsoft.azure.management.resources.fluentcore.arm.Region;
+import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
+import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import org.apache.maven.plugin.MojoExecutionException;
+
+public class V2NoValidationConfigurationParser extends V2ConfigurationParser {
+
+    public V2NoValidationConfigurationParser(AbstractWebAppMojo mojo) {
+        super(mojo);
+    }
+
+    @Override
+    protected String getAppName() {
+        try {
+            return super.getAppName();
+        } catch (MojoExecutionException e) {
+            return null;
+        }
+    }
+
+    @Override
+    protected String getResourceGroup() {
+        try {
+            return super.getResourceGroup();
+        } catch (MojoExecutionException e) {
+            return null;
+        }
+    }
+
+    @Override
+    protected OperatingSystemEnum getOs() {
+        try {
+            return super.getOs();
+        } catch (MojoExecutionException e) {
+            return null;
+        }
+    }
+
+    @Override
+    protected Region getRegion() {
+        try {
+            return super.getRegion();
+        } catch (MojoExecutionException e) {
+            return null;
+        }
+    }
+
+    @Override
+    protected RuntimeStack getRuntimeStack() {
+        try {
+            return super.getRuntimeStack();
+        } catch (MojoExecutionException e) {
+            return null;
+        }
+    }
+
+    @Override
+    protected String getImage() {
+        try {
+            return super.getImage();
+        } catch (MojoExecutionException e) {
+            return null;
+        }
+    }
+
+    @Override
+    protected WebContainer getWebContainer() {
+        try {
+            return super.getWebContainer();
+        } catch (MojoExecutionException e) {
+            return null;
+        }
+    }
+
+    @Override
+    protected JavaVersion getJavaVersion() {
+        try {
+            return super.getJavaVersion();
+        } catch (MojoExecutionException e) {
+            return null;
+        }
+    }
+}

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2NoValidationConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2NoValidationConfigurationParser.java
@@ -12,12 +12,12 @@ import com.microsoft.azure.management.appservice.WebContainer;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
-import com.microsoft.azure.maven.webapp.validator.ConfigurationValidator;
+import com.microsoft.azure.maven.webapp.validator.AbstractConfigurationValidator;
 import org.apache.maven.plugin.MojoExecutionException;
 
 public class V2NoValidationConfigurationParser extends V2ConfigurationParser {
 
-    public V2NoValidationConfigurationParser(AbstractWebAppMojo mojo, ConfigurationValidator validator) {
+    public V2NoValidationConfigurationParser(AbstractWebAppMojo mojo, AbstractConfigurationValidator validator) {
         super(mojo, validator);
     }
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2NoValidationConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2NoValidationConfigurationParser.java
@@ -12,83 +12,60 @@ import com.microsoft.azure.management.appservice.WebContainer;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.webapp.validator.ConfigurationValidator;
 import org.apache.maven.plugin.MojoExecutionException;
 
 public class V2NoValidationConfigurationParser extends V2ConfigurationParser {
 
-    public V2NoValidationConfigurationParser(AbstractWebAppMojo mojo) {
-        super(mojo);
+    public V2NoValidationConfigurationParser(AbstractWebAppMojo mojo, ConfigurationValidator validator) {
+        super(mojo, validator);
     }
 
     @Override
-    protected String getAppName() {
-        try {
-            return super.getAppName();
-        } catch (MojoExecutionException e) {
-            return null;
-        }
+    protected String getAppName() throws MojoExecutionException {
+        return validateConfiguration(validator.validateAppName()) ? super.getAppName() : mojo.getAppName();
     }
 
     @Override
-    protected String getResourceGroup() {
-        try {
-            return super.getResourceGroup();
-        } catch (MojoExecutionException e) {
-            return null;
-        }
+    protected String getResourceGroup() throws MojoExecutionException {
+        return validateConfiguration(validator.validateResourceGroup()) ?
+                super.getResourceGroup() : mojo.getResourceGroup();
     }
 
     @Override
-    protected OperatingSystemEnum getOs() {
-        try {
-            return super.getOs();
-        } catch (MojoExecutionException e) {
-            return null;
-        }
+    protected OperatingSystemEnum getOs() throws MojoExecutionException {
+        return validateConfiguration(validator.validateOs()) ? super.getOs() : null;
     }
 
     @Override
-    protected Region getRegion() {
-        try {
-            return super.getRegion();
-        } catch (MojoExecutionException e) {
-            return null;
-        }
+    protected Region getRegion() throws MojoExecutionException {
+        return validateConfiguration(validator.validateRegion()) ? super.getRegion() : null;
     }
 
     @Override
-    protected RuntimeStack getRuntimeStack() {
-        try {
-            return super.getRuntimeStack();
-        } catch (MojoExecutionException e) {
-            return null;
-        }
+    protected RuntimeStack getRuntimeStack() throws MojoExecutionException {
+        return validateConfiguration(validator.validateRuntimeStack()) ? super.getRuntimeStack() : null;
     }
 
     @Override
-    protected String getImage() {
-        try {
-            return super.getImage();
-        } catch (MojoExecutionException e) {
-            return null;
-        }
+    protected String getImage() throws MojoExecutionException {
+        return validateConfiguration(validator.validateImage()) ? super.getImage() : null;
     }
 
     @Override
-    protected WebContainer getWebContainer() {
-        try {
-            return super.getWebContainer();
-        } catch (MojoExecutionException e) {
-            return null;
-        }
+    protected JavaVersion getJavaVersion() throws MojoExecutionException {
+        return validateConfiguration(validator.validateJavaVersion()) ? super.getJavaVersion() : null;
     }
 
     @Override
-    protected JavaVersion getJavaVersion() {
-        try {
-            return super.getJavaVersion();
-        } catch (MojoExecutionException e) {
-            return null;
+    protected WebContainer getWebContainer() throws MojoExecutionException {
+        return validateConfiguration(validator.validateWebContainer()) ? super.getWebContainer() : null;
+    }
+
+    protected boolean validateConfiguration(String errorMessage) {
+        if (errorMessage != null) {
+            mojo.getLog().warn(errorMessage);
         }
+        return errorMessage == null;
     }
 }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/serializer/V2ConfigurationSerializer.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/serializer/V2ConfigurationSerializer.java
@@ -82,16 +82,20 @@ public class V2ConfigurationSerializer extends ConfigurationSerializer {
                                         Element configurationElement) {
         final String oldOS = oldConfigs.getOs() == null ? null : oldConfigs.getOs().toString();
         createOrUpdateAttribute("os", "linux", oldOS, configurationElement);
-        final String oldJavaVersion = oldConfigs.getJavaVersion() == null ? null :
-            oldConfigs.getJavaVersion().toString();
-        createOrUpdateAttribute("javaVersion",
-            RuntimeStackUtils.getJavaVersionFromRuntimeStack(newConfigs.getRuntimeStack()), oldJavaVersion,
-            configurationElement);
-        final String oldWebContainer = oldConfigs.getRuntimeStack() == null ? null :
-            RuntimeStackUtils.getWebContainerFromRuntimeStack(oldConfigs.getRuntimeStack());
-        createOrUpdateAttribute("webContainer",
-            RuntimeStackUtils.getWebContainerFromRuntimeStack(newConfigs.getRuntimeStack())
-            , oldWebContainer, configurationElement);
+        if (newConfigs.getJavaVersion() != null) {
+            final String oldJavaVersion = oldConfigs.getJavaVersion() == null ? null :
+                    oldConfigs.getJavaVersion().toString();
+            createOrUpdateAttribute("javaVersion",
+                    RuntimeStackUtils.getJavaVersionFromRuntimeStack(newConfigs.getRuntimeStack()), oldJavaVersion,
+                    configurationElement);
+        }
+        if (newConfigs.getWebContainer() != null) {
+            final String oldWebContainer = oldConfigs.getRuntimeStack() == null ? null :
+                    RuntimeStackUtils.getWebContainerFromRuntimeStack(oldConfigs.getRuntimeStack());
+            createOrUpdateAttribute("webContainer",
+                    RuntimeStackUtils.getWebContainerFromRuntimeStack(newConfigs.getRuntimeStack())
+                    , oldWebContainer, configurationElement);
+        }
     }
 
     private void updateWindowsRunTimeNode(WebAppConfiguration newConfigs, WebAppConfiguration oldConfigs,
@@ -99,14 +103,18 @@ public class V2ConfigurationSerializer extends ConfigurationSerializer {
 
         final String oldOS = oldConfigs.getOs() == null ? null : oldConfigs.getOs().toString();
         createOrUpdateAttribute("os", "windows", oldOS, configurationElement);
-        final String oldJavaVersion = oldConfigs.getJavaVersion() == null ? null :
-            oldConfigs.getJavaVersion().toString();
-        createOrUpdateAttribute("javaVersion", newConfigs.getJavaVersion().toString(),
-            oldJavaVersion, configurationElement);
-        final String oldWebContainer = oldConfigs.getWebContainer() == null ? null :
-            oldConfigs.getWebContainer().toString();
-        createOrUpdateAttribute("webContainer", newConfigs.getWebContainer().toString(), oldWebContainer,
-            configurationElement);
+        if (newConfigs.getJavaVersion() != null) {
+            final String oldJavaVersion = oldConfigs.getJavaVersion() == null ? null :
+                    oldConfigs.getJavaVersion().toString();
+            createOrUpdateAttribute("javaVersion", newConfigs.getJavaVersion().toString(),
+                    oldJavaVersion, configurationElement);
+        }
+        if (newConfigs.getWebContainer() != null) {
+            final String oldWebContainer = oldConfigs.getWebContainer() == null ? null :
+                    oldConfigs.getWebContainer().toString();
+            createOrUpdateAttribute("webContainer", newConfigs.getWebContainer().toString(), oldWebContainer,
+                    configurationElement);
+        }
     }
 
     private void updateDockerRunTimeNode(WebAppConfiguration newConfigs, WebAppConfiguration oldConfigs,

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/validator/AbstractConfigurationValidator.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/validator/AbstractConfigurationValidator.java
@@ -9,14 +9,14 @@ package com.microsoft.azure.maven.webapp.validator;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import org.codehaus.plexus.util.StringUtils;
 
-public abstract class ConfigurationValidator {
+public abstract class AbstractConfigurationValidator {
 
     public static final String APP_NAME_PATTERN = "[a-zA-Z0-9\\-]{2,60}";
     public static final String RESOURCE_GROUP_PATTERN = "[a-zA-Z0-9\\.\\_\\-\\(\\)]{1,90}";
 
     protected final AbstractWebAppMojo mojo;
 
-    public ConfigurationValidator(AbstractWebAppMojo mojo){
+    public AbstractConfigurationValidator(AbstractWebAppMojo mojo){
         this.mojo = mojo;
     }
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/validator/ConfigurationValidator.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/validator/ConfigurationValidator.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.maven.webapp.validator;
+
+import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
+import org.codehaus.plexus.util.StringUtils;
+
+public abstract class ConfigurationValidator {
+
+    public static final String APP_NAME_PATTERN = "[a-zA-Z0-9\\-]{2,60}";
+    public static final String RESOURCE_GROUP_PATTERN = "[a-zA-Z0-9\\.\\_\\-\\(\\)]{1,90}";
+
+    protected final AbstractWebAppMojo mojo;
+
+    public ConfigurationValidator(AbstractWebAppMojo mojo){
+        this.mojo = mojo;
+    }
+
+    public String validateAppName() {
+        final String appName = mojo.getAppName();
+        if (StringUtils.isEmpty(appName)) {
+            return "Please config the <appName> in pom.xml.";
+        }
+        if (appName.startsWith("-") || !appName.matches(APP_NAME_PATTERN)) {
+            return "The <appName> only allow alphanumeric characters, " +
+                    "hyphens and cannot start or end in a hyphen.";
+        }
+        return null;
+    }
+
+    public String validateResourceGroup(){
+        final String resourceGroupName = mojo.getResourceGroup();
+        if (StringUtils.isEmpty(resourceGroupName)) {
+            return "Please config the <resourceGroup> in pom.xml.";
+        }
+        if (resourceGroupName.endsWith(".") || !resourceGroupName.matches(RESOURCE_GROUP_PATTERN)) {
+            return "The <resourceGroup> only allow alphanumeric characters, periods, underscores," +
+                    " hyphens and parenthesis and cannot end in a period.";
+        }
+        return null;
+    }
+
+    public abstract String validateRegion();
+
+    public abstract String validateOs();
+
+    public abstract String validateRuntimeStack();
+
+    public abstract String validateImage();
+
+    public abstract String validateJavaVersion();
+
+    public abstract String validateWebContainer();
+}

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/validator/V1ConfigurationValidator.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/validator/V1ConfigurationValidator.java
@@ -14,7 +14,7 @@ import org.codehaus.plexus.util.StringUtils;
 
 import java.util.Arrays;
 
-public class V1ConfigurationValidator extends ConfigurationValidator{
+public class V1ConfigurationValidator extends AbstractConfigurationValidator {
 
     private static final String RUNTIME_CONFIG_CONFLICT = "Conflict settings found. <javaVersion>, <linuxRuntime>" +
             "and <containerSettings> should not be set at the same time.";

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/validator/V1ConfigurationValidator.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/validator/V1ConfigurationValidator.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.maven.webapp.validator;
+
+import com.microsoft.azure.management.appservice.JavaVersion;
+import com.microsoft.azure.management.resources.fluentcore.arm.Region;
+import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
+import com.microsoft.azure.maven.webapp.configuration.ContainerSetting;
+import org.codehaus.plexus.util.StringUtils;
+
+import java.util.Arrays;
+
+public class V1ConfigurationValidator extends ConfigurationValidator{
+
+    private static final String RUNTIME_CONFIG_CONFLICT = "Conflict settings found. <javaVersion>, <linuxRuntime>" +
+            "and <containerSettings> should not be set at the same time.";
+
+    public V1ConfigurationValidator(AbstractWebAppMojo mojo) {
+        super(mojo);
+    }
+
+    @Override
+    public String validateRegion() {
+        if (StringUtils.isNotEmpty(mojo.getRegion()) &&
+                !Arrays.asList(Region.values()).contains(Region.fromName(mojo.getRegion()))) {
+            return "The value of <region> is not correct, please correct it in pom.xml.";
+        }
+        return null;
+    }
+
+    @Override
+    public String validateOs() {
+        final String linuxRuntime = mojo.getLinuxRuntime();
+        final JavaVersion javaVersion = mojo.getJavaVersion();
+        final ContainerSetting containerSetting = mojo.getContainerSettings();
+        final boolean isContainerSettingEmpty = containerSetting == null || containerSetting.isEmpty();
+        int osCount = 0;
+        if (javaVersion != null) {
+            osCount++;
+        }
+        if (linuxRuntime != null) {
+            osCount++;
+        }
+        if (!isContainerSettingEmpty) {
+            osCount++;
+        }
+        if (osCount > 1) {
+            return RUNTIME_CONFIG_CONFLICT;
+        }
+        return null;
+    }
+
+    @Override
+    public String validateRuntimeStack() {
+        if (mojo.getLinuxRuntime() == null) {
+            return "Please configure the <linuxRuntime> in pom.xml.";
+        }
+        return null;
+    }
+
+    @Override
+    public String validateImage() {
+        final ContainerSetting containerSetting = mojo.getContainerSettings();
+        if (containerSetting == null) {
+            return "Please config the <containerSettings> in pom.xml.";
+        }
+        if (StringUtils.isEmpty(containerSetting.getImageName())) {
+            return "Please config the <imageName> of <containerSettings> in pom.xml.";
+        }
+        return null;
+    }
+
+    @Override
+    public String validateJavaVersion() {
+        if (mojo.getJavaVersion() == null) {
+            return "The configuration of <javaVersion> in pom.xml is not correct.";
+        }
+        return null;
+    }
+
+    @Override
+    public String validateWebContainer() {
+        if (mojo.getJavaWebContainer() == null) {
+            return "The configuration of <javaWebContainer> in pom.xml is not correct.";
+        }
+        return null;
+    }
+}

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/validator/V2ConfigurationValidator.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/validator/V2ConfigurationValidator.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
 
 import static com.microsoft.azure.maven.webapp.configuration.RuntimeSetting.RUNTIME_CONFIG_REFERENCE;
 
-public class V2ConfigurationValidator extends ConfigurationValidator {
+public class V2ConfigurationValidator extends AbstractConfigurationValidator {
 
     public static final String[] VALID_OS = new String[]{"windows", "linux", "docker"};
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/validator/V2ConfigurationValidator.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/validator/V2ConfigurationValidator.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.maven.webapp.validator;
+
+import com.microsoft.azure.management.appservice.JavaVersion;
+import com.microsoft.azure.management.appservice.RuntimeStack;
+import com.microsoft.azure.management.resources.fluentcore.arm.Region;
+import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
+import com.microsoft.azure.maven.webapp.configuration.RuntimeSetting;
+import org.codehaus.plexus.util.StringUtils;
+
+import java.util.Arrays;
+
+import static com.microsoft.azure.maven.webapp.configuration.RuntimeSetting.RUNTIME_CONFIG_REFERENCE;
+
+public class V2ConfigurationValidator extends ConfigurationValidator {
+
+    public static final String[] VALID_OS = new String[]{"windows", "linux", "docker"};
+
+    public V2ConfigurationValidator(AbstractWebAppMojo mojo) {
+        super(mojo);
+    }
+
+    @Override
+    public String validateRegion() {
+        final String region = mojo.getRegion();
+        if (!StringUtils.isEmpty(region) && Region.findByLabelOrName(region) == null) {
+            return "The value of <region> is not supported, please correct it in pom.xml.";
+        }
+        return null;
+    }
+
+    @Override
+    public String validateOs() {
+        final RuntimeSetting runtime = mojo.getRuntime();
+        final String os = runtime.getOs();
+        if (runtime.isEmpty()) {
+            return null;
+        } else if (StringUtils.isEmpty(os)) {
+            return "Pleas configure the <os> of <runtime> in pom.xml.";
+        }
+        if (!Arrays.asList(VALID_OS).contains(os)) {
+            return "The value of <os> is not correct, supported values are: windows, linux and docker.";
+        }
+        return null;
+    }
+
+    @Override
+    public String validateRuntimeStack() {
+        final RuntimeSetting runtime = mojo.getRuntime();
+        if (runtime == null || runtime.isEmpty()) {
+            return null;
+        }
+        final RuntimeStack result = runtime.getLinuxRuntime();
+        return result == null ? String.format("Unsupported values for linux runtime, please refer %s " +
+                "more information", RUNTIME_CONFIG_REFERENCE) : null;
+    }
+
+    @Override
+    public String validateJavaVersion() {
+        final RuntimeSetting runtime = mojo.getRuntime();
+        if (runtime == null) {
+            return "Pleas config the <runtime> in pom.xml.";
+        }
+        if (runtime.getJavaVersion() == null || !JavaVersion.values().contains(runtime.getJavaVersion())) {
+            return "The configuration <javaVersion> in pom.xml is not correct.";
+        }
+        return null;
+    }
+
+    @Override
+    public String validateWebContainer() {
+        final RuntimeSetting runtime = mojo.getRuntime();
+        if (runtime == null) {
+            return "Pleas config the <runtime> in pom.xml.";
+        }
+        if (runtime.getWebContainer() == null) {
+            return "The configuration <webContainer> in pom.xml is not correct.";
+        }
+        return null;
+    }
+
+    public String validateImage() {
+        final RuntimeSetting runtime = mojo.getRuntime();
+        if (runtime == null) {
+            return "Please configure the <runtime> in pom.xml.";
+        }
+        if (StringUtils.isEmpty(runtime.getImage())) {
+            return "Please config the <image> of <runtime> in pom.xml.";
+        }
+        return null;
+    }
+}

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/ConfigurationParserTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/ConfigurationParserTest.java
@@ -14,7 +14,7 @@ import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.WebAppConfiguration;
 import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
-import com.microsoft.azure.maven.webapp.validator.ConfigurationValidator;
+import com.microsoft.azure.maven.webapp.validator.AbstractConfigurationValidator;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -42,7 +42,7 @@ public class ConfigurationParserTest {
     protected ConfigurationParser parser;
 
     public void buildParser() {
-        parser = new ConfigurationParser(mojo, new ConfigurationValidator(mojo) {
+        parser = new ConfigurationParser(mojo, new AbstractConfigurationValidator(mojo) {
             @Override
             public String validateRegion() {
                 return null;

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/ConfigurationParserTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/ConfigurationParserTest.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.WebAppConfiguration;
 import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.webapp.validator.ConfigurationValidator;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -25,6 +26,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
+
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -40,7 +42,37 @@ public class ConfigurationParserTest {
     protected ConfigurationParser parser;
 
     public void buildParser() {
-        parser = new ConfigurationParser(mojo) {
+        parser = new ConfigurationParser(mojo, new ConfigurationValidator(mojo) {
+            @Override
+            public String validateRegion() {
+                return null;
+            }
+
+            @Override
+            public String validateOs() {
+                return null;
+            }
+
+            @Override
+            public String validateRuntimeStack() {
+                return null;
+            }
+
+            @Override
+            public String validateImage() {
+                return null;
+            }
+
+            @Override
+            public String validateJavaVersion() {
+                return null;
+            }
+
+            @Override
+            public String validateWebContainer() {
+                return null;
+            }
+        }) {
             @Override
             protected OperatingSystemEnum getOs() {
                 return null;

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/V1ConfigurationParserTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/V1ConfigurationParserTest.java
@@ -13,6 +13,7 @@ import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.configuration.ContainerSetting;
 import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.webapp.validator.V1ConfigurationValidator;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,7 +37,7 @@ public class V1ConfigurationParserTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        parser = new V1ConfigurationParser(mojo);
+        parser = new V1ConfigurationParser(mojo, new V1ConfigurationValidator(mojo));
     }
 
     @Test

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParserTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParserTest.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.configuration.Deployment;
 import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.configuration.RuntimeSetting;
+import com.microsoft.azure.maven.webapp.validator.V2ConfigurationValidator;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.Before;
@@ -37,7 +38,7 @@ public class V2ConfigurationParserTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        parser = new V2ConfigurationParser(mojo);
+        parser = new V2ConfigurationParser(mojo, new V2ConfigurationValidator(mojo));
     }
 
     @Test


### PR DESCRIPTION
Separate the parser and validator, and show warnings while `azure-webapp:config`.
![image](https://user-images.githubusercontent.com/12445236/59742548-8e387c80-92a0-11e9-886e-593f48f68201.png)
