### PR TITLE
Missing AppSettigs for WebAppConfig

### DIFF
--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/AbstractConfigParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/AbstractConfigParser.java
@@ -93,6 +93,7 @@ public abstract class AbstractConfigParser {
                 .deploymentSlotName(getDeploymentSlotName())
                 .deploymentSlotConfigurationSource(getDeploymentSlotConfigurationSource())
                 .webAppArtifacts(getMavenArtifacts())
+                .appSettings(this.mojo.getAppSettings())
                 .build();
     }
 


### PR DESCRIPTION
The appSettings are not being passed to the WebAppConfig.  This results in no app settings available on:
 - DeployMojo#createWebApp
 - DeployMojo#updateWebApp

PR enables passing the pom.xml appSettings properties to the above methods.