### PR TITLE
[Task 1855222] Deprecate old error stack properties and migrate to new one

### DIFF
--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -92,6 +92,7 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
     private static final String AZURE_INIT_FAIL = "Failed to authenticate with Azure. Please check your configuration.";
     private static final String ERROR_MESSAGE = "error.message";
     private static final String ERROR_STACK = "error.stack";
+    private static final String ERROR_CLASSNAME = "error.className";
     private static final String JVM_UP_TIME = "jvmUpTime";
     private static final String CONFIGURATION_PATH = Paths.get(System.getProperty("user.home"),
             ".azure", "mavenplugins.properties").toString();
@@ -529,6 +530,8 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
         final Map<String, String> failureParameters = new HashMap<>();
         failureParameters.put(ERROR_MESSAGE, throwable.getMessage());
         failureParameters.put(ERROR_STACK, ExceptionUtils.getStackTrace(throwable));
+        failureParameters.put(ERROR_CLASSNAME, throwable.getClass().getName());
+
         telemetryProxy.trackEvent(this.getClass().getSimpleName() + ".failure", recordJvmUpTime(failureParameters));
     }
 

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -31,8 +31,8 @@ import com.microsoft.azure.toolkit.lib.common.logging.Log;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.model.Subscription;
 import com.microsoft.azure.toolkit.lib.common.proxy.ProxyManager;
-import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemetryClient;
 import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemeter;
+import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemetryClient;
 import com.microsoft.azure.toolkit.lib.common.utils.InstallationIdUtils;
 import com.microsoft.azure.toolkit.lib.common.utils.TextUtils;
 import com.microsoft.azure.toolkit.maven.common.messager.MavenAzureMessager;
@@ -481,9 +481,6 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
                 afterMojoExecution();
             }
         } catch (Exception e) {
-            if (e instanceof AzureToolkitAuthenticationException) {
-                throw new MojoExecutionException(String.format("Cannot authenticate due to error: %s", e.getMessage()), e);
-            }
             onMojoError(e);
         } finally {
             // When maven goal executes too quick, The HTTPClient of AI SDK may not fully initialized and will step

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -92,7 +92,7 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
     private static final String AZURE_INIT_FAIL = "Failed to authenticate with Azure. Please check your configuration.";
     private static final String ERROR_MESSAGE = "error.message";
     private static final String ERROR_STACK = "error.stack";
-    private static final String ERROR_CLASSNAME = "error.className";
+    private static final String ERROR_CLASSNAME = "error.class_name";
     private static final String JVM_UP_TIME = "jvmUpTime";
     private static final String CONFIGURATION_PATH = Paths.get(System.getProperty("user.home"),
             ".azure", "mavenplugins.properties").toString();

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -40,6 +40,7 @@ import lombok.Getter;
 import lombok.SneakyThrows;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -89,7 +90,8 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
     private static final String TELEMETRY_NOT_ALLOWED = "TelemetryNotAllowed";
     private static final String INIT_FAILURE = "InitFailure";
     private static final String AZURE_INIT_FAIL = "Failed to authenticate with Azure. Please check your configuration.";
-    private static final String FAILURE_REASON = "failureReason";
+    private static final String ERROR_MESSAGE = "error.message";
+    private static final String ERROR_STACK = "error.stack";
     private static final String JVM_UP_TIME = "jvmUpTime";
     private static final String CONFIGURATION_PATH = Paths.get(System.getProperty("user.home"),
             ".azure", "mavenplugins.properties").toString();
@@ -523,9 +525,10 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
         telemetryProxy.trackEvent(this.getClass().getSimpleName() + ".success", recordJvmUpTime(new HashMap<>()));
     }
 
-    protected void trackMojoFailure(final String message) {
+    protected void trackMojoFailure(final Throwable throwable) {
         final Map<String, String> failureParameters = new HashMap<>();
-        failureParameters.put(FAILURE_REASON, message);
+        failureParameters.put(ERROR_MESSAGE, throwable.getMessage());
+        failureParameters.put(ERROR_STACK, ExceptionUtils.getStackTrace(throwable));
         telemetryProxy.trackEvent(this.getClass().getSimpleName() + ".failure", recordJvmUpTime(failureParameters));
     }
 
@@ -534,12 +537,9 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
     }
 
     protected void onMojoError(final Exception exception) throws MojoExecutionException {
-        String message = exception.getMessage();
-        if (StringUtils.isEmpty(message)) {
-            message = exception.toString();
-        }
-        trackMojoFailure(message);
+        trackMojoFailure(exception);
 
+        final String message = StringUtils.isEmpty(exception.getMessage()) ? exception.toString() : exception.getMessage();
         if (isFailsOnError()) {
             throw new MojoExecutionException(message, exception);
         } else {

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemeter.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemeter.java
@@ -34,7 +34,7 @@ public class AzureTelemeter {
     private static final String ERROR_CODE = "error.code";
     private static final String ERROR_MSG = "error.message";
     private static final String ERROR_TYPE = "error.type";
-    private static final String ERROR_CLASSNAME = "error.className";
+    private static final String ERROR_CLASSNAME = "error.class_name";
     private static final String ERROR_STACKTRACE = "error.stack";
     @Getter
     @Setter

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemeter.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemeter.java
@@ -31,10 +31,10 @@ public class AzureTelemeter {
     private static final String OP_TYPE = "op_type";
     private static final String OP_PARENT_ID = "op_parentId";
 
-    private static final String ERROR_CODE = "errorCode";
+    private static final String ERROR_CODE = "error.code";
     private static final String ERROR_MSG = "error.message";
-    private static final String ERROR_TYPE = "errorType";
-    private static final String ERROR_CLASSNAME = "errorClassName";
+    private static final String ERROR_TYPE = "error.type";
+    private static final String ERROR_CLASSNAME = "error.className";
     private static final String ERROR_STACKTRACE = "error.stack";
     @Getter
     @Setter

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemeter.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemeter.java
@@ -32,10 +32,10 @@ public class AzureTelemeter {
     private static final String OP_PARENT_ID = "op_parentId";
 
     private static final String ERROR_CODE = "errorCode";
-    private static final String ERROR_MSG = "message";
+    private static final String ERROR_MSG = "error.message";
     private static final String ERROR_TYPE = "errorType";
     private static final String ERROR_CLASSNAME = "errorClassName";
-    private static final String ERROR_STACKTRACE = "errorStackTrace";
+    private static final String ERROR_STACKTRACE = "error.stack";
     @Getter
     @Setter
     @Nullable


### PR DESCRIPTION
Deprecate `failureReason` in maven plugin, replace with `error.message` and `error.stack`, [AB#1855222](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1855222)
- `errorMessage` in spring cloud maven plugin has been removed in https://github.com/microsoft/azure-maven-plugins/pull/1486/files
- `invalidConfiguration` in webapp maven plugin has been removed in https://github.com/microsoft/azure-maven-plugins/pull/1628/files
