### PR TITLE
Enable linux runtime helper for linux function apps

### DIFF
--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
@@ -9,6 +9,7 @@ package com.microsoft.azure.maven.function;
 import com.microsoft.azure.management.appservice.FunctionApp;
 import com.microsoft.azure.management.appservice.PricingTier;
 import com.microsoft.azure.maven.AbstractAppServiceMojo;
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.auth.AzureAuthFailureException;
 import com.microsoft.azure.maven.function.configurations.ElasticPremiumPricingTier;
 import com.microsoft.azure.maven.function.configurations.RuntimeConfiguration;
@@ -150,6 +151,18 @@ public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
             // Swallow exception for non-existing Azure Functions
         }
         return null;
+    }
+
+    public RuntimeConfiguration getRuntime() {
+        return runtime;
+    }
+
+    public OperatingSystemEnum getRuntimeOs() throws MojoExecutionException {
+        if (runtime == null || runtime.getOs() == null) {
+            return OperatingSystemEnum.Windows;
+        } else {
+            return OperatingSystemEnum.fromString(runtime.getOs());
+        }
     }
 
     @Override

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
@@ -9,7 +9,6 @@ package com.microsoft.azure.maven.function;
 import com.microsoft.azure.management.appservice.FunctionApp;
 import com.microsoft.azure.management.appservice.PricingTier;
 import com.microsoft.azure.maven.AbstractAppServiceMojo;
-import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.auth.AzureAuthFailureException;
 import com.microsoft.azure.maven.function.configurations.ElasticPremiumPricingTier;
 import com.microsoft.azure.maven.function.configurations.RuntimeConfiguration;
@@ -155,14 +154,6 @@ public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
 
     public RuntimeConfiguration getRuntime() {
         return runtime;
-    }
-
-    public OperatingSystemEnum getRuntimeOs() throws MojoExecutionException {
-        if (runtime == null || runtime.getOs() == null) {
-            return OperatingSystemEnum.Windows;
-        } else {
-            return OperatingSystemEnum.fromString(runtime.getOs());
-        }
     }
 
     @Override

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
@@ -93,7 +93,7 @@ public class DeployMojo extends AbstractFunctionMojo {
         }
     }
 
