### PR TITLE
Check project packaging before execute `azure-spring:deploy` 

### DIFF
--- a/azure-spring-maven-plugin/pom.xml
+++ b/azure-spring-maven-plugin/pom.xml
@@ -29,6 +29,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.version>3.5.0</maven.version>
+        <junit.version>4.12</junit.version>
+        <mockito.version>2.22.0</mockito.version>
+        <powermock.version>2.0.2</powermock.version>
         <azure.maven-plugin-lib.version>1.2.10-SNAPSHOT</azure.maven-plugin-lib.version>
     </properties>
 
@@ -85,21 +88,33 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-compat</artifactId>
-            <version>${maven.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.6.0</version>
             <scope>provided</scope>
         </dependency>
+        <!-- TEST -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>${maven.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/AbstractSpringMojo.java
+++ b/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/AbstractSpringMojo.java
@@ -99,6 +99,7 @@ public abstract class AbstractSpringMojo extends AbstractMojo {
             handleSuccess();
         } catch (Exception e) {
             handleException(e);
+            throw e;
         } finally {
             AppInsightHelper.INSTANCE.close();
         }

--- a/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/DeployMojo.java
+++ b/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/DeployMojo.java
@@ -27,7 +27,7 @@ import static com.microsoft.azure.maven.spring.TelemetryConstants.TELEMETRY_KEY_
 public class DeployMojo extends AbstractSpringMojo {
 
     protected static final String PROJECT_NOT_SUPPORT = "`azure-spring:deploy` does not support maven project with " +
-            "build type %s, only jar is supported";
+            "packaging %s, only jar is supported";
     protected static final String PROJECT_SKIP = "Skip pom project";
 
     @Override
@@ -55,15 +55,13 @@ public class DeployMojo extends AbstractSpringMojo {
     }
 
     protected boolean checkProjectPackaging(MavenProject project) throws MojoExecutionException {
-        final String buildType = project.getModel().getPackaging();
-        switch (buildType) {
-            case "jar":
-                return true;
-            case "pom":
-                getLog().info(PROJECT_SKIP);
-                return false;
-            default:
-                throw new MojoExecutionException(String.format(PROJECT_NOT_SUPPORT, buildType));
+        if (Utils.isJarPackagingProject(project)) {
+            return true;
+        } else if (Utils.isPomPackagingProject(project)) {
+            getLog().info(PROJECT_SKIP);
+            return false;
+        } else {
+            throw new MojoExecutionException(String.format(PROJECT_NOT_SUPPORT, project.getPackaging()));
         }
     }
 

--- a/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/utils/Utils.java
+++ b/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/utils/Utils.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.maven.spring.configuration.Deployment;
 import com.microsoft.azure.storage.file.CloudFile;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.utils.io.DirectoryScanner;
 
 import java.io.File;
@@ -33,6 +34,8 @@ public class Utils {
     private static final String DATE_FORMAT = "yyyyMMddHHmmss";
     private static final String MEMORY_REGEX = "(\\d+(\\.\\d+)?)([a-zA-Z]+)";
     private static final Pattern MEMORY_PATTERN = Pattern.compile(MEMORY_REGEX);
+    private static final String POM = "pom";
+    private static final String JAR = "jar";
 
     public static int convertSizeStringToNumber(String memory) throws MojoExecutionException {
         final Matcher matcher = MEMORY_PATTERN.matcher(memory);
@@ -103,6 +106,14 @@ public class Utils {
         } catch (Exception e) {
             throw new MojoExecutionException(e.getMessage(), e);
         }
+    }
+
+    public static boolean isPomPackagingProject(MavenProject mavenProject) {
+        return POM.equalsIgnoreCase(mavenProject.getPackaging());
+    }
+
+    public static boolean isJarPackagingProject(MavenProject mavenProject) {
+        return JAR.equalsIgnoreCase(mavenProject.getPackaging());
     }
 
     private Utils() {

--- a/azure-spring-maven-plugin/src/test/java/com/microsoft/azure/maven/spring/DeployMojoTest.java
+++ b/azure-spring-maven-plugin/src/test/java/com/microsoft/azure/maven/spring/DeployMojoTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.maven.spring;
+
+
+import org.apache.maven.model.Model;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class DeployMojoTest extends DeployMojo {
+
+    @Test
+    public void testCheckProjectPackaging() throws MojoExecutionException {
+        final MavenProject mockProject = mock(MavenProject.class);
+        final Model projectModel = mock(Model.class);
+        doReturn(projectModel).when(mockProject).getModel();
+
+        doReturn("jar").when(projectModel).getPackaging();
+        assertTrue(checkProjectPackaging(mockProject));
+
+        doReturn("pom").when(projectModel).getPackaging();
+        assertFalse(checkProjectPackaging(mockProject));
+
+        doReturn("war").when(projectModel).getPackaging();
+        try {
+            checkProjectPackaging(mockProject);
+            fail("Check project packaging should throw exception when project packing is war");
+        } catch (MojoExecutionException exception) {
+            // Should throw exception in this case
+        }
+    }
+
+}

--- a/azure-spring-maven-plugin/src/test/java/com/microsoft/azure/maven/spring/DeployMojoTest.java
+++ b/azure-spring-maven-plugin/src/test/java/com/microsoft/azure/maven/spring/DeployMojoTest.java
@@ -7,7 +7,6 @@
 package com.microsoft.azure.maven.spring;
 
 
-import org.apache.maven.model.Model;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.junit.Test;
@@ -23,16 +22,14 @@ public class DeployMojoTest extends DeployMojo {
     @Test
     public void testCheckProjectPackaging() throws MojoExecutionException {
         final MavenProject mockProject = mock(MavenProject.class);
-        final Model projectModel = mock(Model.class);
-        doReturn(projectModel).when(mockProject).getModel();
 
-        doReturn("jar").when(projectModel).getPackaging();
+        doReturn("jar").when(mockProject).getPackaging();
         assertTrue(checkProjectPackaging(mockProject));
 
-        doReturn("pom").when(projectModel).getPackaging();
+        doReturn("pom").when(mockProject).getPackaging();
         assertFalse(checkProjectPackaging(mockProject));
 
-        doReturn("war").when(projectModel).getPackaging();
+        doReturn("war").when(mockProject).getPackaging();
         try {
             checkProjectPackaging(mockProject);
             fail("Check project packaging should throw exception when project packing is war");


### PR DESCRIPTION
Check project packaging before execute `azure-spring:deploy` 

`azure-spring:deploy` will skip pom project and throw exception for other projects which packing is not `pom` or `jar`
