### PR TITLE
Add new template for rabbit-mq trigger

### DIFF
--- a/azure-tools-common/src/main/resources/bindings.json
+++ b/azure-tools-common/src/main/resources/bindings.json
@@ -270,6 +270,31 @@
           "help": "$cosmosDBIn_createIfNotExists_help"
         }
       ]
+    },
+    {
+      "type": "rabbitMqTrigger",
+      "displayName": "$rabbitMqTrigger_displayName",
+      "direction": "trigger",
+      "enabledInTryMode": false,
+      "settings": [
+        {
+          "name": "connectionStringSetting",
+          "value": "string",
+          "defaultValue": "",
+          "resource": "RabbitMQ",
+          "required": true,
+          "label": "$rabbitMqIn_connectionStringSetting_label",
+          "help": "$rabbitMqIn_connectionStringSetting_help"
+        },
+        {
+          "name": "queueName",
+          "value": "string",
+          "defaultValue": "myqueue",
+          "required": true,
+          "label": "$rabbitMqIn_queueName_label",
+          "help": "$rabbitMqIn_queueName_help"
+        }
+      ]
     }
   ]
 }

--- a/azure-tools-common/src/main/resources/resources.json
+++ b/azure-tools-common/src/main/resources/resources.json
@@ -58,6 +58,12 @@
     "cosmosDBIn_leaseCollectionName_label": "Collection name for leases",
     "cosmosDBIn_leaseCollectionName_help": "Name of the collection to store the leases.",
     "cosmosDBIn_createIfNotExists_label": "Create lease collection if it does not exist",
-    "cosmosDBIn_createIfNotExists_help": "Checks for existence and automatically creates the leases collection."
+    "cosmosDBIn_createIfNotExists_help": "Checks for existence and automatically creates the leases collection.",
+    "RabbitMQTrigger_description" : "A function that will be run whenever a message is added to a specified RabbitMQ queue",
+    "rabbitMqTrigger_displayName" : "RabbitMQ",
+    "rabbitMqIn_connectionStringSetting_label" : "Connection string setting name",
+    "rabbitMqIn_connectionStringSetting_help" : "The name of the app setting containing your RabbitMQ connection.",
+    "rabbitMqIn_queueName_label" : "Queue name",
+    "rabbitMqIn_queueName_help" : "This is the queue name."
   }
 }

--- a/azure-tools-common/src/main/resources/templates.json
+++ b/azure-tools-common/src/main/resources/templates.json
@@ -258,6 +258,34 @@
       "files": {
         "function.java": "package $packageName$;\n\nimport com.microsoft.azure.functions.annotation.*;\nimport com.microsoft.azure.functions.*;\n\n/**\n * Azure Functions with Service Topic Trigger.\n */\npublic class $className$ {\n    /**\n     * This function will be invoked when a new message is received at the Service Bus Topic.\n     */\n    @FunctionName(\"$functionName$\")\n    public void run(\n        @ServiceBusTopicTrigger(\n            name = \"message\",\n            topicName = \"$topicName$\",\n            subscriptionName = \"$subscriptionName$\",\n            connection = \"$connection$\"\n        )\n        String message,\n        final ExecutionContext context\n    ) {\n        context.getLogger().info(\"Java Service Bus Topic trigger function executed.\");\n        context.getLogger().info(message);\n    }\n}"
       }
+    },
+    {
+      "id": "RabbitMQTrigger-Java",
+      "metadata": {
+        "name": "RabbitMQTrigger",
+        "description": "$RabbitMQTrigger_description",
+        "defaultFunctionName": "rabbitMQTriggerJava",
+        "language": "Java",
+        "userPrompt": [
+          "connectionStringSetting",
+          "queueName"
+        ]
+      },
+      "function": {
+        "disabled": false,
+        "bindings": [
+          {
+            "name": "myQueueItem",
+            "type": "rabbitMqTrigger",
+            "direction": "in",
+            "queueName": "",
+            "connectionStringSetting":""
+          }
+        ]
+      },
+      "files": {
+        "function.java": "package $packageName$;\n\nimport com.microsoft.azure.functions.ExecutionContext;\nimport com.microsoft.azure.functions.annotation.FunctionName;\nimport com.microsoft.azure.functions.rabbitmq.annotation.RabbitMQTrigger;\n\n/**\n * Azure Functions with RabbitMQ Trigger.\n *\n * This function will be invoked when a new message is received in RabbitMQ\n * Please add com.microsoft.azure.functions:azure-functions-java-library-rabbitmq to your project dependencies\n * You may get the example and latest version in https://search.maven.org/artifact/com.microsoft.azure.functions/azure-functions-java-library-rabbitmq\n * \n */\npublic class $className$ {\n    @FunctionName(\"$functionName$\")\n    public void run(\n            @RabbitMQTrigger(\n                    connectionStringSetting = \"$connectionStringSetting$\",\n                    queueName = \"$queueName$\"\n            ) String input,\n            final ExecutionContext context) {\n        context.getLogger().info(\"Java RabbitMQ trigger processed a request.\" + input);\n    }\n}"
+      }
     }
   ]
 }


### PR DESCRIPTION
Add RabbitMQ Trigger for `azure-functions:add`, for issue https://github.com/microsoft/azure-maven-plugins/issues/1197

``` java
package com.functions;

import com.microsoft.azure.functions.ExecutionContext;
import com.microsoft.azure.functions.annotation.FunctionName;
import com.microsoft.azure.functions.rabbitmq.annotation.RabbitMQTrigger;

/**
 * Azure Functions with RabbitMQ Trigger.
 *
 * This function will be invoked when a new message is received in RabbitMQ
 * Please add com.microsoft.azure.functions:azure-functions-java-library-rabbitmq to your project dependencies
 * You may get the example and latest version in https://search.maven.org/artifact/com.microsoft.azure.functions/azure-functions-java-library-rabbitmq
 * 
 */
public class RabbitMQTriggerJava {
    @FunctionName("RabbitMQTriggerJava")
    public void run(
            @RabbitMQTrigger(
                    connectionStringSetting = "RabbitMQSetting",
                    queueName = "test"
            ) String input,
            final ExecutionContext context) {
        context.getLogger().info("Java RabbitMQ trigger processed a request." + input);
    }
}
```