### PR TITLE
Fix bug: print '!!' for empty string in messager 

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/bundle/AzureString.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/bundle/AzureString.java
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for
- * license information.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
 package com.microsoft.azure.toolkit.lib.common.bundle;
@@ -47,6 +46,11 @@ public class AzureString {
     }
 
     public String getString(Object... params) {
+        // sometimes we may need to print an empty line by: messager.info("")
+        // we need to
+        if (StringUtils.isBlank(name)) {
+            return "";
+        }
         final String pattern = Objects.nonNull(bundle) ? bundle.pattern(name) : name;
         try {
             if (StringUtils.isBlank(pattern)) {


### PR DESCRIPTION
## What problem is this PR solving?
print '!!' when calling `messager.info("")`

## What has been done in this PR?
 1. return empty string for empty string before using name to get pattern
 2. use a unified MIT header

