### PR TITLE
Fix telemetry may not be sent within multi-project

### DIFF
--- a/azure-maven-plugin-common/src/main/java/com/microsoft/azure/maven/common/telemetry/AppInsightHelper.java
+++ b/azure-maven-plugin-common/src/main/java/com/microsoft/azure/maven/common/telemetry/AppInsightHelper.java
@@ -29,6 +29,7 @@ public enum AppInsightHelper implements TelemetryProxy {
         sessionId = UUID.randomUUID().toString();
         defaultProperties.put(TELEMETRY_KEY_SESSION_ID, sessionId);
         defaultProperties.put(TELEMETRY_KEY_INSTALLATIONID, GetHashMac.getHashMac());
+        initTelemetryHttpClient();
     }
 
     public void enable() {
@@ -61,14 +62,12 @@ public enum AppInsightHelper implements TelemetryProxy {
     // into endless loop when close, we need to call it in main thread.
     // Refer here for detail codes: https://github.com/Microsoft/ApplicationInsights-Java/blob/master/core/src
     // /main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java#L103
-    public void close(){
+    public void initTelemetryHttpClient() {
         try {
-            // Sleep to wait ai sdk flush telemetries
-            Thread.sleep(2 * 1000);
-        } catch (InterruptedException e) {
+            ApacheSenderFactory.INSTANCE.create().getHttpClient();
+        } catch (Exception e) {
             // swallow this exception
         }
-        ApacheSenderFactory.INSTANCE.create().close();
     }
 
     public String getSessionId() {

--- a/azure-maven-plugin/src/main/java/com/microsoft/azure/plugin/login/AbstractAzureMojo.java
+++ b/azure-maven-plugin/src/main/java/com/microsoft/azure/plugin/login/AbstractAzureMojo.java
@@ -49,8 +49,6 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
         } catch (Exception e) {
             handleException(e);
             throw e;
-        } finally {
-            AppInsightHelper.INSTANCE.close();
         }
     }
 

--- a/azure-maven-plugin/src/test/java/com/microsoft/azure/plugin/login/LoginMojoTest.java
+++ b/azure-maven-plugin/src/test/java/com/microsoft/azure/plugin/login/LoginMojoTest.java
@@ -42,7 +42,7 @@ import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.net.ssl.*","javax.security.*"})
+@PowerMockIgnore({"javax.net.ssl.*", "javax.security.*"})
 @PrepareForTest({ AzureAuthHelper.class, AppInsightHelper.class, TelemetryClient.class, LoginMojo.class, Azure.class })
 public class LoginMojoTest {
     @Rule

--- a/azure-maven-plugin/src/test/java/com/microsoft/azure/plugin/login/LoginMojoTest.java
+++ b/azure-maven-plugin/src/test/java/com/microsoft/azure/plugin/login/LoginMojoTest.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -41,6 +42,7 @@ import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.net.ssl.*","javax.security.*"})
 @PrepareForTest({ AzureAuthHelper.class, AppInsightHelper.class, TelemetryClient.class, LoginMojo.class, Azure.class })
 public class LoginMojoTest {
     @Rule

--- a/azure-maven-plugin/src/test/java/com/microsoft/azure/plugin/login/SelectSubscriptionMojoTest.java
+++ b/azure-maven-plugin/src/test/java/com/microsoft/azure/plugin/login/SelectSubscriptionMojoTest.java
@@ -47,7 +47,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.net.ssl.*","javax.security.*"})
+@PowerMockIgnore({"javax.net.ssl.*", "javax.security.*"})
 @PrepareForTest({ AzureAuthHelper.class, AppInsightHelper.class, TelemetryClient.class, SelectSubscriptionMojo.class, Azure.class, Scanner.class })
 public class SelectSubscriptionMojoTest {
     @Rule

--- a/azure-maven-plugin/src/test/java/com/microsoft/azure/plugin/login/SelectSubscriptionMojoTest.java
+++ b/azure-maven-plugin/src/test/java/com/microsoft/azure/plugin/login/SelectSubscriptionMojoTest.java
@@ -24,6 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -46,6 +47,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.net.ssl.*","javax.security.*"})
 @PrepareForTest({ AzureAuthHelper.class, AppInsightHelper.class, TelemetryClient.class, SelectSubscriptionMojo.class, Azure.class, Scanner.class })
 public class SelectSubscriptionMojoTest {
     @Rule

--- a/azure-spring-cloud-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/AbstractSpringMojo.java
+++ b/azure-spring-cloud-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/AbstractSpringMojo.java
@@ -131,8 +131,6 @@ public abstract class AbstractSpringMojo extends AbstractMojo {
         } catch (Exception e) {
             handleException(e);
             throw new MojoFailureException(e.getMessage(), e);
-        } finally {
-            AppInsightHelper.INSTANCE.close();
         }
     }
 

--- a/azure-spring-cloud-maven-plugin/src/test/java/com/microsoft/azure/maven/spring/ConfigMojoTest.java
+++ b/azure-spring-cloud-maven-plugin/src/test/java/com/microsoft/azure/maven/spring/ConfigMojoTest.java
@@ -59,7 +59,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.net.ssl.*","javax.security.*"})
+@PowerMockIgnore({"javax.net.ssl.*", "javax.security.*"})
 @PrepareForTest({ AzureAuthHelper.class, AppInsightHelper.class, TelemetryClient.class, ConfigMojo.class, AbstractSpringMojo.class, Azure.class,
         ServiceResourceInner.class, ProxyResource.class, SpringServiceClient.class, PomXmlUpdater.class})
 public class ConfigMojoTest {

--- a/azure-spring-cloud-maven-plugin/src/test/java/com/microsoft/azure/maven/spring/ConfigMojoTest.java
+++ b/azure-spring-cloud-maven-plugin/src/test/java/com/microsoft/azure/maven/spring/ConfigMojoTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -58,6 +59,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.net.ssl.*","javax.security.*"})
 @PrepareForTest({ AzureAuthHelper.class, AppInsightHelper.class, TelemetryClient.class, ConfigMojo.class, AbstractSpringMojo.class, Azure.class,
         ServiceResourceInner.class, ProxyResource.class, SpringServiceClient.class, PomXmlUpdater.class})
 public class ConfigMojoTest {

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -12,7 +12,6 @@ environment:
 install:
   - cmd: npm i -g azure-functions-core-tools@core --unsafe-perm true
   - cmd: SET PATH=%PYTHON%;%PYTHON%\Scripts;%JAVA_HOME%\bin;%PATH%
-  - cmd: python -m pip install azure-cli
   - cmd: copy "C:\Program Files (x86)\Apache\Maven\bin\mvn.cmd" "C:\Program Files (x86)\Apache\Maven\bin\mvn.bat"
 
 build_script:


### PR DESCRIPTION
Fix telemetry may not be sent within multi-project, by calling getHttpClient instead of close.