### PR TITLE
Bump version for function and update documents

### DIFF
--- a/azure-functions-maven-plugin/CHANGELOG.md
+++ b/azure-functions-maven-plugin/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 All notable changes to the "Maven Plugin for Azure Function" will be documented in this file.
 - [Change Log](#change-log)
+  - [1.4.0](#140)
+  - [1.3.5](#135)
   - [1.3.4](#134)
   - [1.3.3](#133)
   - [1.3.2](#132)
@@ -9,6 +11,17 @@ All notable changes to the "Maven Plugin for Azure Function" will be documented 
   - [1.2.2](#122)
   - [1.2.1](#121)
   - [1.2.0](#120)
+
+## 1.4.0
+- Support functions with Linux runtime.[PR#906](https://github.com/microsoft/azure-maven-plugins/pull/906)
+- Support functions in docker runtime.[PR#917](https://github.com/microsoft/azure-maven-plugins/pull/917)
+- Support new deployment methods: RUN_FROM_ZIP,RUN_FROM_BLOB.[PR#896](https://github.com/microsoft/azure-maven-plugins/pull/896),[PR#903](https://github.com/microsoft/azure-maven-plugins/pull/903)
+- Add default value for `FUNCTIONS_EXTENSION_VERSION`.[PR#898](https://github.com/microsoft/azure-maven-plugins/pull/898)
+
+## 1.3.5
+- Support OAuth and Device Login support to auth with Azure.[PR#843](https://github.com/microsoft/azure-maven-plugins/pull/843)
+- Update to `azure-function-java-library` 1.3.1. [#882](https://github.com/microsoft/azure-maven-plugins/issues/822)
+- Always write `authLevel` of HTTPTrigger to `function.json`, for HttpTrigger-Java connector issues.[PR#892](https://github.com/microsoft/azure-maven-plugins/pull/892)
 
 ## 1.3.4
 - Skip `func extensions install` when using extension bundles [#609](https://github.com/microsoft/azure-maven-plugins/issues/609)

--- a/azure-functions-maven-plugin/README.md
+++ b/azure-functions-maven-plugin/README.md
@@ -103,6 +103,7 @@ Property | Required | Description
 `<resourceGroup>` | true | Specifies the Azure Resource Group for your Azure Functions.
 `<appName>` | true | Specifies the name of your Azure Functions.
 `<region>`* | false | Specifies the region where your Azure Functions will be hosted; default value is **westus**. All valid regions are at [Supported Regions](#supported-regions) section.
+`<runtime>` | false |The runtime environment configuration, default runtime is **windows**. Details could be found in [Runtime](https://github.com/microsoft/azure-maven-plugins/wiki/Azure-Functions:-Configuration-Details#runtime) section.
 `<pricingTier>`* | false | Specifies the pricing tier for your Azure Functions; default value is **Consumption**. All valid pricing tiers are at [Supported Pricing Tiers](#supported-pricing-tiers) section.
 `<appServicePlanResourceGroup>` | false | Specifies the resource group of the existing App Service Plan when you do not want to create a new one. If this setting is not specified, the plugin will use the value defined in `<resourceGroup>`.
 `<appServicePlanName>` | false | Specifies the name of the existing App Service Plan when you do not want to create a new one.

--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-functions-maven-plugin</artifactId>
-    <version>1.3.5</version>
+    <version>1.4.0</version>
     <packaging>maven-plugin</packaging>
     <name>Maven Plugin for Azure Functions</name>
     <description>Maven Plugin for Azure Functions</description>
@@ -28,7 +28,7 @@
         <maven.plugin-tools.version>3.2</maven.plugin-tools.version>
         <maven.plugin-testing.version>3.3.0</maven.plugin-testing.version>
         <codehaus.plexus-utils.version>3.0.20</codehaus.plexus-utils.version>
-        <azure.maven-plugin-lib.version>1.2.12-SNAPSHOT</azure.maven-plugin-lib.version>
+        <azure.maven-plugin-lib.version>1.2.12</azure.maven-plugin-lib.version>
         <azure.function.version>1.3.1</azure.function.version>
         <reflections.version>0.9.11</reflections.version>
         <junit.version>4.12</junit.version>

--- a/azure-maven-plugin-lib/pom.xml
+++ b/azure-maven-plugin-lib/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>azure-maven-plugin-lib</artifactId>
-    <version>1.2.12-SNAPSHOT</version>
+    <version>1.2.12</version>
     <packaging>jar</packaging>
     <name>Azure Maven Plugin Library</name>
     <description>Common library for Azure Maven Plugins</description>

--- a/azure-webapp-maven-plugin/pom.xml
+++ b/azure-webapp-maven-plugin/pom.xml
@@ -29,7 +29,7 @@
         <maven.plugin-testing.version>3.3.0</maven.plugin-testing.version>
         <codehaus.plexus-utils.version>3.0.20</codehaus.plexus-utils.version>
         <azure.ai.version>1.0.9</azure.ai.version>
-        <azure.maven-plugin-lib.version>1.2.12-SNAPSHOT</azure.maven-plugin-lib.version>
+        <azure.maven-plugin-lib.version>1.2.12</azure.maven-plugin-lib.version>
         <junit.version>4.12</junit.version>
         <mockito.version>2.22.0</mockito.version>
         <spring-test.version>4.1.6.RELEASE</spring-test.version>


### PR DESCRIPTION
1. Bump version
    - azure-function-maven-plugin from 1.3.5 to 1.4.0
    - azure-maven-plugin-lib to 1.2.12
2. Update document for function configuration
3. Update function release notes.