### PR TITLE
[Task 1855218] Erase pii data from telemetry

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemetryClient.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemetryClient.java
@@ -18,9 +18,17 @@ import java.util.regex.Pattern;
 
 @Getter
 public class AzureTelemetryClient {
-
-    public static final String CONFIGURATION_FILE = "ApplicationInsights.xml";
-    public static final Pattern INSTRUMENTATION_KEY_PATTERN = Pattern.compile("<InstrumentationKey>(.*)</InstrumentationKey>");
+    // refers https://github.com/microsoft/vscode-extension-telemetry/blob/main/src/telemetryReporter.ts
+    private static final String FILE_PATH_REGEX =
+            "(file://)?([a-zA-Z]:(\\\\\\\\|\\\\|/)|(\\\\\\\\|\\\\|/))?([\\w-._]+(\\\\\\\\|\\\\|/))+[\\w-._]*";
+    private static final Pattern FILE_PATH_PATTERN = Pattern.compile(FILE_PATH_REGEX);
+    // refers https://stackoverflow.com/questions/201323/how-can-i-validate-an-email-address-using-a-regular-expression
+    private static final String EMAIL_REGEX = "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"" +
+            "(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@" +
+            "(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}" +
+            "(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:" +
+            "(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)])";
+    private static final Pattern EMAIL_PATTERN = Pattern.compile(EMAIL_REGEX);
 
     private final TelemetryClient client;
     @Setter
@@ -70,7 +78,7 @@ public class AzureTelemetryClient {
         }
 
         final Map<String, String> properties = mergeProperties(getDefaultProperties(), customProperties, overrideDefaultProperties);
-
+        anonymizePersonallyIdentifiableInformation(properties);
         client.trackEvent(eventName, properties, metrics);
         client.flush();
     }
@@ -92,5 +100,12 @@ public class AzureTelemetryClient {
         }
         merged.entrySet().removeIf(stringStringEntry -> StringUtils.isEmpty(stringStringEntry.getValue()));
         return merged;
+    }
+
+    private void anonymizePersonallyIdentifiableInformation(final Map<String, String> properties) {
+        properties.replaceAll((key, value) -> {
+            final String input = FILE_PATH_PATTERN.matcher(value).replaceAll("<REDACTED: user-file-path>");
+            return EMAIL_PATTERN.matcher(input).replaceAll("<REDACTED: user-email-address>>");
+        });
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemetryClient.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemetryClient.java
@@ -105,7 +105,7 @@ public class AzureTelemetryClient {
     private void anonymizePersonallyIdentifiableInformation(final Map<String, String> properties) {
         properties.replaceAll((key, value) -> {
             final String input = FILE_PATH_PATTERN.matcher(value).replaceAll("<REDACTED: user-file-path>");
-            return EMAIL_PATTERN.matcher(input).replaceAll("<REDACTED: user-email-address>>");
+            return EMAIL_PATTERN.matcher(input).replaceAll("<REDACTED: user-email-address>");
         });
     }
 }


### PR DESCRIPTION
Erase pii data from telemetry, [AB#1855218](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1855218)
- For file path, refers file path pattern from https://github.com/microsoft/vscode-extension-telemetry/blob/main/src/telemetryReporter.ts#L188
- For email pattern, refers https://stackoverflow.com/questions/201323/how-can-i-validate-an-email-address-using-a-regular-expression, using the complex one could handle more cases with better perf for longer input

**Known issues**
- module name in error stack may be recognize as path and erased
    `at java.base/java.io.FileInputStream.open0(Native Method)` => `at <REDACTED: user-file-path>(Native Method)`