### PR TITLE
Get default deployment type by runtime if user didn't set it in configuration

### DIFF
--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/artifact/DockerArtifactHandler.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/handlers/artifact/DockerArtifactHandler.java
@@ -11,6 +11,8 @@ import com.microsoft.azure.maven.handlers.artifact.ArtifactHandlerBase;
 
 public class DockerArtifactHandler extends ArtifactHandlerBase {
 
+    public static final String SKIP_DOCKER_DEPLOYMENT = "Skip deployment for docker functions";
+
     public static class Builder extends ArtifactHandlerBase.Builder<Builder> {
 
         @Override
@@ -30,7 +32,7 @@ public class DockerArtifactHandler extends ArtifactHandlerBase {
 
     @Override
     public void publish(DeployTarget deployTarget) {
-        log.info("Skip deployment for docker functions");
+        log.info(SKIP_DOCKER_DEPLOYMENT);
         deployTarget.getApp().restart();
     }
 }

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/appservice/DeploymentType.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/appservice/DeploymentType.java
@@ -19,6 +19,7 @@ public enum DeploymentType {
     AUTO,
     NONE,
     EMPTY,
+    DOCKER,
     MSDEPLOY,
     RUN_FROM_ZIP,
     RUN_FROM_BLOB;


### PR DESCRIPTION
Get default deployment type by runtime if user didn't set it in configuration
- For windows function, use `RUN_FROM_ZIP` by default
- For docker function, use `DOCKER` by default
- For linux function, use `RUN_FROM_ZIP` for Dedicated plan and use `RUN_FROM_BLOB` for others(Consumption & Premium )