### PR TITLE
Remove sync triggers for Run from Blob handler

### DIFF
--- a/azure-tools-common/src/main/java/com/microsoft/azure/common/function/handlers/artifact/RunFromBlobArtifactHandlerImpl.java
+++ b/azure-tools-common/src/main/java/com/microsoft/azure/common/function/handlers/artifact/RunFromBlobArtifactHandlerImpl.java
@@ -52,7 +52,6 @@ public class RunFromBlobArtifactHandlerImpl extends ArtifactHandlerBase {
         final CloudBlockBlob blob = deployArtifactToAzureStorage(deployTarget, zipPackage, storageAccount);
         final String sasToken = AzureStorageHelper.getSASToken(blob, Period.ofYears(SAS_EXPIRE_DATE_BY_YEAR));
         FunctionArtifactHelper.updateAppSetting(deployTarget, APP_SETTING_WEBSITE_RUN_FROM_PACKAGE, sasToken);
-        ((FunctionApp) deployTarget.getApp()).syncTriggers();
     }
 
     private CloudBlockBlob deployArtifactToAzureStorage(DeployTarget deployTarget, File zipPackage, CloudStorageAccount storageAccount)


### PR DESCRIPTION
Remove sync triggers for Run from Blob handler, as kudu app settings may not updated immediately, fixes #1247, #1248, will add the sync process back after fixes #1251 