### PR TITLE
Update RichNav action to acquire github token

### DIFF
--- a/.github/workflows/RichCodeNav.yml
+++ b/.github/workflows/RichCodeNav.yml
@@ -13,4 +13,5 @@ jobs:
     - uses: actions/checkout@v2
     - uses: microsoft/RichCodeNavIndexer@v0.1
       with:
+        repo-token: ${{ github.token }}
         languages: java


### PR DESCRIPTION
Another recent change missed before which requires getting the github token to successfully index the repo. This will prevent the RichNav action from throwing 401 errors.