### PR TITLE
Task 1849630: support 'p1v3' in config

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/Runtime.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/Runtime.java
@@ -28,6 +28,8 @@ public class Runtime {
     public static final Runtime LINUX_JAVA11 = new Runtime(OperatingSystem.LINUX, WebContainer.JAVA_SE, JavaVersion.JAVA_11);
     public static final Runtime LINUX_JAVA8_TOMCAT9 = new Runtime(OperatingSystem.LINUX, WebContainer.TOMCAT_9, JavaVersion.JAVA_8);
     public static final Runtime LINUX_JAVA8_TOMCAT85 = new Runtime(OperatingSystem.LINUX, WebContainer.TOMCAT_85, JavaVersion.JAVA_8);
+    public static final Runtime LINUX_JAVA8_JBOSS7 = new Runtime(OperatingSystem.LINUX, WebContainer.JBOSS_7, JavaVersion.JAVA_8);
+    public static final Runtime LINUX_JAVA11_JBOSS7 = new Runtime(OperatingSystem.LINUX, WebContainer.JBOSS_7, JavaVersion.JAVA_11);
     public static final Runtime LINUX_JAVA8_JBOSS72 = new Runtime(OperatingSystem.LINUX, WebContainer.JBOSS_72, JavaVersion.JAVA_8);
     public static final Runtime LINUX_JAVA11_TOMCAT9 = new Runtime(OperatingSystem.LINUX, WebContainer.TOMCAT_9, JavaVersion.JAVA_11);
     public static final Runtime LINUX_JAVA11_TOMCAT85 = new Runtime(OperatingSystem.LINUX, WebContainer.TOMCAT_85, JavaVersion.JAVA_11);
@@ -41,7 +43,7 @@ public class Runtime {
 
     private static final List<Runtime> values = Collections.unmodifiableList(Arrays.asList(WINDOWS_JAVA8, WINDOWS_JAVA11, WINDOWS_JAVA8_TOMCAT9,
         WINDOWS_JAVA8_TOMCAT85, WINDOWS_JAVA11_TOMCAT9, WINDOWS_JAVA11_TOMCAT85, LINUX_JAVA8, LINUX_JAVA11, LINUX_JAVA8_TOMCAT9, LINUX_JAVA8_TOMCAT85,
-        LINUX_JAVA8_JBOSS72, LINUX_JAVA11_TOMCAT9, LINUX_JAVA11_TOMCAT85));
+        LINUX_JAVA8_JBOSS72, LINUX_JAVA11_JBOSS7, LINUX_JAVA8_JBOSS7, LINUX_JAVA11_TOMCAT9, LINUX_JAVA11_TOMCAT85));
 
     private final OperatingSystem operatingSystem;
     private final WebContainer webContainer;

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/WebContainer.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/WebContainer.java
@@ -27,6 +27,7 @@ public class WebContainer {
     public static final WebContainer TOMCAT_8 = new WebContainer("tomcat 8.0");
     public static final WebContainer TOMCAT_85 = new WebContainer("tomcat 8.5");
     public static final WebContainer TOMCAT_9 = new WebContainer("tomcat 9.0");
+    public static final WebContainer JBOSS_7 = new WebContainer("JBOSSEAP 7");
     public static final WebContainer JBOSS_72 = new WebContainer("JBOSSEAP 7.2");
 
     public static final WebContainer TOMCAT_7_0_50 = new WebContainer("tomcat 7.0.50");
@@ -48,7 +49,7 @@ public class WebContainer {
 
     private static final List<WebContainer> values = Collections.unmodifiableList(Arrays.asList(TOMCAT_7, TOMCAT_7_0_50, TOMCAT_7_0_62, TOMCAT_8,
         TOMCAT_8_0_23, TOMCAT_85, TOMCAT_8_5_6, TOMCAT_8_5_20, TOMCAT_8_5_31, TOMCAT_8_5_34, TOMCAT_8_5_37, TOMCAT_9, TOMCAT_9_0_0, TOMCAT_9_0_8,
-        TOMCAT_9_0_12, TOMCAT_9_0_14, JETTY_9_1_NEWEST, JETTY_9_1_V20131115, JETTY_9_3_NEWEST, JETTY_9_3_V20161014, JAVA_SE, JBOSS_72));
+        TOMCAT_9_0_12, TOMCAT_9_0_14, JETTY_9_1_NEWEST, JETTY_9_1_V20131115, JETTY_9_3_NEWEST, JETTY_9_3_V20161014, JAVA_SE, JBOSS_72, JBOSS_7));
 
     private final String value;
 

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/appservice/AppServiceUtils.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/appservice/AppServiceUtils.java
@@ -39,6 +39,10 @@ public class AppServiceUtils {
                 }
             }
         }
+
+        pricingTiers.add(new PricingTier("PremiumV3", "P1v3"));
+        pricingTiers.add(new PricingTier("PremiumV3", "P2v3"));
+        pricingTiers.add(new PricingTier("PremiumV3", "P3v3"));
     }
 
     public static AppServicePlan getAppServicePlan(final String servicePlanName, final Azure azureClient,

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/WebAppConfiguration.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/WebAppConfiguration.java
@@ -24,13 +24,14 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.shared.filtering.MavenResourcesFiltering;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Objects;
 
 public class WebAppConfiguration {
-
-    public static final Region DEFAULT_REGION = Region.EUROPE_WEST;
+    public static final PricingTier DEFAULT_JBOSS_PRICING_TIER = new PricingTier("PremiumV3", "P1v3");
     public static final PricingTier DEFAULT_PRICINGTIER = PricingTier.PREMIUM_P1V2;
+    public static final Region DEFAULT_REGION = Region.EUROPE_WEST;
     public static final JavaVersion DEFAULT_WINDOWS_JAVA_VERSION = JavaVersion.JAVA_8_NEWEST;
     public static final WebContainer DEFAULT_WINDOWS_WEB_CONTAINER = WebContainer.TOMCAT_8_5_NEWEST;
     public static final String DEFAULT_LINUX_JAVA_VERSION = JavaVersionEnum.JAVA_8.toString();
@@ -213,8 +214,8 @@ public class WebAppConfiguration {
         return region != null ? region.toString() : DEFAULT_REGION.toString();
     }
 
-    public String getPricingTierOrDefault() {
-        return AppServiceUtils.convertPricingTierToString(pricingTier != null ? pricingTier : DEFAULT_PRICINGTIER);
+    public String getPricingTierOrDefault(@Nonnull PricingTier defaultPricingTier) {
+        return AppServiceUtils.convertPricingTierToString(pricingTier != null ? pricingTier : defaultPricingTier);
     }
 
     public String getLinuxJavaVersionOrDefault() {


### PR DESCRIPTION
[AB#1849630](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1849630)

1.	config will add p1v3, p2v3 and p3v3 pricing tier
2.	config will support to choose jbosseap runtime for both java versions: 8 and 11(keep the same with portal)
3.	config will also change to sequence to:
      a.	Subscription
      b.	OS
      c.	Java Version
      d.	Runtime Stack
      e.	Pricing Tier
4.	During above steps,  when user has selected jboss runtime, only P*v3 pricing tiers will be listed for him.
