### PR TITLE
Begin using git token with Rich Nav task

### DIFF
--- a/.github/workflows/RichCodeNav.yml
+++ b/.github/workflows/RichCodeNav.yml
@@ -14,3 +14,4 @@ jobs:
     - uses: microsoft/RichCodeNavIndexer@v0.1
       with:
         languages: java
+        repo-token: ${{ github.token }}


### PR DESCRIPTION
A recent update to our service requires a Git token with all indexing requests. With this change, the Rich Nav task will have access to the aforementioned token to make requests to our service.