### PR TITLE
bug: weird error dialog shown after refreshing springcloud service node

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/task/AzureTaskContext.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/task/AzureTaskContext.java
@@ -83,6 +83,11 @@ public class AzureTaskContext {
                 AzureTaskContext.current().pushOperation(task);
             });
             runnable.run();
+            Optional.ofNullable(context.getTask()).ifPresent(task -> {
+                final IAzureOperation popped = AzureTaskContext.current().popOperation();
+                AzureTelemeter.afterExit(task);
+                assert Objects.equals(task, popped) : String.format("popped op[%s] is not the exiting async task[%s]", popped, task);
+            });
         } catch (final Throwable throwable) {
             AzureExceptionHandler.onRxException(throwable);
             Optional.ofNullable(context.getTask()).ifPresent(task -> {
@@ -91,11 +96,6 @@ public class AzureTaskContext {
                 assert Objects.equals(task, popped) : String.format("popped op[%s] is not the task[%s] throwing exception", popped, task);
             });
         } finally {
-            Optional.ofNullable(context.getTask()).ifPresent(task -> {
-                final IAzureOperation popped = AzureTaskContext.current().popOperation();
-                AzureTelemeter.afterExit(task);
-                assert Objects.equals(task, popped) : String.format("popped op[%s] is not the exiting async task[%s]", popped, task);
-            });
             context.dispose();
         }
     }


### PR DESCRIPTION
because: operation is exited twice from both the catch and finaly block.