### PR TITLE
Fix resource id parser in `WebAppDeploymentSlot`

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/WebApp.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/WebApp.java
@@ -101,16 +101,6 @@ public class WebApp extends AbstractAppService<com.azure.resourcemanager.appserv
             .collect(Collectors.toList());
     }
 
-    @Override
-    public String id() {
-        return getRemoteResource().id();
-    }
-
-    @Override
-    public String name() {
-        return getRemoteResource().name();
-    }
-
     public class WebAppCreator extends AbstractAppServiceCreator<WebApp> {
         // todo: Add validation for required parameters
         @Override

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/WebAppDeploymentSlot.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/WebAppDeploymentSlot.java
@@ -10,6 +10,7 @@ import com.azure.resourcemanager.appservice.models.DeployOptions;
 import com.azure.resourcemanager.appservice.models.DeploymentSlot;
 import com.azure.resourcemanager.appservice.models.DeploymentSlotBase;
 import com.azure.resourcemanager.appservice.models.WebApp;
+import com.microsoft.azure.arm.resources.ResourceId;
 import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.appservice.AzureAppService;
 import com.microsoft.azure.toolkit.lib.appservice.entity.WebAppDeploymentSlotEntity;
@@ -84,7 +85,7 @@ public class WebAppDeploymentSlot extends AbstractAppService<DeploymentSlot> imp
 
     private WebApp getParentWebApp() {
         return StringUtils.isNotEmpty(entity.getId()) ?
-                azureClient.webApps().getById(entity.getId().substring(0, entity.getId().indexOf("/slots"))) :
+                azureClient.webApps().getById(ResourceId.fromString(entity().getId()).parent().id()) :
                 azureClient.webApps().getByResourceGroup(entity.getResourceGroup(), entity.getWebappName());
     }
 


### PR DESCRIPTION
- Using `ResourceId` as id parser instead of `String.indexOf` in case resources with specific prefix
- Remove duplicated codes