### PR TITLE
[#1866133] add PropertyChangeSupport into Azure resource classes for future reactive UI implementation

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/AbstractAzureResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/AbstractAzureResource.java
@@ -7,12 +7,16 @@
 package com.microsoft.azure.toolkit.lib.common.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
 import java.util.Objects;
 
 public abstract class AbstractAzureResource<T extends IAzureResource<E>, E extends AbstractAzureResource.RemoteAwareResourceEntity<R>, R>
@@ -21,6 +25,8 @@ public abstract class AbstractAzureResource<T extends IAzureResource<E>, E exten
     private boolean refreshed;
     @Nonnull
     protected final E entity;
+    protected final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+    private String status = null;
 
     protected AbstractAzureResource(@Nonnull E entity) {
         this.entity = entity;
@@ -36,12 +42,14 @@ public abstract class AbstractAzureResource<T extends IAzureResource<E>, E exten
     @Nonnull
     @Override
     public synchronized T refresh() {
+        this.refreshStatus(Status.LOADING);
         return this.refresh(this.loadRemote());
     }
 
     protected T refresh(@Nullable R remote) {
         this.entity.setRemote(remote);
         this.refreshed = true;
+        this.refreshStatus();
         //noinspection unchecked
         return (T) this;
     }
@@ -56,8 +64,52 @@ public abstract class AbstractAzureResource<T extends IAzureResource<E>, E exten
         return this.entity.getRemote();
     }
 
+    public final void refreshChildren() {
+        this.refresh();
+        this.pcs.firePropertyChange(PROPERTY_CHILDREN, 0, 1);
+    }
+
+    @Override
+    public final String status() {
+        if (Objects.nonNull(this.status)) {
+            return this.status;
+        } else {
+            this.refreshStatus();
+            return Status.LOADING;
+        }
+    }
+
+    public final void refreshStatus() {
+        AzureTaskManager.getInstance().runOnPooledThread(() -> this.refreshStatus(this.loadStatus()));
+    }
+
+    protected final void refreshStatus(@Nonnull String status) {
+        final String oldStatus = this.status;
+        this.status = status;
+        if (!StringUtils.equalsIgnoreCase(oldStatus, this.status)) {
+            this.pcs.firePropertyChange(PROPERTY_STATUS, oldStatus, this.status);
+        }
+    }
+
     @Nullable
     protected abstract R loadRemote();
+
+    /**
+     * @return {@link Status}
+     */
+    protected String loadStatus() {
+        return Status.RUNNING;
+    }
+
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        this.pcs.addPropertyChangeListener(listener);
+    }
+
+    @Override
+    public void removePropertyChangeListener(PropertyChangeListener listener) {
+        this.pcs.removePropertyChangeListener(listener);
+    }
 
     public abstract static class RemoteAwareResourceEntity<R> implements IAzureResourceEntity {
         @Nullable

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/IAzureResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/IAzureResource.java
@@ -27,12 +27,28 @@ import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.account.IAzureAccount;
 import com.microsoft.azure.toolkit.lib.common.model.Subscription;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
 public interface IAzureResource<T extends IAzureResourceEntity> {
+    String PROPERTY_STATUS = "status";
+    String PROPERTY_CHILDREN = "children";
+
     IAzureResource<T> refresh();
 
     boolean exists();
 
     T entity();
+
+    default String status() {
+        return null;
+    }
+
+    default void refreshStatus() {
+    }
+
+    default void refreshChildren() {
+    }
 
     default String name() {
         return this.entity().getName();
@@ -50,7 +66,33 @@ public interface IAzureResource<T extends IAzureResourceEntity> {
         return ResourceId.fromString(id()).resourceGroupName();
     }
 
-    default Subscription subscription(){
+    default Subscription subscription() {
         return Azure.az(IAzureAccount.class).account().getSubscription(this.subscriptionId());
+    }
+
+    default String portalUrl() {
+        return null;
+    }
+
+    default void addPropertyChangeListener(PropertyChangeListener listener) {
+
+    }
+
+    default void removePropertyChangeListener(PropertyChangeListener listener) {
+
+    }
+
+    interface Status {
+        // unstable states
+        String UNSTABLE = "UNSTABLE";
+        String PENDING = "PENDING";
+
+        // stable states
+        String STABLE = "STABLE";
+        String LOADING = "LOADING";
+        String ERROR = "ERROR";
+        String RUNNING = "RUNNING";
+        String STOPPED = "STOPPED";
+        String UNKNOWN = "UNKNOWN";
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/Startable.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/Startable.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.toolkit.lib.common.entity;
 
+import java.util.Objects;
+
 public interface Startable<T extends IAzureResourceEntity> extends IAzureResource<T> {
 
     void start();
@@ -14,14 +16,14 @@ public interface Startable<T extends IAzureResourceEntity> extends IAzureResourc
     void restart();
 
     default boolean isStartable() {
-        return true;
+        return Objects.equals(this.status(), Status.STOPPED);
     }
 
     default boolean isStoppable() {
-        return true;
+        return Objects.equals(this.status(), Status.RUNNING);
     }
 
     default boolean isRestartable() {
-        return true;
+        return Objects.equals(this.status(), Status.RUNNING);
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/operation/AzureOperationAspect.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/operation/AzureOperationAspect.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.toolkit.lib.common.operation;
 
+import com.microsoft.azure.toolkit.lib.common.entity.IAzureResource;
 import com.microsoft.azure.toolkit.lib.common.event.AzureEventBus;
 import com.microsoft.azure.toolkit.lib.common.event.AzureOperationEvent;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext;
@@ -70,6 +71,9 @@ public final class AzureOperationAspect {
             final AzureOperationEvent.Source<?> target = ((AzureOperationEvent.Source<?>) source).getEventSource();
             final AzureOperationEvent<?> event = new AzureOperationEvent(target, operation, AzureOperationEvent.Stage.ERROR);
             AzureEventBus.emit(operation.getName(), event);
+        }
+        if (source instanceof IAzureResource) {
+            ((IAzureResource<?>) source).refresh();
         }
         if (!(e instanceof RuntimeException)) {
             throw e; // do not wrap checked exception


### PR DESCRIPTION
[AB#1866133](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1866133)
[AB#1862935](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1862935)
`java.beans.`property change framework(`PropertyChangeSupport`/`PropertyChangeEvent`/`PropertyChangeListener`) are widely used to implement "reactive" UI. 

as for Azure resource classes, `STATUS` and `CHILDREN` are the key properties we care.
`PropertyChangeEvent` will be fired when status and children changed.