-    protected void createFunctionApp() throws MojoExecutionException, AzureAuthFailureException {
+    protected void createFunctionApp() throws AzureAuthFailureException, MojoExecutionException {
         info(FUNCTION_APP_CREATE_START);
         final FunctionRuntimeHandler runtimeHandler = getFunctionRuntimeHandler();
         final WithCreate withCreate = runtimeHandler.defineAppWithRuntime();
@@ -102,7 +102,7 @@ public class DeployMojo extends AbstractFunctionMojo {
         info(String.format(FUNCTION_APP_CREATED, getAppName()));
     }
 
-    protected void updateFunctionApp(final FunctionApp app) throws MojoExecutionException, AzureAuthFailureException {
+    protected void updateFunctionApp(final FunctionApp app) throws AzureAuthFailureException, MojoExecutionException {
         info(FUNCTION_APP_UPDATE);
         // Work around of https://github.com/Azure/azure-sdk-for-java/issues/1755
         app.inner().withTags(null);
@@ -135,7 +135,7 @@ public class DeployMojo extends AbstractFunctionMojo {
 
     //endregion
 
-    protected FunctionRuntimeHandler getFunctionRuntimeHandler() throws MojoExecutionException, AzureAuthFailureException {
+    protected FunctionRuntimeHandler getFunctionRuntimeHandler() throws AzureAuthFailureException, MojoExecutionException {
         final FunctionRuntimeHandler.Builder<?> builder;
         final OperatingSystemEnum os = getOsEnum();
         switch (os) {

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
@@ -14,8 +14,10 @@ import com.microsoft.azure.management.appservice.JavaVersion;
 import com.microsoft.azure.management.appservice.PricingTier;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.appservice.DeployTargetType;
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.auth.AzureAuthFailureException;
 import com.microsoft.azure.maven.deploytarget.DeployTarget;
+import com.microsoft.azure.maven.function.configurations.RuntimeConfiguration;
 import com.microsoft.azure.maven.function.handlers.artifact.MSDeployArtifactHandlerImpl;
 import com.microsoft.azure.maven.function.handlers.artifact.RunFromBlobArtifactHandlerImpl;
 import com.microsoft.azure.maven.function.handlers.artifact.RunFromZipArtifactHandlerImpl;
@@ -154,7 +156,8 @@ public class DeployMojo extends AbstractFunctionMojo {
 
     protected FunctionRuntimeHandler getFunctionRuntimeHandler() throws MojoExecutionException, AzureAuthFailureException {
         final FunctionRuntimeHandler.Builder<?> builder;
-        switch (this.getRuntimeOs()) {
+        final OperatingSystemEnum os = this.runtime == null ? RuntimeConfiguration.DEFAULT_OS : runtime.getOperationSystemEnum();
+        switch (os) {
             case Windows:
                 builder = new WindowsFunctionRuntimeHandler.Builder();
                 break;
@@ -162,7 +165,7 @@ public class DeployMojo extends AbstractFunctionMojo {
                 builder = new LinuxFunctionRuntimeHandler.Builder();
                 break;
             default:
-                throw new MojoExecutionException(String.format("Unsupported runtime %s", this.getRuntimeOs()));
+                throw new MojoExecutionException(String.format("Unsupported runtime %s", os));
         }
         return builder.appName(getAppName())
                 .resourceGroup(getResourceGroup())

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/PackageMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/PackageMojo.java
@@ -21,6 +21,7 @@ import com.microsoft.azure.maven.function.handlers.CommandHandler;
 import com.microsoft.azure.maven.function.handlers.CommandHandlerImpl;
 import com.microsoft.azure.maven.function.handlers.FunctionCoreToolsHandler;
 import com.microsoft.azure.maven.function.handlers.FunctionCoreToolsHandlerImpl;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.input.BOMInputStream;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Resource;
@@ -28,6 +29,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -191,7 +193,7 @@ public class PackageMojo extends AbstractFunctionMojo {
     protected String getScriptFilePath() {
         return new StringBuilder()
                 .append("..")
-                .append(File.separator)
+                .append("/")
                 .append(getFinalName())
                 .append(".jar")
                 .toString();
@@ -250,7 +252,10 @@ public class PackageMojo extends AbstractFunctionMojo {
             throws IOException {
         targetFile.getParentFile().mkdirs();
         targetFile.createNewFile();
-        objectWriter.writeValue(targetFile, object);
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        objectWriter.writeValue(byteArrayOutputStream, object);
+        // Change line of end to LF, refers https://stackoverflow.com/questions/3776923/how-can-i-normalize-the-eol-character-in-java
+        FileUtils.write(targetFile, byteArrayOutputStream.toString().replaceAll("\\r\\n?", "\n"));
     }
 
     protected ObjectWriter getObjectWriter() {

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/PackageMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/PackageMojo.java
@@ -6,6 +6,9 @@
 
 package com.microsoft.azure.maven.function;
 
+import com.fasterxml.jackson.core.PrettyPrinter;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -21,7 +24,6 @@ import com.microsoft.azure.maven.function.handlers.CommandHandler;
 import com.microsoft.azure.maven.function.handlers.CommandHandlerImpl;
 import com.microsoft.azure.maven.function.handlers.FunctionCoreToolsHandler;
 import com.microsoft.azure.maven.function.handlers.FunctionCoreToolsHandlerImpl;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.input.BOMInputStream;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Resource;
@@ -29,7 +31,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -252,16 +253,15 @@ public class PackageMojo extends AbstractFunctionMojo {
             throws IOException {
         targetFile.getParentFile().mkdirs();
         targetFile.createNewFile();
-        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        objectWriter.writeValue(byteArrayOutputStream, object);
-        // Change line of end to LF, refers https://stackoverflow.com/questions/3776923/how-can-i-normalize-the-eol-character-in-java
-        FileUtils.write(targetFile, byteArrayOutputStream.toString().replaceAll("\\r\\n?", "\n"));
+        objectWriter.writeValue(targetFile, object);
     }
 
     protected ObjectWriter getObjectWriter() {
+        final DefaultIndenter indenter = DefaultIndenter.SYSTEM_LINEFEED_INSTANCE.withLinefeed("\n");
+        final PrettyPrinter prettyPrinter = (new DefaultPrettyPrinter()).withObjectIndenter(indenter);
         return new ObjectMapper()
                 .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
-                .writerWithDefaultPrettyPrinter();
+                .writer(prettyPrinter);
     }
 
     //endregion

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/PackageMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/PackageMojo.java
@@ -257,8 +257,8 @@ public class PackageMojo extends AbstractFunctionMojo {
     }
 
     protected ObjectWriter getObjectWriter() {
-        final DefaultIndenter indenter = DefaultIndenter.SYSTEM_LINEFEED_INSTANCE.withLinefeed("\n");
-        final PrettyPrinter prettyPrinter = (new DefaultPrettyPrinter()).withObjectIndenter(indenter);
+        final DefaultPrettyPrinter.Indenter indenter = DefaultIndenter.SYSTEM_LINEFEED_INSTANCE.withLinefeed("\n");
+        final PrettyPrinter prettyPrinter = new DefaultPrettyPrinter().withObjectIndenter(indenter);
         return new ObjectMapper()
                 .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
                 .writer(prettyPrinter);

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/configurations/RuntimeConfiguration.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/configurations/RuntimeConfiguration.java
@@ -6,7 +6,14 @@
 
 package com.microsoft.azure.maven.function.configurations;
 
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.codehaus.plexus.util.StringUtils;
+
 public class RuntimeConfiguration {
+
+    public static final OperatingSystemEnum DEFAULT_OS = OperatingSystemEnum.Windows;
+
     protected String os;
     protected String image;
     protected String serverId;
@@ -18,6 +25,10 @@ public class RuntimeConfiguration {
 
     public void setOs(String os) {
         this.os = os;
+    }
+
+    public OperatingSystemEnum getOperationSystemEnum() throws MojoExecutionException {
+        return StringUtils.isEmpty(os) ? DEFAULT_OS : OperatingSystemEnum.fromString(os);
     }
 
     public String getImage() {

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/configurations/RuntimeConfiguration.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/configurations/RuntimeConfiguration.java
@@ -7,8 +7,6 @@
 package com.microsoft.azure.maven.function.configurations;
 
 import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.codehaus.plexus.util.StringUtils;
 
 public class RuntimeConfiguration {
 
@@ -25,10 +23,6 @@ public class RuntimeConfiguration {
 
     public void setOs(String os) {
         this.os = os;
-    }
-
-    public OperatingSystemEnum getOperationSystemEnum() throws MojoExecutionException {
-        return StringUtils.isEmpty(os) ? DEFAULT_OS : OperatingSystemEnum.fromString(os);
     }
 
     public String getImage() {

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/runtime/FunctionRuntimeHandler.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/runtime/FunctionRuntimeHandler.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.management.resources.ResourceGroup;
 import com.microsoft.azure.maven.function.configurations.RuntimeConfiguration;
 import com.microsoft.azure.maven.handlers.runtime.BaseRuntimeHandler;
 import com.microsoft.azure.maven.utils.AppServiceUtils;
+import org.apache.maven.plugin.MojoExecutionException;
 
 public abstract class FunctionRuntimeHandler extends BaseRuntimeHandler<FunctionApp> {
 
@@ -37,13 +38,13 @@ public abstract class FunctionRuntimeHandler extends BaseRuntimeHandler<Function
     }
 
     @Override
-    public abstract FunctionApp.DefinitionStages.WithCreate defineAppWithRuntime() throws Exception;
+    public abstract FunctionApp.DefinitionStages.WithCreate defineAppWithRuntime() throws MojoExecutionException;
 
     @Override
-    public abstract FunctionApp.Update updateAppRuntime(FunctionApp app) throws Exception;
+    public abstract FunctionApp.Update updateAppRuntime(FunctionApp app) throws MojoExecutionException;
 
     @Override
-    public abstract AppServicePlan updateAppServicePlan(FunctionApp app) throws Exception;
+    public abstract AppServicePlan updateAppServicePlan(FunctionApp app) throws MojoExecutionException;
 
     protected FunctionApp.DefinitionStages.Blank defineFunction() {
         return azure.appServices().functionApps().define(appName);

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/runtime/FunctionRuntimeHandler.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/runtime/FunctionRuntimeHandler.java
@@ -12,7 +12,6 @@ import com.microsoft.azure.management.resources.ResourceGroup;
 import com.microsoft.azure.maven.function.configurations.RuntimeConfiguration;
 import com.microsoft.azure.maven.handlers.runtime.BaseRuntimeHandler;
 import com.microsoft.azure.maven.utils.AppServiceUtils;
-import org.codehaus.plexus.util.StringUtils;
 
 public abstract class FunctionRuntimeHandler extends BaseRuntimeHandler<FunctionApp> {
 
@@ -37,16 +36,21 @@ public abstract class FunctionRuntimeHandler extends BaseRuntimeHandler<Function
         this.runtimeConfiguration = builder.runtimeConfiguration;
     }
 
+    @Override
+    public abstract FunctionApp.DefinitionStages.WithCreate defineAppWithRuntime() throws Exception;
+
+    @Override
+    public abstract FunctionApp.Update updateAppRuntime(FunctionApp app) throws Exception;
+
+    @Override
+    public abstract AppServicePlan updateAppServicePlan(FunctionApp app) throws Exception;
+
     protected FunctionApp.DefinitionStages.Blank defineFunction() {
         return azure.appServices().functionApps().define(appName);
     }
 
     protected AppServicePlan getAppServicePlan() {
         return AppServiceUtils.getAppServicePlan(servicePlanName, azure, resourceGroup, servicePlanResourceGroup);
-    }
-
-    protected String changeAppServicePlan() {
-        return StringUtils.isEmpty(servicePlanResourceGroup) ? resourceGroup : servicePlanResourceGroup;
     }
 
     protected ResourceGroup getResourceGroup() {

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/runtime/LinuxFunctionRuntimeHandler.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/runtime/LinuxFunctionRuntimeHandler.java
@@ -9,7 +9,6 @@ package com.microsoft.azure.maven.function.handlers.runtime;
 import com.microsoft.azure.management.appservice.AppServicePlan;
 import com.microsoft.azure.management.appservice.FunctionApp;
 import com.microsoft.azure.management.appservice.FunctionRuntimeStack;
-import com.microsoft.azure.management.appservice.WebAppBase;
 
 public class LinuxFunctionRuntimeHandler extends FunctionRuntimeHandler {
 
@@ -31,7 +30,7 @@ public class LinuxFunctionRuntimeHandler extends FunctionRuntimeHandler {
     }
 
     @Override
-    public WebAppBase.DefinitionStages.WithCreate defineAppWithRuntime() throws Exception {
+    public FunctionApp.DefinitionStages.WithCreate defineAppWithRuntime() throws Exception {
         final AppServicePlan appServicePlan = getAppServicePlan();
         final FunctionApp.DefinitionStages.Blank functionApp = defineFunction();
         final FunctionApp.DefinitionStages.WithCreate withCreate;
@@ -61,7 +60,7 @@ public class LinuxFunctionRuntimeHandler extends FunctionRuntimeHandler {
     }
 
     @Override
-    public WebAppBase.Update updateAppRuntime(FunctionApp app) throws Exception {
+    public FunctionApp.Update updateAppRuntime(FunctionApp app) throws Exception {
         return app.update();
     }
 

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/runtime/LinuxFunctionRuntimeHandler.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/runtime/LinuxFunctionRuntimeHandler.java
@@ -30,7 +30,7 @@ public class LinuxFunctionRuntimeHandler extends FunctionRuntimeHandler {
     }
 
     @Override
-    public FunctionApp.DefinitionStages.WithCreate defineAppWithRuntime() throws Exception {
+    public FunctionApp.DefinitionStages.WithCreate defineAppWithRuntime() {
         final AppServicePlan appServicePlan = getAppServicePlan();
         final FunctionApp.DefinitionStages.Blank functionApp = defineFunction();
         final FunctionApp.DefinitionStages.WithCreate withCreate;
@@ -60,12 +60,12 @@ public class LinuxFunctionRuntimeHandler extends FunctionRuntimeHandler {
     }
 
     @Override
-    public FunctionApp.Update updateAppRuntime(FunctionApp app) throws Exception {
+    public FunctionApp.Update updateAppRuntime(FunctionApp app) {
         return app.update();
     }
 
     @Override
-    public AppServicePlan updateAppServicePlan(FunctionApp app) throws Exception {
+    public AppServicePlan updateAppServicePlan(FunctionApp app) {
         // Todo: update app service plan
         return null;
     }

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/runtime/WindowsFunctionRuntimeHandler.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/runtime/WindowsFunctionRuntimeHandler.java
@@ -8,7 +8,6 @@ package com.microsoft.azure.maven.function.handlers.runtime;
 
 import com.microsoft.azure.management.appservice.AppServicePlan;
 import com.microsoft.azure.management.appservice.FunctionApp;
-import com.microsoft.azure.management.appservice.WebAppBase;
 
 public class WindowsFunctionRuntimeHandler extends FunctionRuntimeHandler {
 
@@ -30,7 +29,7 @@ public class WindowsFunctionRuntimeHandler extends FunctionRuntimeHandler {
     }
 
     @Override
-    public WebAppBase.DefinitionStages.WithCreate defineAppWithRuntime() throws Exception {
+    public FunctionApp.DefinitionStages.WithCreate defineAppWithRuntime() throws Exception {
         final AppServicePlan appServicePlan = getAppServicePlan();
         final FunctionApp.DefinitionStages.Blank functionApp = defineFunction();
         FunctionApp.DefinitionStages.WithCreate appWithCreate;
@@ -60,7 +59,7 @@ public class WindowsFunctionRuntimeHandler extends FunctionRuntimeHandler {
     }
 
     @Override
-    public WebAppBase.Update updateAppRuntime(FunctionApp app) throws Exception {
+    public FunctionApp.Update updateAppRuntime(FunctionApp app) throws Exception {
         return app.update();
     }
 

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/runtime/WindowsFunctionRuntimeHandler.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/runtime/WindowsFunctionRuntimeHandler.java
@@ -29,7 +29,7 @@ public class WindowsFunctionRuntimeHandler extends FunctionRuntimeHandler {
     }
 
     @Override
-    public FunctionApp.DefinitionStages.WithCreate defineAppWithRuntime() throws Exception {
+    public FunctionApp.DefinitionStages.WithCreate defineAppWithRuntime() {
         final AppServicePlan appServicePlan = getAppServicePlan();
         final FunctionApp.DefinitionStages.Blank functionApp = defineFunction();
         FunctionApp.DefinitionStages.WithCreate appWithCreate;
@@ -59,12 +59,12 @@ public class WindowsFunctionRuntimeHandler extends FunctionRuntimeHandler {
     }
 
     @Override
-    public FunctionApp.Update updateAppRuntime(FunctionApp app) throws Exception {
+    public FunctionApp.Update updateAppRuntime(FunctionApp app) {
         return app.update();
     }
 
     @Override
-    public AppServicePlan updateAppServicePlan(FunctionApp app) throws Exception {
+    public AppServicePlan updateAppServicePlan(FunctionApp app) {
         // Todo: update app service plan
         return null;
     }

--- a/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/PackageMojoTest.java
+++ b/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/PackageMojoTest.java
@@ -17,7 +17,6 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.lang.reflect.Method;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -70,7 +69,7 @@ public class PackageMojoTest extends MojoTestBase {
 
         final String finalName = mojoSpy.getScriptFilePath();
 
-        assertEquals(Paths.get("..", "artifact-0.1.0.jar").toString(), finalName);
+        assertEquals("../artifact-0.1.0.jar", finalName);
     }
 
     @Test

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/Utils.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/Utils.java
@@ -6,6 +6,7 @@
 
 package com.microsoft.azure.maven;
 
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -23,6 +24,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Utility class
@@ -125,6 +127,23 @@ public final class Utils {
             filtering.filterResources(mavenResourcesExecution);
         } catch (MavenFilteringException ex) {
             throw new IOException("Failed to copy resources", ex);
+        }
+    }
+
+    public static OperatingSystemEnum parseOperationSystem(final String os) throws MojoExecutionException {
+        if (StringUtils.isEmpty(os)) {
+            throw new MojoExecutionException("The value of <os> is empty, please specify it in pom.xml.");
+        }
+        switch (os.toLowerCase(Locale.ENGLISH)) {
+            case "windows":
+                return OperatingSystemEnum.Windows;
+            case "linux":
+                return OperatingSystemEnum.Linux;
+            case "docker":
+                return OperatingSystemEnum.Docker;
+            default:
+                throw new MojoExecutionException("The value of <os> is unknown, supported values are: windows, " +
+                        "linux and docker.");
         }
     }
 }

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/appservice/OperatingSystemEnum.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/appservice/OperatingSystemEnum.java
@@ -6,31 +6,8 @@
 
 package com.microsoft.azure.maven.appservice;
 
-import org.apache.maven.plugin.MojoExecutionException;
-import org.codehaus.plexus.util.StringUtils;
-
-import java.util.Locale;
-
 public enum OperatingSystemEnum {
     Linux,
     Windows,
-    Docker;
-
-    public static OperatingSystemEnum fromString(final String os) throws MojoExecutionException {
-        if (StringUtils.isEmpty(os)) {
-            throw new MojoExecutionException("The configuration <os> in <runtime> is required, " +
-                "please specify it in pom.xml.");
-        }
-        switch (os.toLowerCase(Locale.ENGLISH)) {
-            case "windows":
-                return Windows;
-            case "linux":
-                return Linux;
-            case "docker":
-                return Docker;
-            default:
-                throw new MojoExecutionException("The value of <os> is unknown, supported values are: windows, " +
-                    "linux and docker.");
-        }
-    }
+    Docker
 }

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/appservice/OperatingSystemEnum.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/appservice/OperatingSystemEnum.java
@@ -4,7 +4,7 @@
  * license information.
  */
 
-package com.microsoft.azure.maven.webapp.configuration;
+package com.microsoft.azure.maven.appservice;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.util.StringUtils;

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/handlers/RuntimeHandler.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/handlers/RuntimeHandler.java
@@ -8,12 +8,13 @@ package com.microsoft.azure.maven.handlers;
 
 import com.microsoft.azure.management.appservice.AppServicePlan;
 import com.microsoft.azure.management.appservice.WebAppBase;
+import org.apache.maven.plugin.MojoExecutionException;
 
 public interface RuntimeHandler<T extends WebAppBase> {
 
-    WebAppBase.DefinitionStages.WithCreate defineAppWithRuntime() throws Exception;
+    WebAppBase.DefinitionStages.WithCreate defineAppWithRuntime() throws MojoExecutionException;
 
-    WebAppBase.Update updateAppRuntime(final T app) throws Exception;
+    WebAppBase.Update updateAppRuntime(final T app) throws MojoExecutionException;
 
-    AppServicePlan updateAppServicePlan(final T app) throws Exception;
+    AppServicePlan updateAppServicePlan(final T app) throws MojoExecutionException;
 }

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/handlers/runtime/BaseRuntimeHandler.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/handlers/runtime/BaseRuntimeHandler.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.management.appservice.PricingTier;
 import com.microsoft.azure.management.appservice.WebAppBase;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.handlers.RuntimeHandler;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.settings.Settings;
 
@@ -125,9 +126,9 @@ public abstract class BaseRuntimeHandler<T extends WebAppBase> implements Runtim
         this.log = builder.log;
     }
 
-    public abstract WebAppBase.DefinitionStages.WithCreate defineAppWithRuntime() throws Exception;
+    public abstract WebAppBase.DefinitionStages.WithCreate defineAppWithRuntime() throws MojoExecutionException;
 
-    public abstract WebAppBase.Update updateAppRuntime(T app) throws Exception;
+    public abstract WebAppBase.Update updateAppRuntime(T app) throws MojoExecutionException;
 
-    public abstract AppServicePlan updateAppServicePlan(T app) throws Exception;
+    public abstract AppServicePlan updateAppServicePlan(T app) throws MojoExecutionException;
 }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
@@ -16,7 +16,7 @@ import com.microsoft.azure.maven.queryer.QueryFactory;
 import com.microsoft.azure.maven.utils.AppServiceUtils;
 import com.microsoft.azure.maven.webapp.configuration.Deployment;
 import com.microsoft.azure.maven.webapp.configuration.DeploymentSlotSetting;
-import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.configuration.SchemaVersion;
 import com.microsoft.azure.maven.webapp.handlers.WebAppPomHandler;
 import com.microsoft.azure.maven.webapp.parser.V2NoValidationConfigurationParser;

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.management.appservice.OperatingSystem;
 import com.microsoft.azure.management.appservice.PricingTier;
 import com.microsoft.azure.management.appservice.WebContainer;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
+import com.microsoft.azure.maven.Utils;
 import com.microsoft.azure.maven.queryer.MavenPluginQueryer;
 import com.microsoft.azure.maven.queryer.QueryFactory;
 import com.microsoft.azure.maven.utils.AppServiceUtils;
@@ -236,7 +237,7 @@ public class ConfigMojo extends AbstractWebAppMojo {
         final OperatingSystemEnum defaultOs = configuration.getOs() == null ? OperatingSystemEnum.Linux :
             configuration.getOs();
         final String os = queryer.assureInputFromUser("OS", defaultOs, null);
-        builder.os(OperatingSystemEnum.fromString(os));
+        builder.os(Utils.parseOperationSystem(os));
 
         switch (os.toLowerCase()) {
             case "linux":

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/WebAppConfiguration.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/WebAppConfiguration.java
@@ -13,7 +13,7 @@ import com.microsoft.azure.management.appservice.WebContainer;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.utils.AppServiceUtils;
 import com.microsoft.azure.maven.webapp.configuration.DeploymentSlotSetting;
-import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.utils.RuntimeStackUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Resource;

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/configuration/RuntimeSetting.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/configuration/RuntimeSetting.java
@@ -9,6 +9,7 @@ package com.microsoft.azure.maven.webapp.configuration;
 import com.microsoft.azure.management.appservice.JavaVersion;
 import com.microsoft.azure.management.appservice.RuntimeStack;
 import com.microsoft.azure.management.appservice.WebContainer;
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.utils.RuntimeStackUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/configuration/RuntimeSetting.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/configuration/RuntimeSetting.java
@@ -9,6 +9,7 @@ package com.microsoft.azure.maven.webapp.configuration;
 import com.microsoft.azure.management.appservice.JavaVersion;
 import com.microsoft.azure.management.appservice.RuntimeStack;
 import com.microsoft.azure.management.appservice.WebContainer;
+import com.microsoft.azure.maven.Utils;
 import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.utils.RuntimeStackUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -40,7 +41,7 @@ public class RuntimeSetting {
 
     public OperatingSystemEnum getOsEnum() {
         try {
-            return OperatingSystemEnum.fromString(this.os);
+            return Utils.parseOperationSystem(this.os);
         } catch (MojoExecutionException e) {
             return null;
         }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/HandlerFactoryImpl.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/HandlerFactoryImpl.java
@@ -74,7 +74,7 @@ public class HandlerFactoryImpl extends HandlerFactory {
     protected WebAppRuntimeHandler.Builder getDockerRuntimeHandlerBuilder(final WebAppConfiguration config)
         throws MojoExecutionException {
 
-        final WebAppRuntimeHandler.Builder builder;
+        final WebAppRuntimeHandler.Builder<? extends WebAppRuntimeHandler.Builder> builder;
         final DockerImageType imageType = WebAppUtils.getDockerImageType(config.getImage(), config.getServerId(),
             config.getRegistryUrl());
         switch (imageType) {
@@ -90,7 +90,7 @@ public class HandlerFactoryImpl extends HandlerFactory {
             default:
                 throw new MojoExecutionException("Invalid docker runtime configured.");
         }
-        return (WebAppRuntimeHandler.Builder) builder.image(config.getImage()).serverId(config.getServerId()).registryUrl(config.getRegistryUrl());
+        return builder.image(config.getImage()).serverId(config.getServerId()).registryUrl(config.getRegistryUrl());
     }
 
     @Override

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/artifact/ArtifactHandlerImplV2.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/artifact/ArtifactHandlerImplV2.java
@@ -8,7 +8,7 @@ package com.microsoft.azure.maven.webapp.handlers.artifact;
 
 import com.microsoft.azure.maven.handlers.artifact.ArtifactHandlerBase;
 import com.microsoft.azure.maven.deploytarget.DeployTarget;
-import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.configuration.RuntimeSetting;
 import com.microsoft.azure.maven.webapp.utils.Utils;
 import org.apache.commons.lang3.StringUtils;

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/runtime/LinuxRuntimeHandlerImpl.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/runtime/LinuxRuntimeHandlerImpl.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.management.appservice.OperatingSystem;
 import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.management.appservice.WebApp.Update;
 import com.microsoft.azure.maven.webapp.utils.WebAppUtils;
+import org.apache.maven.plugin.MojoExecutionException;
 
 public class LinuxRuntimeHandlerImpl extends WebAppRuntimeHandler {
     public static class Builder extends WebAppRuntimeHandler.Builder<Builder> {
@@ -31,14 +32,14 @@ public class LinuxRuntimeHandlerImpl extends WebAppRuntimeHandler {
     }
 
     @Override
-    public WebApp.DefinitionStages.WithCreate defineAppWithRuntime() throws Exception {
+    public WebApp.DefinitionStages.WithCreate defineAppWithRuntime() throws MojoExecutionException {
         final AppServicePlan plan = createOrGetAppServicePlan();
         return WebAppUtils.defineLinuxApp(resourceGroup, appName, azure, plan)
             .withBuiltInImage(runtime);
     }
 
     @Override
-    public Update updateAppRuntime(WebApp app) throws Exception {
+    public Update updateAppRuntime(WebApp app) throws MojoExecutionException {
         WebAppUtils.assureLinuxWebApp(app);
         WebAppUtils.clearTags(app);
         return app.update().withBuiltInImage(runtime);

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/runtime/NullRuntimeHandlerImpl.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/runtime/NullRuntimeHandlerImpl.java
@@ -19,7 +19,7 @@ public class NullRuntimeHandlerImpl implements RuntimeHandler<WebApp> {
         "For V2 schema version, please use <runtime>.";
 
     @Override
-    public WithCreate defineAppWithRuntime() throws Exception {
+    public WithCreate defineAppWithRuntime() throws MojoExecutionException {
         throw new MojoExecutionException(NO_RUNTIME_CONFIG);
     }
 
@@ -29,7 +29,7 @@ public class NullRuntimeHandlerImpl implements RuntimeHandler<WebApp> {
     }
 
     @Override
-    public AppServicePlan updateAppServicePlan(final WebApp app) throws Exception {
+    public AppServicePlan updateAppServicePlan(final WebApp app) {
         return null;
     }
 }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/runtime/PrivateDockerHubRuntimeHandlerImpl.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/runtime/PrivateDockerHubRuntimeHandlerImpl.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.management.appservice.OperatingSystem;
 import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.maven.Utils;
 import com.microsoft.azure.maven.webapp.utils.WebAppUtils;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.settings.Server;
 
 import static com.microsoft.azure.maven.Utils.assureServerExist;
@@ -33,7 +34,7 @@ public class PrivateDockerHubRuntimeHandlerImpl extends WebAppRuntimeHandler {
     }
 
     @Override
-    public WebApp.DefinitionStages.WithCreate defineAppWithRuntime() throws Exception {
+    public WebApp.DefinitionStages.WithCreate defineAppWithRuntime() throws MojoExecutionException {
         final Server server = Utils.getServer(settings, serverId);
         assureServerExist(server, serverId);
 
@@ -44,7 +45,7 @@ public class PrivateDockerHubRuntimeHandlerImpl extends WebAppRuntimeHandler {
     }
 
     @Override
-    public WebApp.Update updateAppRuntime(final WebApp app) throws Exception {
+    public WebApp.Update updateAppRuntime(final WebApp app) throws MojoExecutionException {
         WebAppUtils.assureLinuxWebApp(app);
         WebAppUtils.clearTags(app);
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/runtime/PrivateRegistryRuntimeHandlerImpl.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/runtime/PrivateRegistryRuntimeHandlerImpl.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.management.appservice.OperatingSystem;
 import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.maven.Utils;
 import com.microsoft.azure.maven.webapp.utils.WebAppUtils;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.settings.Server;
 
 import static com.microsoft.azure.maven.Utils.assureServerExist;
@@ -34,7 +35,7 @@ public class PrivateRegistryRuntimeHandlerImpl extends WebAppRuntimeHandler {
     }
 
     @Override
-    public WebApp.DefinitionStages.WithCreate defineAppWithRuntime() throws Exception {
+    public WebApp.DefinitionStages.WithCreate defineAppWithRuntime() throws MojoExecutionException {
         final Server server = Utils.getServer(settings, serverId);
         assureServerExist(server, serverId);
 
@@ -45,7 +46,7 @@ public class PrivateRegistryRuntimeHandlerImpl extends WebAppRuntimeHandler {
     }
 
     @Override
-    public WebApp.Update updateAppRuntime(final WebApp app) throws Exception {
+    public WebApp.Update updateAppRuntime(final WebApp app) throws MojoExecutionException {
         WebAppUtils.assureLinuxWebApp(app);
         WebAppUtils.clearTags(app);
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/runtime/PublicDockerHubRuntimeHandlerImpl.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/runtime/PublicDockerHubRuntimeHandlerImpl.java
@@ -10,6 +10,7 @@ import com.microsoft.azure.management.appservice.AppServicePlan;
 import com.microsoft.azure.management.appservice.OperatingSystem;
 import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.maven.webapp.utils.WebAppUtils;
+import org.apache.maven.plugin.MojoExecutionException;
 
 public class PublicDockerHubRuntimeHandlerImpl extends WebAppRuntimeHandler {
     public static class Builder extends WebAppRuntimeHandler.Builder<PublicDockerHubRuntimeHandlerImpl.Builder> {
@@ -29,14 +30,14 @@ public class PublicDockerHubRuntimeHandlerImpl extends WebAppRuntimeHandler {
     }
 
     @Override
-    public WebApp.DefinitionStages.WithCreate defineAppWithRuntime() throws Exception {
+    public WebApp.DefinitionStages.WithCreate defineAppWithRuntime() throws MojoExecutionException {
         final AppServicePlan plan = createOrGetAppServicePlan();
         return WebAppUtils.defineLinuxApp(resourceGroup, appName, azure, plan)
             .withPublicDockerHubImage(image);
     }
 
     @Override
-    public WebApp.Update updateAppRuntime(final WebApp app) throws Exception {
+    public WebApp.Update updateAppRuntime(final WebApp app) throws MojoExecutionException {
         WebAppUtils.assureLinuxWebApp(app);
         WebAppUtils.clearTags(app);
         return app.update().withPublicDockerHubImage(image);

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/runtime/WebAppRuntimeHandler.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/runtime/WebAppRuntimeHandler.java
@@ -49,7 +49,7 @@ public abstract class WebAppRuntimeHandler extends BaseRuntimeHandler<WebApp> {
     }
 
     @Override
-    public AppServicePlan updateAppServicePlan(final WebApp app) throws Exception {
+    public AppServicePlan updateAppServicePlan(final WebApp app) throws MojoExecutionException {
         final AppServicePlan appServicePlan = WebAppUtils.getAppServicePlanByWebApp(app);
         // If app's service plan differs from pom, change and update it
         if ((StringUtils.isNotEmpty(servicePlanName) && !servicePlanName.equals(appServicePlan.name())) ||

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/runtime/WindowsRuntimeHandlerImpl.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/handlers/runtime/WindowsRuntimeHandlerImpl.java
@@ -12,6 +12,7 @@ import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.management.appservice.WebApp.DefinitionStages.WithCreate;
 import com.microsoft.azure.management.appservice.WebApp.Update;
 import com.microsoft.azure.maven.webapp.utils.WebAppUtils;
+import org.apache.maven.plugin.MojoExecutionException;
 
 public class WindowsRuntimeHandlerImpl extends WebAppRuntimeHandler {
     public static class Builder extends WebAppRuntimeHandler.Builder<WindowsRuntimeHandlerImpl.Builder> {
@@ -31,7 +32,7 @@ public class WindowsRuntimeHandlerImpl extends WebAppRuntimeHandler {
     }
 
     @Override
-    public WithCreate defineAppWithRuntime() throws Exception {
+    public WithCreate defineAppWithRuntime() throws MojoExecutionException {
         final AppServicePlan plan = createOrGetAppServicePlan();
         final WithCreate withCreate = WebAppUtils.defineWindowsApp(resourceGroup, appName, azure, plan);
         withCreate.withJavaVersion(javaVersion).withWebContainer(webContainer);
@@ -39,7 +40,7 @@ public class WindowsRuntimeHandlerImpl extends WebAppRuntimeHandler {
     }
 
     @Override
-    public Update updateAppRuntime(final WebApp app) throws Exception {
+    public Update updateAppRuntime(final WebApp app) throws MojoExecutionException {
         WebAppUtils.assureWindowsWebApp(app);
         WebAppUtils.clearTags(app);
         final Update update = app.update();

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/ConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/ConfigurationParser.java
@@ -15,7 +15,7 @@ import com.microsoft.azure.maven.utils.AppServiceUtils;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.WebAppConfiguration;
 import com.microsoft.azure.maven.webapp.configuration.DeploymentSlotSetting;
-import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.validator.AbstractConfigurationValidator;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V1ConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V1ConfigurationParser.java
@@ -12,7 +12,7 @@ import com.microsoft.azure.management.appservice.WebContainer;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.configuration.ContainerSetting;
-import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.utils.RuntimeStackUtils;
 import com.microsoft.azure.maven.webapp.validator.AbstractConfigurationValidator;
 import org.apache.maven.model.Resource;

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParser.java
@@ -12,7 +12,7 @@ import com.microsoft.azure.management.appservice.WebContainer;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.configuration.Deployment;
-import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.configuration.RuntimeSetting;
 import com.microsoft.azure.maven.webapp.validator.AbstractConfigurationValidator;
 import org.apache.maven.model.Resource;

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2NoValidationConfigurationParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/V2NoValidationConfigurationParser.java
@@ -13,7 +13,7 @@ import com.microsoft.azure.management.appservice.WebContainer;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.configuration.DeploymentSlotSetting;
-import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.validator.AbstractConfigurationValidator;
 import org.apache.maven.plugin.MojoExecutionException;
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/utils/WebAppUtils.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/utils/WebAppUtils.java
@@ -53,7 +53,7 @@ public class WebAppUtils {
     public static WithDockerContainerImage defineLinuxApp(final String resourceGroup,
                                                           final String appName,
                                                           final Azure azureClient,
-                                                          final AppServicePlan plan) throws Exception {
+                                                          final AppServicePlan plan) throws MojoExecutionException {
         assureLinuxPlan(plan);
 
         final ExistingLinuxPlanWithGroup existingLinuxPlanWithGroup = azureClient.webApps()
@@ -65,7 +65,7 @@ public class WebAppUtils {
 
     public static WithCreate defineWindowsApp(final String resourceGroup,
                                               final String appName,
-                                              final Azure azureClient, final AppServicePlan plan) throws Exception {
+                                              final Azure azureClient, final AppServicePlan plan) throws MojoExecutionException {
         assureWindowsPlan(plan);
 
         final ExistingWindowsPlanWithGroup existingWindowsPlanWithGroup = azureClient.webApps()

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/HandlerFactoryImplTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/HandlerFactoryImplTest.java
@@ -17,7 +17,7 @@ import com.microsoft.azure.maven.handlers.ArtifactHandler;
 import com.microsoft.azure.maven.handlers.RuntimeHandler;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.WebAppConfiguration;
-import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.handlers.artifact.JarArtifactHandlerImpl;
 import com.microsoft.azure.maven.webapp.handlers.artifact.WarArtifactHandlerImpl;
 import com.microsoft.azure.maven.webapp.handlers.runtime.LinuxRuntimeHandlerImpl;

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/artifact/ArtifactHandlerImplV2Test.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/handlers/artifact/ArtifactHandlerImplV2Test.java
@@ -12,7 +12,7 @@ import com.microsoft.azure.maven.appservice.DeployTargetType;
 import com.microsoft.azure.maven.deploytarget.DeployTarget;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.configuration.Deployment;
-import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.configuration.RuntimeSetting;
 import com.microsoft.azure.maven.webapp.deploytarget.WebAppDeployTarget;
 import org.apache.maven.model.Resource;

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/ConfigurationParserTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/ConfigurationParserTest.java
@@ -13,7 +13,7 @@ import com.microsoft.azure.management.appservice.WebContainer;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.WebAppConfiguration;
-import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.validator.AbstractConfigurationValidator;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Resource;

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/V1ConfigurationParserTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/V1ConfigurationParserTest.java
@@ -12,7 +12,7 @@ import com.microsoft.azure.management.appservice.WebContainer;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.configuration.ContainerSetting;
-import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.validator.V1ConfigurationValidator;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.Before;

--- a/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParserTest.java
+++ b/azure-webapp-maven-plugin/src/test/java/com/microsoft/azure/maven/webapp/parser/V2ConfigurationParserTest.java
@@ -12,7 +12,7 @@ import com.microsoft.azure.management.appservice.WebContainer;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.maven.webapp.AbstractWebAppMojo;
 import com.microsoft.azure.maven.webapp.configuration.Deployment;
-import com.microsoft.azure.maven.webapp.configuration.OperatingSystemEnum;
+import com.microsoft.azure.maven.appservice.OperatingSystemEnum;
 import com.microsoft.azure.maven.webapp.configuration.RuntimeSetting;
 import com.microsoft.azure.maven.webapp.validator.V2ConfigurationValidator;
 import org.apache.maven.model.Resource;


### PR DESCRIPTION
1. Update function.json format to fit both windows and linux
2. Enable linux runtime helper for linux function apps

Todo:
Add test cases for function runtime handlers