### PR TITLE
fix NPE exception when the 'runtimeVersion' is not set

### DIFF
--- a/azure-spring-cloud-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/spring/SpringDeploymentClient.java
+++ b/azure-spring-cloud-maven-plugin/src/main/java/com/microsoft/azure/maven/spring/spring/SpringDeploymentClient.java
@@ -106,6 +106,9 @@ public class SpringDeploymentClient extends AbstractSpringClient {
     }
 
     private RuntimeVersion parseRuntimeVersion(String runtimeVersion) {
+        if (StringUtils.isAllEmpty(runtimeVersion)) {
+            return DEFAULT_RUNTIME_VERSION;
+        }
         final Matcher matcher = Pattern.compile(RUNTIME_VERSION_PATTERN).matcher(runtimeVersion);
         if (matcher.matches()) {
             return StringUtils.equals(matcher.group(3), "8") ? RuntimeVersion.JAVA_8 : RuntimeVersion.JAVA_11;


### PR DESCRIPTION
In the Maven plugin, if the `<runtimeVersion>Java8</runtimeVersion>` is not set (which should be the majority of cases, as it's an optional parameter, and as only Java 8 is supported at the moment according to the doc - when in fact Java 11 also works), then you'll get an NPE when doing the regexp on the line below.
This prevents the NPE, and instead gives the default value, which should be the case when nothing is configured.