### PR TITLE
Enhance prompt for web app configuration validator

### DIFF
--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
@@ -136,7 +136,11 @@ public class DeployMojo extends AbstractFunctionMojo {
     private static final String INVALID_OS = "The value of <os> is not correct, supported values are: windows, linux and docker.";
     private static final String FAILED_TO_LIST_TRIGGERS = "Deployment succeeded, but failed to list http trigger urls.";
     private static final String SKIP_DEPLOYMENT_FOR_DOCKER_APP_SERVICE = "Skip deployment for docker app service";
-    private static final String EXPANDABLE_PARAMETER_WARNING = "'%s' may not be a valid %s";
+    private static final String EXPANDABLE_PRICING_TIER_WARNING = "'%s' may not be a valid pricing tier, " +
+            "please refer https://aka.ms/maven_function_configuration#supported-pricing-tiers for valid values";
+    private static final String EXPANDABLE_REGION_WARNING = "'%s' may not be a valid region, " +
+            "please refer https://aka.ms/maven_function_configuration#supported-regions for valid values";
+    private static final String EXPANDABLE_JAVA_VERSION_WARNING = "'%s' may not be a valid java version, recommended values are `Java 8` and `Java 11`";
 
     private AzureAppService az;
 
@@ -195,8 +199,7 @@ public class DeployMojo extends AbstractFunctionMojo {
         }
         // region
         if (StringUtils.isNotEmpty(region) && Region.fromName(region).isExpandedValue()) {
-            AzureMessager.getMessager().warning(String.format(EXPANDABLE_PARAMETER_WARNING, region, Region.class.getSimpleName()));
-
+            AzureMessager.getMessager().warning(String.format(EXPANDABLE_REGION_WARNING, region));
         }
         // os
         if (StringUtils.isNotEmpty(runtime.getOs()) && OperatingSystem.fromString(runtime.getOs()) == null) {
@@ -204,11 +207,11 @@ public class DeployMojo extends AbstractFunctionMojo {
         }
         // java version
         if (StringUtils.isNotEmpty(runtime.getJavaVersion()) && JavaVersion.fromString(runtime.getJavaVersion()).isExpandedValue()) {
-            AzureMessager.getMessager().warning(String.format(EXPANDABLE_PARAMETER_WARNING, runtime.getJavaVersion(), JavaVersion.class.getSimpleName()));
+            AzureMessager.getMessager().warning(String.format(EXPANDABLE_JAVA_VERSION_WARNING, runtime.getJavaVersion()));
         }
         // pricing tier
         if (StringUtils.isNotEmpty(pricingTier) && PricingTier.fromString(pricingTier).isExpandedValue()) {
-            AzureMessager.getMessager().warning(String.format(EXPANDABLE_PARAMETER_WARNING, pricingTier, PricingTier.class.getSimpleName()));
+            AzureMessager.getMessager().warning(String.format(EXPANDABLE_PRICING_TIER_WARNING, pricingTier));
         }
         // docker image
         if (OperatingSystem.fromString(runtime.getOs()) == OperatingSystem.DOCKER && StringUtils.isEmpty(runtime.getImage())) {

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/JavaVersion.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/JavaVersion.java
@@ -95,7 +95,7 @@ public class JavaVersion implements ExpandableParameter {
         if (!(o instanceof JavaVersion)) {
             return false;
         }
-        // users may get javaVersion by setTier/Size, which will skip the parse step in fromString, so compare the parsed value in equals
+        // users may get javaVersion by setValue, which will skip the parse step in fromString, so compare the parsed value in equals
         // todo: update the implement once we find solution to serialize parameters without public setter/constructor
         final JavaVersion current = JavaVersion.fromString(value);
         final JavaVersion toCompare = JavaVersion.fromString(((JavaVersion) o).value);

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/ConfigParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/ConfigParser.java
@@ -186,7 +186,7 @@ public class ConfigParser {
         return builder.appName(getAppName())
                 .resourceGroup(getResourceGroup())
                 .region(getRegion())
-                .pricingTier(mojo.getPricingTier())
+                .pricingTier(getPricingTier().getSize())
                 .servicePlanName(mojo.getAppServicePlanName())
                 .servicePlanResourceGroup(mojo.getAppServicePlanResourceGroup())
                 .deploymentSlotSetting(mojo.getDeploymentSlotSetting())

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/ConfigParser.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/parser/ConfigParser.java
@@ -45,6 +45,14 @@ import java.util.stream.Collectors;
 
 public class ConfigParser {
 
+    private static final String EXPANDABLE_PRICING_TIER_WARNING = "'%s' may not be a valid pricing tier, " +
+            "please refer https://aka.ms/maven_webapp_runtime#pricingtier for valid values";
+    private static final String EXPANDABLE_REGION_WARNING = "'%s' may not be a valid region, " +
+            "please refer https://aka.ms/maven_webapp_runtime#region for valid values";
+    private static final String EXPANDABLE_WEB_CONTAINER_WARNING = "'%s' may not be a valid web container, " +
+            "please refer https://aka.ms/maven_webapp_runtime#webcontainer for valid values";
+    private static final String EXPANDABLE_JAVA_VERSION_WARNING = "'%s' may not be a valid java version, recommended values are `Java 8` and `Java 11`";
+
     protected AbstractWebAppMojo mojo;
 
     public ConfigParser(AbstractWebAppMojo mojo) {
@@ -75,7 +83,7 @@ public class ConfigParser {
             } else {
                 return PricingTier.fromString(mojo.getPricingTier());
             }
-        }, mojo.getPricingTier());
+        }, mojo.getPricingTier(), EXPANDABLE_PRICING_TIER_WARNING);
     }
 
     public String getAppServicePlanName() {
@@ -91,7 +99,7 @@ public class ConfigParser {
     }
 
     public Region getRegion() {
-        return parseExpandableParameter(Region::fromName, mojo.getRegion());
+        return parseExpandableParameter(Region::fromName, mojo.getRegion(), EXPANDABLE_REGION_WARNING);
     }
 
     public DockerConfiguration getDockerConfiguration() throws AzureExecutionException {
@@ -127,8 +135,8 @@ public class ConfigParser {
         if (os == OperatingSystem.DOCKER) {
             return Runtime.DOCKER;
         }
-        final JavaVersion javaVersion = parseExpandableParameter(JavaVersion::fromString, runtime.getJavaVersion());
-        final WebContainer webContainer = parseExpandableParameter(WebContainer::fromString, runtime.getWebContainer());
+        final JavaVersion javaVersion = parseExpandableParameter(JavaVersion::fromString, runtime.getJavaVersion(), EXPANDABLE_JAVA_VERSION_WARNING);
+        final WebContainer webContainer = parseExpandableParameter(WebContainer::fromString, runtime.getWebContainer(), EXPANDABLE_WEB_CONTAINER_WARNING);
         return Runtime.getRuntime(os, webContainer, javaVersion);
     }
 
@@ -210,10 +218,10 @@ public class ConfigParser {
         }
     }
 
-    private static <T extends ExpandableParameter> T parseExpandableParameter(Function<String, T> parser, String input) {
+    private static <T extends ExpandableParameter> T parseExpandableParameter(Function<String, T> parser, String input, String prompt) {
         final T result = parser.apply(input);
         if (StringUtils.isNotEmpty(input) && result.isExpandedValue()) {
-            AzureMessager.getMessager().warning(String.format("'%s' may not be a valid %s", input, result.getClass().getSimpleName()));
+            AzureMessager.getMessager().warning(String.format(prompt, input));
         }
         return result;
     }

--- a/azure-webapp-maven-plugin/src/main/resources/schema/WebAppConfiguration.json
+++ b/azure-webapp-maven-plugin/src/main/resources/schema/WebAppConfiguration.json
@@ -119,7 +119,8 @@
           "$ref": "#/definitions/non-empty-string"
         },
         "registryUrl": {
-          "$ref": "#/definitions/non-empty-string"
+          "type": "string",
+          "pattern": "^https.*"
         }
       },
       "dependencies": {


### PR DESCRIPTION
- Add valid values to expandale parameter warning message
- Show validation message for pricing tier in `webapp:config`
- Restrict registry url to start with https in web app configuration schema, refers https://docs.microsoft.com/en-us/azure/app-service/tutorial-custom-container?pivots=container-linux
- Fix comment for `JavaVersion.equals`