### PR TITLE
Add RichCodeNav GitHub Action

### DIFF
--- a/.github/workflows/RichCodeNav.yml
+++ b/.github/workflows/RichCodeNav.yml
@@ -1,0 +1,16 @@
+name: RichNavIndexing
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - validate/*
+
+jobs:
+  richnav:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: microsoft/RichCodeNavIndexer@master
+      with:
+        languages: java


### PR DESCRIPTION
This is a change to introduce the Rich Code Navigation indexing service to your repository and here is [our wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/2340/Rich-Code-Navigation-Docs).
RichNav would allow you to navigate through remotely-hosted code without checking them out such as when reviewing PRs or browsing remote branches, and this RichNav GitHub action does the indexing without interfering with the official build CI. Please feel free to let me know if there is any questions!

Here is a verified GitHub action run on my fork: https://github.com/xuachen/azure-maven-plugins/pull/1/checks?check_run_id=664070342