### PR TITLE
Fix issues in renaming jar artifact

### DIFF
--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/artifact/ArtifactHandlerImplV2.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/artifact/ArtifactHandlerImplV2.java
@@ -212,11 +212,11 @@ public class ArtifactHandlerImplV2 extends ArtifactHandlerBase {
         }
         final File artifact = getProjectJarArtifact(artifacts);
         final File renamedArtifact = new File(artifact.getParent(), DEFAULT_APP_SERVICE_JAR_NAME);
-        try {
+        if (!StringUtils.equals(artifact.getName(), DEFAULT_APP_SERVICE_JAR_NAME)) {
             log.info(String.format(RENAMING_MESSAGE, artifact.getAbsolutePath(), DEFAULT_APP_SERVICE_JAR_NAME));
-            FileUtils.rename(artifact, renamedArtifact);
-        } catch (IOException e) {
-            throw new MojoExecutionException(String.format(RENAMING_FAILED_MESSAGE, DEFAULT_APP_SERVICE_JAR_NAME));
+            if (!artifact.renameTo(renamedArtifact)) {
+                throw new MojoExecutionException(String.format(RENAMING_FAILED_MESSAGE, DEFAULT_APP_SERVICE_JAR_NAME));
+            }
         }
     }
 


### PR DESCRIPTION
- Don't rename artifact when its name equals app.jar
- Use `File.renameTo` instead of `FileUtils.rename()` as `FileUtils` will delete the origin file when original file name equalsIgnoreCase with `app.jar`