### PR TITLE
[Auth 1] class name adjustment for tenant token 

### DIFF
--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/auth/AzureAuthHelperLegacy.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/auth/AzureAuthHelperLegacy.java
@@ -35,8 +35,6 @@ import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.Scanner;
 
-
-
 /**
  * Helper class to authenticate with Azure
  */

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/SingleTenantCredential.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/SingleTenantCredential.java
@@ -8,22 +8,17 @@ package com.microsoft.azure.toolkit.lib.auth;
 import com.azure.core.credential.AccessToken;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.credential.TokenRequestContext;
-import com.azure.core.management.AzureEnvironment;
+import lombok.AllArgsConstructor;
+import lombok.Setter;
 import reactor.core.publisher.Mono;
 
-import java.util.Objects;
-
-public class DefaultTokenCredential extends BaseTokenCredential {
-    private TokenCredential onBehalfOf;
-
-    public DefaultTokenCredential(AzureEnvironment environment, TokenCredential onBehalfOf) {
-        super(environment);
-        Objects.requireNonNull(onBehalfOf, "Cannot create a DefaultTokenCredential from a null TokenCredential.");
-        this.onBehalfOf = onBehalfOf;
-    }
+@Setter
+@AllArgsConstructor
+public class SingleTenantCredential extends TenantCredential {
+    private TokenCredential credential;
 
     @Override
     protected Mono<AccessToken> getAccessToken(String tenantId, TokenRequestContext request) {
-        return onBehalfOf.getToken(request);
+        return credential.getToken(request);
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/TenantCredential.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/TenantCredential.java
@@ -15,11 +15,7 @@ import lombok.Setter;
 import reactor.core.publisher.Mono;
 
 @AllArgsConstructor
-public abstract class BaseTokenCredential implements TokenCredential {
-    @Setter
-    @Getter
-    private AzureEnvironment environment;
-
+public abstract class TenantCredential implements TokenCredential {
     @Override
     public Mono<AccessToken> getToken(TokenRequestContext request) {
         return getAccessToken(null, request);
@@ -27,7 +23,7 @@ public abstract class BaseTokenCredential implements TokenCredential {
 
     protected abstract Mono<AccessToken> getAccessToken(String tenantId, TokenRequestContext request);
 
-    public TokenCredential createTenantTokenCredential(String tenantId) {
+    public TokenCredential createTokenCredential(String tenantId) {
         return new CachedTokenCredential(request -> getAccessToken(tenantId, request));
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/core/azurecli/AzureCliAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/core/azurecli/AzureCliAccount.java
@@ -11,7 +11,6 @@ import com.microsoft.azure.toolkit.lib.auth.model.AuthMethod;
 import com.microsoft.azure.toolkit.lib.auth.model.AzureCliSubscription;
 import com.microsoft.azure.toolkit.lib.auth.util.AzureCliUtils;
 import com.microsoft.azure.toolkit.lib.common.model.Subscription;
-import lombok.Getter;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -45,9 +44,9 @@ public class AzureCliAccount extends Account {
 
         this.entity.setEmail(defaultSubscription.getEmail());
 
-        AzureCliTokenCredential azureCliCredential = new AzureCliTokenCredential(defaultSubscription.getEnvironment());
+        AzureCliTokenCredential azureCliCredential = new AzureCliTokenCredential();
 
-        verifyTokenCredential(azureCliCredential.getEnvironment(), azureCliCredential);
+        verifyTokenCredential(defaultSubscription.getEnvironment(), azureCliCredential);
 
         // use the tenant who has one or more subscriptions
         this.entity.setTenantIds(subscriptions.stream().map(Subscription::getTenantId).distinct().collect(Collectors.toList()));
@@ -56,7 +55,7 @@ public class AzureCliAccount extends Account {
         this.entity.setSelectedSubscriptionIds(subscriptions.stream().filter(Subscription::isSelected)
                 .map(Subscription::getId).distinct().collect(Collectors.toList()));
 
-        this.entity.setCredential(azureCliCredential);
+        this.entity.setTenantCredential(azureCliCredential);
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/core/azurecli/AzureCliTokenCredential.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/core/azurecli/AzureCliTokenCredential.java
@@ -10,7 +10,7 @@ import com.azure.core.credential.TokenRequestContext;
 import com.azure.core.management.AzureEnvironment;
 import com.azure.identity.implementation.util.ScopeUtil;
 import com.google.gson.JsonObject;
-import com.microsoft.azure.toolkit.lib.auth.BaseTokenCredential;
+import com.microsoft.azure.toolkit.lib.auth.TenantCredential;
 import com.microsoft.azure.toolkit.lib.auth.exception.AzureToolkitAuthenticationException;
 import com.microsoft.azure.toolkit.lib.auth.util.AzureCliUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -22,12 +22,8 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
-class AzureCliTokenCredential extends BaseTokenCredential {
+class AzureCliTokenCredential extends TenantCredential {
     private static final String CLI_GET_ACCESS_TOKEN_CMD = "az account get-access-token --resource %s %s --output json";
-
-    public AzureCliTokenCredential(AzureEnvironment environment) {
-        super(environment);
-    }
 
     public Mono<AccessToken> getAccessToken(String tenantId, TokenRequestContext request) {
         String scopes = ScopeUtil.scopesToResource(request.getScopes());

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/core/refresktoken/RefreshTokenAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/core/refresktoken/RefreshTokenAccount.java
@@ -14,7 +14,7 @@ import com.azure.identity.implementation.util.IdentityConstants;
 import com.azure.identity.implementation.util.ScopeUtil;
 import com.microsoft.aad.msal4j.IAuthenticationResult;
 import com.microsoft.azure.toolkit.lib.auth.Account;
-import com.microsoft.azure.toolkit.lib.auth.BaseTokenCredential;
+import com.microsoft.azure.toolkit.lib.auth.TenantCredential;
 import com.microsoft.azure.toolkit.lib.auth.exception.LoginFailureException;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
@@ -66,9 +66,9 @@ public abstract class RefreshTokenAccount extends Account {
     }
 
     private void initializeFromRefreshToken(String refreshToken) {
-        BaseTokenCredential refreshTokenCredential =
-                new RefreshTokenTokenCredential(environment, clientId, refreshToken);
-        entity.setCredential(refreshTokenCredential);
+        TenantCredential refreshTokenCredential =
+                new RefreshTokenTokenCredential(clientId, refreshToken);
+        entity.setTenantCredential(refreshTokenCredential);
     }
 
 }

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/core/refresktoken/RefreshTokenTokenCredential.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/core/refresktoken/RefreshTokenTokenCredential.java
@@ -9,20 +9,19 @@ import com.azure.core.credential.AccessToken;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.credential.TokenRequestContext;
 import com.azure.core.management.AzureEnvironment;
-import com.microsoft.azure.toolkit.lib.auth.BaseTokenCredential;
+import com.microsoft.azure.toolkit.lib.auth.TenantCredential;
 import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class RefreshTokenTokenCredential extends BaseTokenCredential {
+public class RefreshTokenTokenCredential extends TenantCredential {
     private final Map<String, TokenCredential> accessTokenCache = new ConcurrentHashMap<>();
     private String refreshToken;
     private String clientId;
 
-    public RefreshTokenTokenCredential(AzureEnvironment environment, String clientId, String refreshToken) {
-        super(environment);
+    public RefreshTokenTokenCredential(String clientId, String refreshToken) {
         this.clientId = clientId;
         this.refreshToken = refreshToken;
     }
@@ -32,7 +31,8 @@ public class RefreshTokenTokenCredential extends BaseTokenCredential {
         String key = StringUtils.firstNonBlank(tenantId, "$");
         if (!accessTokenCache.containsKey(key)) {
             accessTokenCache.put(key,
-                    RefreshTokenCredentialFactory.fromRefreshToken(this.getEnvironment(), clientId, tenantId, refreshToken));
+                    // TODO: hard coded env, will be fixed in future PR
+                    RefreshTokenCredentialFactory.fromRefreshToken(AzureEnvironment.AZURE, clientId, tenantId, refreshToken));
         }
         return accessTokenCache.get(key).getToken(context);
     }

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/core/serviceprincipal/ServicePrincipalAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/core/serviceprincipal/ServicePrincipalAccount.java
@@ -10,7 +10,7 @@ import com.azure.core.management.AzureEnvironment;
 import com.azure.identity.ClientCertificateCredentialBuilder;
 import com.azure.identity.ClientSecretCredentialBuilder;
 import com.microsoft.azure.toolkit.lib.auth.Account;
-import com.microsoft.azure.toolkit.lib.auth.DefaultTokenCredential;
+import com.microsoft.azure.toolkit.lib.auth.SingleTenantCredential;
 import com.microsoft.azure.toolkit.lib.auth.exception.LoginFailureException;
 import com.microsoft.azure.toolkit.lib.auth.model.AuthConfiguration;
 import com.microsoft.azure.toolkit.lib.auth.model.AuthMethod;
@@ -57,6 +57,6 @@ public class ServicePrincipalAccount extends Account {
     protected void initializeCredentials() throws LoginFailureException {
         this.entity.setEnvironment(ObjectUtils.firstNonNull(configuration.getEnvironment(), AzureEnvironment.AZURE));
         verifyTokenCredential(ObjectUtils.firstNonNull(configuration.getEnvironment(), AzureEnvironment.AZURE), clientSecretCredential);
-        this.entity.setCredential(new DefaultTokenCredential(this.entity.getEnvironment(), clientSecretCredential));
+        this.entity.setTenantCredential(new SingleTenantCredential(clientSecretCredential));
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/model/AccountEntity.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/model/AccountEntity.java
@@ -6,7 +6,7 @@
 package com.microsoft.azure.toolkit.lib.auth.model;
 
 import com.azure.core.management.AzureEnvironment;
-import com.microsoft.azure.toolkit.lib.auth.BaseTokenCredential;
+import com.microsoft.azure.toolkit.lib.auth.TenantCredential;
 import com.microsoft.azure.toolkit.lib.common.model.Subscription;
 import lombok.Getter;
 import lombok.Setter;
@@ -35,5 +35,5 @@ public class AccountEntity {
 
     private Throwable lastError;
 
-    private BaseTokenCredential credential;
+    private TenantCredential tenantCredential;
 }


### PR DESCRIPTION
1. rename BaseTokenCredential to TenantCredential
2. remove env from credential
3. rename DefaultTokenCredential to SingleTenantCredential