### PR TITLE
 Adapt to server deployment design

### DIFF
--- a/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/configuration/Deployment.java
+++ b/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/configuration/Deployment.java
@@ -17,6 +17,7 @@ public class Deployment {
     private Integer cpu;
     private Integer memoryInGB;
     private Integer instanceCount;
+    private String deploymentName;
     private String jvmOptions;
     private Map<String, String> environment;
     private List<Volume> volumes;
@@ -32,6 +33,10 @@ public class Deployment {
 
     public Integer getInstanceCount() {
         return instanceCount;
+    }
+
+    public String getDeploymentName() {
+        return deploymentName;
     }
 
     public Map<String, String> getEnvironment() {
@@ -72,6 +77,11 @@ public class Deployment {
 
     public Deployment withEnvironment(Map<String, String> environment) {
         this.environment = environment;
+        return this;
+    }
+
+    public Deployment withDeploymentName(String deploymentName) {
+        this.deploymentName = deploymentName;
         return this;
     }
 

--- a/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/spring/SpringAppClient.java
+++ b/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/spring/SpringAppClient.java
@@ -21,6 +21,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class SpringAppClient extends AbstractSpringClient {
+
+    public static final String DEFAULT_DEPLOYMENT = "Init-Deployment";
+    public static final String NO_ACTIVE_DEPLOYMENT = "No active deployment found in app %s, please specify the deployment name in configuration.";
+
     protected String appName;
 
     public static class Builder extends AbstractSpringClient.Builder<Builder> {
@@ -86,9 +90,9 @@ public class SpringAppClient extends AbstractSpringClient {
             final String activeDeploymentName = getActiveDeploymentName();
             final List<DeploymentResourceInner> deployments = getDeployments();
             if (StringUtils.isEmpty(activeDeploymentName) && deployments.size() > 0) {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException(String.format(NO_ACTIVE_DEPLOYMENT, appName));
             }
-            deployment = StringUtils.isEmpty(activeDeploymentName) ? "Init-Deployment" : activeDeploymentName;
+            deployment = StringUtils.isEmpty(activeDeploymentName) ? DEFAULT_DEPLOYMENT : activeDeploymentName;
         }
         return new SpringDeploymentClient(this, deployment);
     }

--- a/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/spring/SpringAppClient.java
+++ b/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/spring/SpringAppClient.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 public class SpringAppClient extends AbstractSpringClient {
 
-    public static final String DEFAULT_DEPLOYMENT = "Init-Deployment";
+    public static final String DEFAULT_DEPLOYMENT_NAME = "Init-Deployment";
     public static final String NO_ACTIVE_DEPLOYMENT = "No active deployment found in app %s, please specify the deployment name in configuration.";
 
     protected String appName;
@@ -84,17 +84,17 @@ public class SpringAppClient extends AbstractSpringClient {
         return getApp().properties().activeDeploymentName();
     }
 
-    public SpringDeploymentClient getDeploymentClient(String deployment) {
-        if (StringUtils.isEmpty(deployment)) {
+    public SpringDeploymentClient getDeploymentClient(String deploymentName) {
+        if (StringUtils.isEmpty(deploymentName)) {
             // When deployment name is not specified, get the active Deployment
             final String activeDeploymentName = getActiveDeploymentName();
             final List<DeploymentResourceInner> deployments = getDeployments();
             if (StringUtils.isEmpty(activeDeploymentName) && deployments.size() > 0) {
                 throw new IllegalArgumentException(String.format(NO_ACTIVE_DEPLOYMENT, appName));
             }
-            deployment = StringUtils.isEmpty(activeDeploymentName) ? DEFAULT_DEPLOYMENT : activeDeploymentName;
+            deploymentName = StringUtils.isEmpty(activeDeploymentName) ? DEFAULT_DEPLOYMENT_NAME : activeDeploymentName;
         }
-        return new SpringDeploymentClient(this, deployment);
+        return new SpringDeploymentClient(this, deploymentName);
     }
 
     public ResourceUploadDefinitionInner uploadArtifact(File artifact) throws MojoExecutionException {
@@ -114,6 +114,6 @@ public class SpringAppClient extends AbstractSpringClient {
     }
 
     public AppResourceInner getApp() {
-        return springManager.apps().inner().get(resourceGroup, clusterName, appName);
+        return springManager.apps().inner().get(resourceGroup, clusterName, appName, "true");
     }
 }

--- a/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/spring/SpringDeploymentClient.java
+++ b/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/spring/SpringDeploymentClient.java
@@ -105,6 +105,10 @@ public class SpringDeploymentClient extends AbstractSpringClient {
         return springManager.deployments().inner().get(resourceGroup, clusterName, appName, deploymentName);
     }
 
+    public boolean isDeploymentExist() {
+        return getDeployment() != null;
+    }
+
     public SpringDeploymentClient(Builder builder) {
         super(builder);
         this.appName = builder.appName;

--- a/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/utils/Utils.java
+++ b/azure-spring-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/utils/Utils.java
@@ -31,11 +31,11 @@ import java.util.stream.Collectors;
 
 public class Utils {
 
+    private static final String POM = "pom";
+    private static final String JAR = "jar";
     private static final String DATE_FORMAT = "yyyyMMddHHmmss";
     private static final String MEMORY_REGEX = "(\\d+(\\.\\d+)?)([a-zA-Z]+)";
     private static final Pattern MEMORY_PATTERN = Pattern.compile(MEMORY_REGEX);
-    private static final String POM = "pom";
-    private static final String JAR = "jar";
 
     public static int convertSizeStringToNumber(String memory) throws MojoExecutionException {
         final Matcher matcher = MEMORY_PATTERN.matcher(memory);
@@ -108,7 +108,7 @@ public class Utils {
 
     private static boolean isExecutableJar(File file) {
         try (final FileInputStream fileInputStream = new FileInputStream(file);
-                final JarInputStream jarInputStream = new JarInputStream(fileInputStream)) {
+             final JarInputStream jarInputStream = new JarInputStream(fileInputStream)) {
             final Manifest manifest = jarInputStream.getManifest();
             return manifest.getMainAttributes().getValue("Main-Class") != null;
         } catch (IOException e) {


### PR DESCRIPTION
Spring Cloud Services support at most deployments in each app, this pr add the support for deploy to app with existing deployments, an here is the summary for plugin behavior.(... means same as left)

 Deployments | No deployment | 1 active deployment | 1 inactive deployment | 1 active + 1 inactive deployments | summary
---|---|---|---|---|---
Give an existing deployments name |/|Update existing deployment|...|...|Update existing deployment, start but don't change active status
No Deployment Name given |Create new deployment,active it unless -DcreateInactvie |Update the active deployment|**error**|Update the active deployment|Create/Update active deployment
Given an non-exist deployment's Name |Create new deployment,active it| if app have deployment already, Error, ask usr to add -DcreateInactvie. With -DcreateInactvie, try create inactive deployment and deploy|...|...|allow blue-green with goal parameter
 -DcreateInactvie Given an non-exist deployment's Name|try create inactive deployment and deploy|...|...|...|...



