### PR TITLE
Add Java runtime validation while package and deploy

### DIFF
--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
@@ -110,7 +110,7 @@ public class DeployMojo extends AbstractFunctionMojo {
     private static final String NO_TRIGGERS_FOUNDED = "No triggers found in deployed function app, " +
             "please try recompile the project by `mvn clean package` and deploy again.";
     private static final String SYNCING_TRIGGERS_AND_FETCH_FUNCTION_INFORMATION = "Syncing triggers and fetching function information (Attempt %d/%d)...";
-    private static final String ARTIFACT_UNCOMPITABLE = "Your function app artifact compile version is higher than the java version in function host, " +
+    private static final String ARTIFACT_INCOMPATIBLE = "Your function app artifact compile version is higher than the java version in function host, " +
             "please downgrade the project compile version and try again.";
 
     private JavaVersion parsedJavaVersion;
@@ -330,7 +330,7 @@ public class DeployMojo extends AbstractFunctionMojo {
         final ComparableVersion runtimeVersion = new ComparableVersion(parsedJavaVersion.toString());
         final ComparableVersion artifactVersion = new ComparableVersion(Utils.getArtifactCompileVersion(getArtifactToDeploy()));
         if (runtimeVersion.compareTo(artifactVersion) < 0) {
-            throw new AzureExecutionException(ARTIFACT_UNCOMPITABLE);
+            throw new AzureExecutionException(ARTIFACT_INCOMPATIBLE);
         }
     }
 

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
@@ -126,7 +126,7 @@ public class DeployMojo extends AbstractFunctionMojo {
         try {
             parseConfiguration();
 
-            validateArtifactCompileVersion();
+            checkArtifactCompileVersion();
 
             createOrUpdateFunctionApp();
 
@@ -323,7 +323,7 @@ public class DeployMojo extends AbstractFunctionMojo {
         }
     }
 
-    protected void validateArtifactCompileVersion() throws AzureExecutionException {
+    protected void checkArtifactCompileVersion() throws AzureExecutionException {
         if (getOsEnum() == OperatingSystemEnum.Docker) {
             return;
         }

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/PackageMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/PackageMojo.java
@@ -124,7 +124,7 @@ public class PackageMojo extends AbstractFunctionMojo {
 
             copyJarsToStageDirectory();
         } catch (IOException e) {
-            throw new AzureExecutionException("Canot perform IO operations due to error:" + e.getMessage(), e);
+            throw new AzureExecutionException("Cannot perform IO operations due to error:" + e.getMessage(), e);
         }
 
         final CommandHandler commandHandler = new CommandHandlerImpl();

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/PackageMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/PackageMojo.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.microsoft.applicationinsights.core.dependencies.apachecommons.lang3.StringUtils;
+import com.microsoft.azure.common.Utils;
 import com.microsoft.azure.common.exceptions.AzureExecutionException;
 import com.microsoft.azure.common.function.bindings.BindingEnum;
 import com.microsoft.azure.common.function.configurations.FunctionConfiguration;
@@ -94,6 +95,8 @@ public class PackageMojo extends AbstractFunctionMojo {
 
     @Override
     protected void doExecute() throws AzureExecutionException {
+        promptArtifactCompileVersion();
+
         final AnnotationHandler annotationHandler = getAnnotationHandler();
 
         Set<Method> methods = null;
@@ -369,6 +372,10 @@ public class PackageMojo extends AbstractFunctionMojo {
         }
     }
     // end region
+
+    protected void promptArtifactCompileVersion() throws AzureExecutionException {
+        Log.info(String.format("Artifact compile version : %s", Utils.getArtifactCompileVersion(project.getArtifact().getFile())));
+    }
 
     /**
      * Copy resources to target directory using Maven resource filtering so that we don't have to handle

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/PackageMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/PackageMojo.java
@@ -95,7 +95,7 @@ public class PackageMojo extends AbstractFunctionMojo {
 
     @Override
     protected void doExecute() throws AzureExecutionException {
-        promptArtifactCompileVersion();
+        promptCompileInfo();
 
         final AnnotationHandler annotationHandler = getAnnotationHandler();
 
@@ -373,7 +373,8 @@ public class PackageMojo extends AbstractFunctionMojo {
     }
     // end region
 
-    protected void promptArtifactCompileVersion() throws AzureExecutionException {
+    protected void promptCompileInfo() throws AzureExecutionException {
+        Log.info(String.format("Java home : %s", System.getenv("JAVA_HOME")));
         Log.info(String.format("Artifact compile version : %s", Utils.getArtifactCompileVersion(project.getArtifact().getFile())));
     }
 

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/RunMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/RunMojo.java
@@ -37,8 +37,8 @@ public class RunMojo extends AbstractFunctionMojo {
             "\"-agentlib:jdwp=%s\"";
     private static final ComparableVersion JAVA_9 = new ComparableVersion("9");
     private static final ComparableVersion FUNC_3 = new ComparableVersion("3");
-    private static final ComparableVersion MINIMUM_JAVA_11_SUPPORTED_VERSION = new ComparableVersion("3.0.2630");
-    private static final ComparableVersion MINIMUM_JAVA_11_SUPPORTED_VERSION_V2 = new ComparableVersion("2.7.2628");
+    private static final ComparableVersion MINIMUM_JAVA_9_SUPPORTED_VERSION = new ComparableVersion("3.0.2630");
+    private static final ComparableVersion MINIMUM_JAVA_9_SUPPORTED_VERSION_V2 = new ComparableVersion("2.7.2628");
     private static final String FUNC_VERSION_CMD = "func -v";
     private static final String FUNCTION_CORE_TOOLS_OUT_OF_DATE = "Local function core tools didn't support java 9 or higher runtime, " +
             "to update it, see: https://aka.ms/azfunc-install.";
@@ -73,7 +73,7 @@ public class RunMojo extends AbstractFunctionMojo {
 
         checkRuntimeExistence(commandHandler);
 
-        validateJavaCompatibility(commandHandler);
+        checkRuntimeCompatibility(commandHandler);
 
         runFunctions(commandHandler);
     }
@@ -107,7 +107,7 @@ public class RunMojo extends AbstractFunctionMojo {
         );
     }
 
-    private void validateJavaCompatibility(final CommandHandler handler) throws AzureExecutionException {
+    private void checkRuntimeCompatibility(final CommandHandler handler) throws AzureExecutionException {
         // Maven will always refer JAVA_HOME, which is also adopted by function core tools
         // So we could get function core tools runtime by java.version
         final ComparableVersion javaVersion = new ComparableVersion(System.getProperty("java.version"));
@@ -116,8 +116,8 @@ public class RunMojo extends AbstractFunctionMojo {
             return;
         }
         final ComparableVersion funcVersion = new ComparableVersion(handler.runCommandAndGetOutput(FUNC_VERSION_CMD, false, null));
-        final ComparableVersion minimumVersion = funcVersion.compareTo(FUNC_3) >= 0 ? MINIMUM_JAVA_11_SUPPORTED_VERSION :
-                MINIMUM_JAVA_11_SUPPORTED_VERSION_V2;
+        final ComparableVersion minimumVersion = funcVersion.compareTo(FUNC_3) >= 0 ? MINIMUM_JAVA_9_SUPPORTED_VERSION :
+                MINIMUM_JAVA_9_SUPPORTED_VERSION_V2;
         if (funcVersion.compareTo(minimumVersion) < 0) {
             throw new AzureExecutionException(FUNCTION_CORE_TOOLS_OUT_OF_DATE);
         }

--- a/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/DeployMojoTest.java
+++ b/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/DeployMojoTest.java
@@ -80,6 +80,8 @@ public class DeployMojoTest extends MojoTestBase {
         final DeployTarget deployTarget = new DeployTarget(app, DeployTargetType.FUNCTION);
         doNothing().when(mojoSpy).updateFunctionApp(app);
         doNothing().when(mojoSpy).listHTTPTriggerUrls();
+        doNothing().when(mojoSpy).validateArtifactCompileVersion();
+        doNothing().when(mojoSpy).parseConfiguration();
         mojoSpy.doExecute();
         verify(mojoSpy, times(1)).createOrUpdateFunctionApp();
         verify(mojoSpy, times(1)).doExecute();

--- a/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/DeployMojoTest.java
+++ b/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/DeployMojoTest.java
@@ -80,7 +80,7 @@ public class DeployMojoTest extends MojoTestBase {
         final DeployTarget deployTarget = new DeployTarget(app, DeployTargetType.FUNCTION);
         doNothing().when(mojoSpy).updateFunctionApp(app);
         doNothing().when(mojoSpy).listHTTPTriggerUrls();
-        doNothing().when(mojoSpy).validateArtifactCompileVersion();
+        doNothing().when(mojoSpy).checkArtifactCompileVersion();
         doNothing().when(mojoSpy).parseConfiguration();
         mojoSpy.doExecute();
         verify(mojoSpy, times(1)).createOrUpdateFunctionApp();

--- a/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/PackageMojoTest.java
+++ b/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/PackageMojoTest.java
@@ -50,7 +50,7 @@ public class PackageMojoTest extends MojoTestBase {
         doReturn(false).when(mojoSpy).isInstallingExtensionNeeded(any());
         doReturn(mock(MavenResourcesFiltering.class)).when(mojoSpy).getMavenResourcesFiltering();
         doNothing().when(mojoSpy).copyHostJsonFile(any());
-
+        doNothing().when(mojoSpy).promptArtifactCompileVersion();
         mojoSpy.doExecute();
     }
 

--- a/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/PackageMojoTest.java
+++ b/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/PackageMojoTest.java
@@ -50,7 +50,7 @@ public class PackageMojoTest extends MojoTestBase {
         doReturn(false).when(mojoSpy).isInstallingExtensionNeeded(any());
         doReturn(mock(MavenResourcesFiltering.class)).when(mojoSpy).getMavenResourcesFiltering();
         doNothing().when(mojoSpy).copyHostJsonFile(any());
-        doNothing().when(mojoSpy).promptArtifactCompileVersion();
+        doNothing().when(mojoSpy).promptCompileInfo();
         mojoSpy.doExecute();
     }
 

--- a/azure-maven-plugin-lib/pom.xml
+++ b/azure-maven-plugin-lib/pom.xml
@@ -35,7 +35,7 @@
         <jaxb.version>2.3.2</jaxb.version>
         <zeroturnaround.zip.version>1.13</zeroturnaround.zip.version>
         <azure.auth.helper.version>0.5.1</azure.auth.helper.version>
-        <azure-tools-common.version>0.5.0</azure-tools-common.version>
+        <azure-tools-common.version>0.6.0-SNAPSHOT</azure-tools-common.version>
         <commons.collections4.version>4.4</commons.collections4.version>
     </properties>
 

--- a/azure-sfmesh-maven-plugin/pom.xml
+++ b/azure-sfmesh-maven-plugin/pom.xml
@@ -20,7 +20,7 @@
   <url>https://github.com/microsoft/azure-maven-plugins</url>
 
   <properties>
-    <jackson.core.version>2.9.10.3</jackson.core.version>
+    <jackson.core.version>2.9.10.4</jackson.core.version>
     <jackson.dataformat.version>2.9.10</jackson.dataformat.version>
     <maven.plugin-tools.version>3.2</maven.plugin-tools.version>
     <maven.version>3.3.3</maven.version>

--- a/azure-tools-common/pom.xml
+++ b/azure-tools-common/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../azure-maven-plugins-pom</relativePath>
     </parent>
     <artifactId>azure-tools-common</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/azure-tools-common/src/main/java/com/microsoft/azure/common/function/handlers/runtime/WindowsFunctionRuntimeHandler.java
+++ b/azure-tools-common/src/main/java/com/microsoft/azure/common/function/handlers/runtime/WindowsFunctionRuntimeHandler.java
@@ -9,7 +9,6 @@ package com.microsoft.azure.common.function.handlers.runtime;
 import com.microsoft.azure.common.logging.Log;
 import com.microsoft.azure.management.appservice.AppServicePlan;
 import com.microsoft.azure.management.appservice.FunctionApp;
-
 import com.microsoft.azure.management.appservice.JavaVersion;
 import org.apache.commons.lang3.StringUtils;
 

--- a/azure-tools-common/src/main/java/com/microsoft/azure/common/function/model/FunctionResource.java
+++ b/azure-tools-common/src/main/java/com/microsoft/azure/common/function/model/FunctionResource.java
@@ -39,7 +39,7 @@ public class FunctionResource {
         if (config instanceof Map) {
             resource.scriptFile = (String) ((Map) config).get(SCRIPT_FILE);
             resource.entryPoint = (String) ((Map) config).get(ENTRY_POINT);
-            Object bindingListObject = ((Map) config).get(BINDINGS);
+            final Object bindingListObject = ((Map) config).get(BINDINGS);
             if (bindingListObject instanceof List) {
                 resource.bindingList = (List<BindingResource>) ((List) bindingListObject).stream()
                         .filter(item -> item instanceof Map)

--- a/azure-tools-common/src/main/java/com/microsoft/azure/common/function/utils/FunctionUtils.java
+++ b/azure-tools-common/src/main/java/com/microsoft/azure/common/function/utils/FunctionUtils.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.common.function.template.BindingsTemplate;
 import com.microsoft.azure.common.function.template.FunctionTemplate;
 import com.microsoft.azure.common.function.template.FunctionTemplates;
 import com.microsoft.azure.common.logging.Log;
+import com.microsoft.azure.management.appservice.JavaVersion;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -26,11 +27,35 @@ import java.util.List;
 
 
 public class FunctionUtils {
+    private static final JavaVersion DEFAULT_JAVA_VERSION = JavaVersion.JAVA_8_NEWEST;
+    private static final String INVALID_JAVA_VERSION = "Invalid java version %s, using default value java 8";
+    private static final String UNSUPPORTED_JAVA_VERSION = "Unsupported java version %s, using default value java 8";
     private static final String LOAD_TEMPLATES_FAIL = "Failed to load all function templates.";
     private static final String LOAD_BINDING_TEMPLATES_FAIL = "Failed to load function binding template.";
-
     private static final String INVALID_FUNCTION_EXTENSION_VERSION = "FUNCTIONS_EXTENSION_VERSION is empty or invalid, " +
             "please check the configuration";
+
+    public static JavaVersion parseJavaVersion(String javaVersion) {
+        if (StringUtils.isEmpty(javaVersion)) {
+            return DEFAULT_JAVA_VERSION;
+        }
+        try {
+            final int version = Integer.valueOf(javaVersion);
+            switch (version) {
+                case 8:
+                    return JavaVersion.JAVA_8_NEWEST;
+                case 11:
+                    Log.info("Using Java 11 (Preview) runtime.");
+                    return JavaVersion.JAVA_11;
+                default:
+                    Log.warn(String.format(UNSUPPORTED_JAVA_VERSION, version));
+                    return DEFAULT_JAVA_VERSION;
+            }
+        } catch (NumberFormatException e) {
+            Log.warn(String.format(INVALID_JAVA_VERSION, javaVersion));
+            return DEFAULT_JAVA_VERSION;
+        }
+    }
 
     public static FunctionExtensionVersion parseFunctionExtensionVersion(String version) throws AzureExecutionException {
         return Arrays.stream(FunctionExtensionVersion.values())


### PR DESCRIPTION
- Prompt java home and artifact compile version during maven package
  * Getting compile level from artifact classes, refers https://en.wikipedia.org/wiki/Java_class_file#General_layout
- Check artifact compile version with function host java version, throw exception when artifact version is higher than function host
- Check whether function core tools support current java runtime, @amamounelsayed please correct me if i'm wrong
  * Minimum version for java 9+ support (v2) : 2.7.2628
  * Minimum version for java 9+ support (v3) : 3.0.2630
- Refactor code structure and fix checkstyle