### PR TITLE
Allow webapp deployment without updating pricing tier

### DIFF
--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/DeployMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/DeployMojo.java
@@ -119,8 +119,10 @@ public class DeployMojo extends AbstractWebAppMojo {
                 az.appServicePlan(getServicePlanResourceGroup(webAppConfig), webAppConfig.getServicePlanName());
         if (!targetServicePlan.exists()) {
             targetServicePlan = getOrCreateAppServicePlan(webAppConfig);
+        } else if (webAppConfig.getPricingTier() != null) {
+            targetServicePlan.update().withPricingTier(webAppConfig.getPricingTier()).commit();
         }
-        targetServicePlan.update().withPricingTier(webAppConfig.getPricingTier()).commit();
+
         final IWebApp result = webApp.update().withPlan(targetServicePlan.id())
                 .withRuntime(webAppConfig.getRuntime())
                 .withDockerConfiguration(webAppConfig.getDockerConfiguration())


### PR DESCRIPTION
Fixes #927, as well as a NullReferenceException that is thrown when deploying to an existing app if <pricingTier> is not specified.