### PR TITLE
remove the log which says Java 11 runtime is in preview. #1343.

### DIFF
--- a/azure-tools-common/src/main/java/com/microsoft/azure/common/function/utils/FunctionUtils.java
+++ b/azure-tools-common/src/main/java/com/microsoft/azure/common/function/utils/FunctionUtils.java
@@ -47,7 +47,6 @@ public class FunctionUtils {
                 case 8:
                     return JavaVersion.JAVA_8_NEWEST;
                 case 11:
-                    Log.info("Using Java 11 (Preview) runtime.");
                     return JavaVersion.JAVA_11;
                 default:
                     Log.warn(String.format(UNSUPPORTED_JAVA_VERSION, version));


### PR DESCRIPTION
In #1343 , Java 11 is still GA so that I removed the dated console log.