### PR TITLE
hotfix: snapshot lib is used in springcloud:1.4.0:config

### DIFF
--- a/azure-maven-plugins-pom/pom.xml
+++ b/azure-maven-plugins-pom/pom.xml
@@ -47,7 +47,7 @@
         <azure.client.version>1.7.12</azure.client.version>
         <azure.eventhubs.version>1.2.0</azure.eventhubs.version>
         <azure.eventhubs-eph.version>2.0.1</azure.eventhubs-eph.version>
-        <azure.function.version>1.4.2-SNAPSHOT</azure.function.version>
+        <azure.function.version>1.4.2</azure.function.version>
         <azure.mgmt-insights.version>1.0.0-beta</azure.mgmt-insights.version>
         <azure.storage-blob.version>11.0.1</azure.storage-blob.version>
         <azure.version>1.38.1</azure.version>


### PR DESCRIPTION
[ERROR] Failed to execute goal com.microsoft.azure:azure-spring-cloud-maven-plugin:1.4.0:config (default-cli) on project spring-boot: Execution default-cli of goal com.microsoft.azure:azure-spring-cloud-maven-plugin:1.4.0:config failed: Plugin com.microsoft.azure:azure-spring-cloud-maven-plugin:1.4.0 or one of its dependencies could not be resolved: Could not find artifact com.microsoft.azure.functions:azure-functions-java-library:jar:1.4.2-SNAPSHOT in maven.snapshots (https://oss.sonatype.org/content/repositories/snapshots/) -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.