### PR TITLE
Remove FUNCTIONS_EXTENSION_VERSION for integration tests

### DIFF
--- a/azure-functions-maven-plugin/src/it/0-http-trigger/pom.xml
+++ b/azure-functions-maven-plugin/src/it/0-http-trigger/pom.xml
@@ -60,12 +60,6 @@
                     <resourceGroup>${functionResourceGroup}</resourceGroup>
                     <appName>${functionAppName}</appName>
                     <region>${functionAppRegion}</region>
-                    <appSettings>
-                        <property>
-                            <name>FUNCTIONS_EXTENSION_VERSION</name>
-                            <value>beta</value>
-                        </property>
-                    </appSettings>
                 </configuration>
                 <executions>
                     <execution>

--- a/azure-functions-maven-plugin/src/it/1-storage-queue-trigger/pom.xml
+++ b/azure-functions-maven-plugin/src/it/1-storage-queue-trigger/pom.xml
@@ -55,12 +55,6 @@
                     <resourceGroup>${functionResourceGroup}</resourceGroup>
                     <appName>${functionAppName}</appName>
                     <region>${functionAppRegion}</region>
-                    <appSettings>
-                        <property>
-                            <name>FUNCTIONS_EXTENSION_VERSION</name>
-                            <value>beta</value>
-                        </property>
-                    </appSettings>
                 </configuration>
                 <executions>
                     <execution>

--- a/azure-functions-maven-plugin/src/it/2-timer-trigger/pom.xml
+++ b/azure-functions-maven-plugin/src/it/2-timer-trigger/pom.xml
@@ -55,12 +55,6 @@
                     <resourceGroup>${functionResourceGroup}</resourceGroup>
                     <appName>${functionAppName}</appName>
                     <region>${functionAppRegion}</region>
-                    <appSettings>
-                        <property>
-                            <name>FUNCTIONS_EXTENSION_VERSION</name>
-                            <value>beta</value>
-                        </property>
-                    </appSettings>
                 </configuration>
                 <executions>
                     <execution>

--- a/azure-functions-maven-plugin/src/it/3-eventhub-trigger/pom.xml
+++ b/azure-functions-maven-plugin/src/it/3-eventhub-trigger/pom.xml
@@ -75,12 +75,6 @@
                     <resourceGroup>${functionResourceGroup}</resourceGroup>
                     <appName>${functionAppName}</appName>
                     <region>${functionAppRegion}</region>
-                    <appSettings>
-                        <property>
-                            <name>FUNCTIONS_EXTENSION_VERSION</name>
-                            <value>beta</value>
-                        </property>
-                    </appSettings>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
The value is outdated (and we should use the default value for tests)