### PR TITLE
Move deployment temp file to temp folder

### DIFF
--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/artifact/ArtifactHandlerImplV2.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/artifact/ArtifactHandlerImplV2.java
@@ -10,9 +10,9 @@ import com.microsoft.azure.maven.artifacthandler.ArtifactHandlerBase;
 import com.microsoft.azure.maven.deploytarget.DeployTarget;
 import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.configuration.RuntimeSetting;
+import com.microsoft.azure.maven.webapp.utils.Utils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.codehaus.plexus.util.FileUtils;
 import org.zeroturnaround.zip.ZipUtil;
 
 import java.io.File;
@@ -150,13 +150,8 @@ public class ArtifactHandlerImplV2 extends ArtifactHandlerBase {
             prepareJavaSERuntime(getAllArtifacts(stagingDirectoryPath));
         }
         final File stagingDirectory = new File(stagingDirectoryPath);
-        final File zipFile = new File(stagingDirectoryPath + ".zip");
+        final File zipFile = Utils.createTempFile(stagingDirectory.getName(), ".zip");
         ZipUtil.pack(stagingDirectory, zipFile);
-        try {
-            FileUtils.forceDeleteOnExit(zipFile);
-        } catch (IOException e) {
-            // swallow this exception for it will not block deployment
-        }
         log.info(String.format("Deploying the zip package %s...", zipFile.getName()));
 
         // Add retry logic here to avoid Kudu's socket timeout issue.

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/utils/Utils.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/utils/Utils.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.maven.webapp.utils;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+import java.io.File;
+import java.io.IOException;
+
+public class Utils {
+
+    private static final String CREATE_TEMP_FILE_FAIL = "Failed to create temp file %s.%s";
+
+    public static File createTempFile(final String prefix, final String suffix) throws MojoExecutionException {
+        try {
+            final File zipFile = File.createTempFile(prefix, suffix);
+            zipFile.deleteOnExit();
+            return zipFile;
+        } catch (IOException e) {
+            throw new MojoExecutionException(String.format(CREATE_TEMP_FILE_FAIL, prefix, suffix), e.getCause());
+        }
+    }
+
+    private Utils(){
+
+    }
+}

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/artifact/ArtifactHandlerImplV2Test.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/artifact/ArtifactHandlerImplV2Test.java
@@ -6,7 +6,6 @@
 
 package com.microsoft.azure.maven.webapp.handlers.artifact;
 
-import com.microsoft.azure.management.appservice.RuntimeStack;
 import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.management.appservice.WebContainer;
 import com.microsoft.azure.maven.appservice.DeployTargetType;
@@ -37,6 +36,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -189,8 +189,7 @@ public class ArtifactHandlerImplV2Test {
         final DeployTarget target = mock(DeployTarget.class);
         final File zipTestDirectory = new File("src/test/resources/artifacthandlerv2");
         final String stagingDirectoryPath = zipTestDirectory.getAbsolutePath();
-        final File zipFile = new File(stagingDirectoryPath + ".zip");
-        doNothing().when(target).zipDeploy(zipFile);
+        doNothing().when(target).zipDeploy(any());
 
         final Log log = mock(Log.class);
         doReturn(log).when(mojo).getLog();


### PR DESCRIPTION
Create deploy zip in temp folder in case it was occupied by other process and unable to delete after deployment.