### PR TITLE
Change to use SDK to get app service instance

### DIFF
--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
@@ -6,7 +6,6 @@
 
 package com.microsoft.azure.maven.function;
 
-import com.microsoft.azure.PagedList;
 import com.microsoft.azure.common.exceptions.AzureExecutionException;
 import com.microsoft.azure.common.function.configurations.ElasticPremiumPricingTier;
 import com.microsoft.azure.common.function.configurations.FunctionExtensionVersion;
@@ -18,13 +17,11 @@ import com.microsoft.azure.management.appservice.FunctionApp;
 import com.microsoft.azure.management.appservice.PricingTier;
 import com.microsoft.azure.maven.AbstractAppServiceMojo;
 import com.microsoft.azure.maven.auth.AzureAuthFailureException;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import javax.annotation.Nullable;
-
 import java.io.File;
 import java.util.Map;
 
@@ -152,8 +149,7 @@ public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
 
     @Nullable
     public FunctionApp getFunctionApp() throws AzureAuthFailureException {
-        final PagedList<FunctionApp> functionList = getAzureClient().appServices().functionApps().list();
-        return AppServiceUtils.findAppServiceInPagedList(functionList, getResourceGroup(), getAppName());
+        return getAzureClient().appServices().functionApps().getByResourceGroup(getResourceGroup(), getAppName());
     }
 
     public RuntimeConfiguration getRuntime() {

--- a/azure-maven-plugin-lib/pom.xml
+++ b/azure-maven-plugin-lib/pom.xml
@@ -36,7 +36,7 @@
         <jaxb.version>2.3.2</jaxb.version>
         <zeroturnaround.zip.version>1.13</zeroturnaround.zip.version>
         <azure.auth.helper.version>0.4.0</azure.auth.helper.version>
-        <azure-tools-common.version>0.2.0</azure-tools-common.version>
+        <azure-tools-common.version>0.3.0-SNAPSHOT</azure-tools-common.version>
     </properties>
 
     <licenses>

--- a/azure-tools-common/src/main/java/com/microsoft/azure/common/utils/AppServiceUtils.java
+++ b/azure-tools-common/src/main/java/com/microsoft/azure/common/utils/AppServiceUtils.java
@@ -6,7 +6,6 @@
 
 package com.microsoft.azure.common.utils;
 
-import com.microsoft.azure.PagedList;
 import com.microsoft.azure.common.appservice.DockerImageType;
 import com.microsoft.azure.common.exceptions.AzureExecutionException;
 import com.microsoft.azure.common.logging.Log;
@@ -15,14 +14,11 @@ import com.microsoft.azure.management.appservice.AppServicePlan;
 import com.microsoft.azure.management.appservice.OperatingSystem;
 import com.microsoft.azure.management.appservice.PricingTier;
 import com.microsoft.azure.management.appservice.WebAppBase;
-
-import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
@@ -127,14 +123,5 @@ public class AppServiceUtils {
         } else {
             return hasCredential ? DockerImageType.PRIVATE_DOCKER_HUB : DockerImageType.PUBLIC_DOCKER_HUB;
         }
-    }
-
-    public static <T extends WebAppBase> T findAppServiceInPagedList(PagedList<T> list, String resourceGroup, String name) {
-        if (StringUtils.isEmpty(resourceGroup) || StringUtils.isEmpty(name)) {
-            return null;
-        }
-        final Iterator<T> iterator = list.listIterator();
-        return IteratorUtils.find(iterator, (appBase) -> StringUtils.equals(appBase.resourceGroupName(), resourceGroup) &&
-                StringUtils.equals(appBase.name(), name));
     }
 }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/AbstractWebAppMojo.java
@@ -6,7 +6,6 @@
 
 package com.microsoft.azure.maven.webapp;
 
-import com.microsoft.azure.PagedList;
 import com.microsoft.azure.common.appservice.DockerImageType;
 import com.microsoft.azure.common.exceptions.AzureExecutionException;
 import com.microsoft.azure.common.utils.AppServiceUtils;
@@ -25,7 +24,6 @@ import com.microsoft.azure.maven.webapp.parser.V1ConfigurationParser;
 import com.microsoft.azure.maven.webapp.parser.V2ConfigurationParser;
 import com.microsoft.azure.maven.webapp.validator.V1ConfigurationValidator;
 import com.microsoft.azure.maven.webapp.validator.V2ConfigurationValidator;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -313,8 +311,7 @@ public abstract class AbstractWebAppMojo extends AbstractAppServiceMojo {
     }
 
     public WebApp getWebApp() throws AzureAuthFailureException {
-        final PagedList<WebApp> webAppPagedList = getAzureClient().webApps().list();
-        return AppServiceUtils.findAppServiceInPagedList(webAppPagedList, getResourceGroup(), getAppName());
+        return getAzureClient().webApps().getByResourceGroup(getResourceGroup(), getAppName());
     }
 
     public DeploymentSlot getDeploymentSlot(final WebApp app, final String slotName) {


### PR DESCRIPTION
Change to use SDK method to get app service instance, as SDK has fixed the null exception so we don't need to use our own workaround, here is the related [issue](https://github.com/Azure/azure-libraries-for-java/issues/953)

Fixes #1056 