### PR TITLE
Fix runtime parser for app service

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/JavaVersion.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/JavaVersion.java
@@ -22,14 +22,11 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 public class JavaVersion implements ExpandableParameter {
-    private static final String JAVA_7_VALUE = "Java 7";
-    private static final String JAVA_7_VALUE_TRIM = "Java7";
-    private static final String JAVA_8_VALUE = "Java 8";
-    private static final String JAVA_8_SIMPLE_VALUE = "8";
-    private static final String JAVA_8_VALUE_TRIM = "Java8";
-    private static final String JAVA_11_VALUE = "Java 11";
-    private static final String JAVA_11_SIMPLE_VALUE = "11";
-    private static final String JAVA_11_VALUE_TRIM = "Java11";
+    private static final String JAVA_7_VALUE = "7";
+    private static final String JAVA_7_DISPLAY_NAME = "Java 7";
+    private static final String JAVA_8_VALUE = "8";
+    private static final String JAVA_8_DISPLAY_NAME = "Java 8";
+    private static final String JAVA_11_DISPLAY_NAME = "Java 11";
 
     public static final JavaVersion OFF = new JavaVersion("<null>");
     public static final JavaVersion JAVA_7 = new JavaVersion("1.7");
@@ -69,18 +66,14 @@ public class JavaVersion implements ExpandableParameter {
         if (StringUtils.isEmpty(input)) {
             return JavaVersion.OFF;
         }
-
-        final String version = StringUtils.lowerCase(input).replaceFirst("jre", "java");
-
-        // parse display name first
-        if (StringUtils.equalsAnyIgnoreCase(version, JAVA_7_VALUE, JAVA_7_VALUE_TRIM)) {
+        // remove java, jre prefix
+        final String version = StringUtils.lowerCase(input).replaceFirst("java|jre", "").trim();
+        // handle java 7/ java 8 cases
+        if (StringUtils.equalsIgnoreCase(version, JAVA_7_VALUE)) {
             return JavaVersion.JAVA_7;
         }
-        if (StringUtils.equalsAnyIgnoreCase(version, JAVA_8_VALUE, JAVA_8_VALUE_TRIM, JAVA_8_SIMPLE_VALUE)) {
+        if (StringUtils.equalsIgnoreCase(version, JAVA_8_VALUE)) {
             return JavaVersion.JAVA_8;
-        }
-        if (StringUtils.equalsAnyIgnoreCase(version, JAVA_11_VALUE, JAVA_11_VALUE_TRIM, JAVA_11_SIMPLE_VALUE)) {
-            return JavaVersion.JAVA_11;
         }
         return values().stream()
                 .filter(javaVersion -> StringUtils.equalsIgnoreCase(version, javaVersion.getValue()))
@@ -110,13 +103,13 @@ public class JavaVersion implements ExpandableParameter {
     @Override
     public String toString() {
         if (this.equals(JAVA_7)) {
-            return JAVA_7_VALUE;
+            return JAVA_7_DISPLAY_NAME;
         }
         if (this.equals(JAVA_8)) {
-            return JAVA_8_VALUE;
+            return JAVA_8_DISPLAY_NAME;
         }
         if (this.equals(JAVA_11)) {
-            return JAVA_11_VALUE;
+            return JAVA_11_DISPLAY_NAME;
         }
         return this.value;
     }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/WebContainer.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/WebContainer.java
@@ -23,6 +23,7 @@ import java.util.Set;
 @AllArgsConstructor
 public class WebContainer implements ExpandableParameter {
     private static final String JAVA = "Java";
+    private static final String JAVA_7 = "Java 7";
     private static final String JAVA_8 = "Java 8";
     private static final String JAVA_11 = "Java 11";
     private static final String STRING_JAVA_SE = "Java SE";
@@ -68,7 +69,7 @@ public class WebContainer implements ExpandableParameter {
         if (StringUtils.isEmpty(input)) {
             return WebContainer.JAVA_OFF;
         }
-        if (StringUtils.equalsAnyIgnoreCase(input, JAVA, JAVA_8, JAVA_11)) {
+        if (StringUtils.equalsAnyIgnoreCase(input, JAVA, JAVA_7, JAVA_8, JAVA_11, STRING_JAVA_SE)) {
             return WebContainer.JAVA_SE;
         }
         return values().stream()

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/AppServiceUtils.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/AppServiceUtils.java
@@ -107,7 +107,7 @@ class AppServiceUtils {
 
     static String getJavaVersionValueForJavaSERuntimeStack(@Nonnull JavaVersion javaVersion) {
         // Java SE with minor version runtime stack follow pattern JAVA|VERSION, like JAVA|11.0.9, JAVA|8u25
-        return javaVersion.getValue().replaceAll("java|jre", "").trim();
+        return javaVersion.getValue().replaceAll("(?i)java|jre", "").trim();
     }
 
     static String getJavaVersionValueForContainerRuntimeStack(@Nonnull JavaVersion javaVersion) {

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/FunctionApp.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/FunctionApp.java
@@ -188,7 +188,7 @@ public class FunctionApp extends FunctionAppBase<com.azure.resourcemanager.appse
                                             Runtime runtime) {
             return (WithCreate) blank.withExistingAppServicePlan(appServicePlan)
                     .withExistingResourceGroup(resourceGroup)
-                    .withJavaVersion(AppServiceUtils.toJavaVersion(runtime))
+                    .withJavaVersion(AppServiceUtils.toJavaVersion(runtime.getJavaVersion()))
                     .withWebContainer(null);
         }
 

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/WebApp.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/WebApp.java
@@ -157,7 +157,7 @@ public class WebApp extends AbstractAppService<com.azure.resourcemanager.appserv
                                                         Runtime runtime) {
             return (DefinitionStages.WithCreate) blank.withExistingWindowsPlan(appServicePlan)
                 .withExistingResourceGroup(resourceGroup)
-                .withJavaVersion(AppServiceUtils.toJavaVersion(runtime))
+                .withJavaVersion(AppServiceUtils.toJavaVersion(runtime.getJavaVersion()))
                 .withWebContainer(AppServiceUtils.toWebContainer(runtime));
         }
 
@@ -249,7 +249,7 @@ public class WebApp extends AbstractAppService<com.azure.resourcemanager.appserv
                 case LINUX:
                     return update.withBuiltInImage(AppServiceUtils.toRuntimeStack(newRuntime));
                 case WINDOWS:
-                    return (Update) update.withJavaVersion(AppServiceUtils.toJavaVersion(newRuntime))
+                    return (Update) update.withJavaVersion(AppServiceUtils.toJavaVersion(newRuntime.getJavaVersion()))
                         .withWebContainer(AppServiceUtils.toWebContainer(newRuntime));
                 case DOCKER:
                     final DockerConfiguration dockerConfiguration = getDockerConfiguration().get();


### PR DESCRIPTION
Fix runtime parser for app service
- Parse linuxFxVersion with regex
- Support Java SE runtime with minor version for Linux app service
- Remove redundant call stack for runtime parse