### PR TITLE
[#1866133] add PropertyChangeSupport into Azure resource classes for future reactive UI implementation

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/Account.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/Account.java
@@ -13,6 +13,7 @@ import com.microsoft.azure.toolkit.lib.account.IAccount;
 import com.microsoft.azure.toolkit.lib.auth.exception.AzureToolkitAuthenticationException;
 import com.microsoft.azure.toolkit.lib.auth.model.AccountEntity;
 import com.microsoft.azure.toolkit.lib.auth.model.AuthType;
+import com.microsoft.azure.toolkit.lib.auth.util.AzureEnvironmentUtils;
 import com.microsoft.azure.toolkit.lib.common.cache.CacheEvict;
 import com.microsoft.azure.toolkit.lib.common.cache.Preloader;
 import com.microsoft.azure.toolkit.lib.common.model.Subscription;
@@ -54,6 +55,10 @@ public abstract class Account implements IAccount {
 
     public AzureEnvironment getEnvironment() {
         return entity == null ? null : entity.getEnvironment();
+    }
+
+    public String portalUrl() {
+        return AzureEnvironmentUtils.getPortalUrl(this.getEnvironment());
     }
 
     protected abstract Mono<Boolean> preLoginCheck();

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/util/AzureEnvironmentUtils.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/util/AzureEnvironmentUtils.java
@@ -16,6 +16,8 @@ import java.util.Map;
 
 public class AzureEnvironmentUtils {
     private static final Map<AzureEnvironment, String[]> AZURE_CLOUD_ALIAS_MAP = new HashMap<>();
+    private static final String CHINA_PORTAL = "https://portal.azure.cn";
+    private static final String GLOBAL_PORTAL = "https://ms.portal.azure.com";
 
     static {
         // the first alias is the cloud name in azure cli
@@ -67,6 +69,20 @@ public class AzureEnvironmentUtils {
         return AZURE_CLOUD_ALIAS_MAP.entrySet().stream().filter(entry -> Utils.containsIgnoreCase(Arrays.asList(entry.getValue()), targetEnvironment))
             .map(Map.Entry::getKey)
             .findFirst().orElse(null);
+    }
+
+    public static String getPortalUrl(AzureEnvironment env) {
+        if (AzureEnvironment.AZURE.equals(env)) {
+            return GLOBAL_PORTAL;
+        } else if (AzureEnvironment.AZURE_CHINA.equals(env)) {
+            return CHINA_PORTAL;
+        } else if (AzureEnvironment.AZURE_GERMANY.equals(env)) {
+            return AzureEnvironment.AZURE_GERMANY.getPortal();
+        } else if (AzureEnvironment.AZURE_US_GOVERNMENT.equals(env)) {
+            return AzureEnvironment.AZURE_US_GOVERNMENT.getPortal();
+        } else {
+            return env.getPortal();
+        }
     }
 
     private static void putAliasMap(AzureEnvironment env, String... aliases) {

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/AzureService.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/AzureService.java
@@ -7,11 +7,20 @@ package com.microsoft.azure.toolkit.lib;
 
 import com.microsoft.azure.toolkit.lib.account.IAzureAccount;
 import com.microsoft.azure.toolkit.lib.common.model.Subscription;
+import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 
 import java.util.List;
 
 public interface AzureService {
     default List<Subscription> getSubscriptions() {
         return Azure.az(IAzureAccount.class).account().getSelectedSubscriptions();
+    }
+
+    default String name() {
+        return this.getClass().getSimpleName();
+    }
+
+    @AzureOperation(name = "common|service.refresh", params = "this.name()", type = AzureOperation.Type.SERVICE)
+    default void refresh() {
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/account/IAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/account/IAccount.java
@@ -13,4 +13,5 @@ public interface IAccount {
     List<Subscription> getSubscriptions();
     List<Subscription> getSelectedSubscriptions();
     Subscription getSubscription(String subscriptionId);
+    String portalUrl();
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/AbstractAzureResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/AbstractAzureResource.java
@@ -7,12 +7,16 @@
 package com.microsoft.azure.toolkit.lib.common.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
 import java.util.Objects;
 
 public abstract class AbstractAzureResource<T extends IAzureResource<E>, E extends AbstractAzureResource.RemoteAwareResourceEntity<R>, R>
@@ -21,6 +25,8 @@ public abstract class AbstractAzureResource<T extends IAzureResource<E>, E exten
     private boolean refreshed;
     @Nonnull
     protected final E entity;
+    protected final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+    private String status = null;
 
     protected AbstractAzureResource(@Nonnull E entity) {
         this.entity = entity;
@@ -36,12 +42,14 @@ public abstract class AbstractAzureResource<T extends IAzureResource<E>, E exten
     @Nonnull
     @Override
     public synchronized T refresh() {
+        this.refreshStatus(Status.LOADING);
         return this.refresh(this.loadRemote());
     }
 
     protected T refresh(@Nullable R remote) {
         this.entity.setRemote(remote);
         this.refreshed = true;
+        this.refreshStatus();
         //noinspection unchecked
         return (T) this;
     }
@@ -56,8 +64,52 @@ public abstract class AbstractAzureResource<T extends IAzureResource<E>, E exten
         return this.entity.getRemote();
     }
 
+    public final void refreshChildren() {
+        this.refresh();
+        this.pcs.firePropertyChange(PROPERTY_CHILDREN, 0, 1);
+    }
+
+    @Override
+    public final String status() {
+        if (Objects.nonNull(this.status)) {
+            return this.status;
+        } else {
+            this.refreshStatus();
+            return Status.LOADING;
+        }
+    }
+
+    public final void refreshStatus() {
+        AzureTaskManager.getInstance().runOnPooledThread(() -> this.refreshStatus(this.loadStatus()));
+    }
+
+    protected final void refreshStatus(@Nonnull String status) {
+        final String oldStatus = this.status;
+        this.status = status;
+        if (!StringUtils.equalsIgnoreCase(oldStatus, this.status)) {
+            this.pcs.firePropertyChange(PROPERTY_STATUS, oldStatus, this.status);
+        }
+    }
+
     @Nullable
     protected abstract R loadRemote();
+
+    /**
+     * @return {@link Status}
+     */
+    protected String loadStatus() {
+        return Status.RUNNING;
+    }
+
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        this.pcs.addPropertyChangeListener(listener);
+    }
+
+    @Override
+    public void removePropertyChangeListener(PropertyChangeListener listener) {
+        this.pcs.removePropertyChangeListener(listener);
+    }
 
     public abstract static class RemoteAwareResourceEntity<R> implements IAzureResourceEntity {
         @Nullable

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/IAzureResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/IAzureResource.java
@@ -47,9 +47,6 @@ public interface IAzureResource<T extends IAzureResourceEntity> {
     default void refreshStatus() {
     }
 
-    default void refreshChildren() {
-    }
-
     default String name() {
         return this.entity().getName();
     }
@@ -72,14 +69,6 @@ public interface IAzureResource<T extends IAzureResourceEntity> {
 
     default String portalUrl() {
         return null;
-    }
-
-    default void addPropertyChangeListener(PropertyChangeListener listener) {
-
-    }
-
-    default void removePropertyChangeListener(PropertyChangeListener listener) {
-
     }
 
     interface Status {

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/IAzureResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/IAzureResource.java
@@ -24,15 +24,17 @@ package com.microsoft.azure.toolkit.lib.common.entity;
 
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.account.IAccount;
 import com.microsoft.azure.toolkit.lib.account.IAzureAccount;
 import com.microsoft.azure.toolkit.lib.common.model.Subscription;
 
-import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
 public interface IAzureResource<T extends IAzureResourceEntity> {
     String PROPERTY_STATUS = "status";
     String PROPERTY_CHILDREN = "children";
+    String REST_SEGMENT_JOB_MANAGEMENT_TENANTID = "/#@";
+    String REST_SEGMENT_JOB_MANAGEMENT_RESOURCE = "/resource";
 
     IAzureResource<T> refresh();
 
@@ -68,7 +70,13 @@ public interface IAzureResource<T extends IAzureResourceEntity> {
     }
 
     default String portalUrl() {
-        return null;
+        final IAccount account = Azure.az(IAzureAccount.class).account();
+        Subscription subscription = account.getSubscription(this.subscriptionId());
+        return account.portalUrl()
+                + REST_SEGMENT_JOB_MANAGEMENT_TENANTID
+                + subscription.getTenantId()
+                + REST_SEGMENT_JOB_MANAGEMENT_RESOURCE
+                + this.id();
     }
 
     interface Status {

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/IAzureResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/IAzureResource.java
@@ -27,12 +27,28 @@ import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.account.IAzureAccount;
 import com.microsoft.azure.toolkit.lib.common.model.Subscription;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
 public interface IAzureResource<T extends IAzureResourceEntity> {
+    String PROPERTY_STATUS = "status";
+    String PROPERTY_CHILDREN = "children";
+
     IAzureResource<T> refresh();
 
     boolean exists();
 
     T entity();
+
+    default String status() {
+        return null;
+    }
+
+    default void refreshStatus() {
+    }
+
+    default void refreshChildren() {
+    }
 
     default String name() {
         return this.entity().getName();
@@ -50,7 +66,33 @@ public interface IAzureResource<T extends IAzureResourceEntity> {
         return ResourceId.fromString(id()).resourceGroupName();
     }
 
-    default Subscription subscription(){
+    default Subscription subscription() {
         return Azure.az(IAzureAccount.class).account().getSubscription(this.subscriptionId());
+    }
+
+    default String portalUrl() {
+        return null;
+    }
+
+    default void addPropertyChangeListener(PropertyChangeListener listener) {
+
+    }
+
+    default void removePropertyChangeListener(PropertyChangeListener listener) {
+
+    }
+
+    interface Status {
+        // unstable states
+        String UNSTABLE = "UNSTABLE";
+        String PENDING = "PENDING";
+
+        // stable states
+        String STABLE = "STABLE";
+        String LOADING = "LOADING";
+        String ERROR = "ERROR";
+        String RUNNING = "RUNNING";
+        String STOPPED = "STOPPED";
+        String UNKNOWN = "UNKNOWN";
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/Startable.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/entity/Startable.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.azure.toolkit.lib.common.entity;
 
+import java.util.Objects;
+
 public interface Startable<T extends IAzureResourceEntity> extends IAzureResource<T> {
 
     void start();
@@ -14,14 +16,14 @@ public interface Startable<T extends IAzureResourceEntity> extends IAzureResourc
     void restart();
 
     default boolean isStartable() {
-        return true;
+        return Objects.equals(this.status(), Status.STOPPED);
     }
 
     default boolean isStoppable() {
-        return true;
+        return Objects.equals(this.status(), Status.RUNNING);
     }
 
     default boolean isRestartable() {
-        return true;
+        return Objects.equals(this.status(), Status.RUNNING);
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/event/AzureEvent.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/event/AzureEvent.java
@@ -9,6 +9,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public interface AzureEvent<T> {
+    Object getSource();
+
     @Nonnull
     String getType();
 

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/event/AzureEventBus.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/event/AzureEventBus.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.toolkit.lib.common.event;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NonNls;
@@ -62,8 +63,8 @@ public class AzureEventBus {
         AzureEventBus.emit(type, new SimpleEvent<>(type, null));
     }
 
-    public static <T> void emit(@Nonnull final String type, @Nullable final T payload) {
-        AzureEventBus.emit(type, new SimpleEvent<>(type, payload));
+    public static void emit(@Nonnull final String type, @Nullable final Object source) {
+        AzureEventBus.emit(type, new SimpleEvent<>(type, source));
     }
 
     public static <T> void emit(@Nonnull final String type, @Nonnull AzureEvent<T> event) {
@@ -88,10 +89,13 @@ public class AzureEventBus {
 
     @Getter
     @RequiredArgsConstructor
+    @AllArgsConstructor
     private static class SimpleEvent<T> implements AzureEvent<T> {
         @Nonnull
         private final String type;
         @Nullable
-        private final T payload;
+        private final Object source;
+        @Nullable
+        private T payload;
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/event/AzureOperationEvent.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/event/AzureOperationEvent.java
@@ -8,24 +8,23 @@ package com.microsoft.azure.toolkit.lib.common.event;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperationRef;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
 import javax.annotation.Nonnull;
 
 @Getter
+@Setter
 @RequiredArgsConstructor
-public class AzureOperationEvent<T extends AzureOperationEvent.Source<T>> implements AzureEvent<T> {
+public class AzureOperationEvent<T extends AzureOperationEvent.Source<T>> implements AzureEvent<Object> {
     private final T source;
     private final AzureOperationRef operation;
     private final Stage stage;
+    private Object payload;
 
     @Nonnull
     @Override
     public String getType() {
         return operation.getName();
-    }
-
-    public T getPayload() {
-        return this.source;
     }
 
     public interface Source<T> {

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/operation/AzureOperationAspect.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/operation/AzureOperationAspect.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.toolkit.lib.common.operation;
 
+import com.microsoft.azure.toolkit.lib.common.entity.IAzureResource;
 import com.microsoft.azure.toolkit.lib.common.event.AzureEventBus;
 import com.microsoft.azure.toolkit.lib.common.event.AzureOperationEvent;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskContext;
@@ -70,6 +71,9 @@ public final class AzureOperationAspect {
             final AzureOperationEvent.Source<?> target = ((AzureOperationEvent.Source<?>) source).getEventSource();
             final AzureOperationEvent<?> event = new AzureOperationEvent(target, operation, AzureOperationEvent.Stage.ERROR);
             AzureEventBus.emit(operation.getName(), event);
+        }
+        if (source instanceof IAzureResource) {
+            ((IAzureResource<?>) source).refresh();
         }
         if (!(e instanceof RuntimeException)) {
             throw e; // do not wrap checked exception

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/AzureSpringCloud.java
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/AzureSpringCloud.java
@@ -37,6 +37,7 @@ import com.microsoft.azure.toolkit.lib.auth.Account;
 import com.microsoft.azure.toolkit.lib.auth.AzureAccount;
 import com.microsoft.azure.toolkit.lib.common.cache.Cacheable;
 import com.microsoft.azure.toolkit.lib.common.cache.Preload;
+import com.microsoft.azure.toolkit.lib.common.event.AzureOperationEvent;
 import com.microsoft.azure.toolkit.lib.common.model.Subscription;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import lombok.extern.slf4j.Slf4j;
@@ -51,7 +52,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
-public class AzureSpringCloud extends SubscriptionScoped<AzureSpringCloud> implements AzureService {
+public class AzureSpringCloud extends SubscriptionScoped<AzureSpringCloud>
+        implements AzureService, AzureOperationEvent.Source<AzureSpringCloud> {
     public AzureSpringCloud() { // for SPI
         super(AzureSpringCloud::new);
     }
@@ -103,6 +105,16 @@ public class AzureSpringCloud extends SubscriptionScoped<AzureSpringCloud> imple
             }
             throw e;
         }
+    }
+
+    @AzureOperation(name = "common|service.refresh", params = "this.name()", type = AzureOperation.Type.SERVICE)
+    public void refresh() {
+        this.clusters(true);
+    }
+
+    @Override
+    public String name() {
+        return "Spring Cloud";
     }
 
     @Cacheable(cacheName = "asc/{}/client", key = "$subscriptionId")

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudApp.java
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudApp.java
@@ -72,7 +72,7 @@ public class SpringCloudApp extends AbstractAzureResource<SpringCloudApp, Spring
     }
 
     @Nonnull
-    @Cacheable(cacheName = "asc/app/{}/deployment/{}", key = "${this.name()}/$name")
+    @Cacheable(cacheName = "resource/{}/child/{}", key = "${this.id()}/$name")
     @AzureOperation(name = "springcloud|deployment.get", params = {"name", "this.name()"}, type = AzureOperation.Type.SERVICE)
     public SpringCloudDeployment deployment(final String name) {
         if (this.exists()) {
@@ -106,7 +106,7 @@ public class SpringCloudApp extends AbstractAzureResource<SpringCloudApp, Spring
     }
 
     @Nonnull
-    @Cacheable(cacheName = "asc/app/{}/deployments", key = "${this.name()}")
+    @Cacheable(cacheName = "resource/{}/children", key = "${this.id()}")
     @AzureOperation(name = "springcloud|deployment.list.app", params = {"this.name()"}, type = AzureOperation.Type.SERVICE)
     public List<SpringCloudDeployment> deployments() {
         if (this.exists()) {
@@ -117,21 +117,21 @@ public class SpringCloudApp extends AbstractAzureResource<SpringCloudApp, Spring
 
     @AzureOperation(name = "springcloud|app.start", params = {"this.name()"}, type = AzureOperation.Type.SERVICE)
     public void start() {
-        this.refreshStatus(Status.PENDING);
+        this.status(Status.PENDING);
         this.deployment(this.activeDeploymentName()).start();
         this.refreshStatus();
     }
 
     @AzureOperation(name = "springcloud|app.stop", params = {"this.name()"}, type = AzureOperation.Type.SERVICE)
     public void stop() {
-        this.refreshStatus(Status.PENDING);
+        this.status(Status.PENDING);
         this.deployment(this.activeDeploymentName()).stop();
         this.refreshStatus();
     }
 
     @AzureOperation(name = "springcloud|app.restart", params = {"this.name()"}, type = AzureOperation.Type.SERVICE)
     public void restart() {
-        this.refreshStatus(Status.PENDING);
+        this.status(Status.PENDING);
         this.deployment(this.activeDeploymentName()).restart();
         this.refreshStatus();
     }
@@ -139,9 +139,9 @@ public class SpringCloudApp extends AbstractAzureResource<SpringCloudApp, Spring
     @AzureOperation(name = "springcloud|app.remove", params = {"this.name()"}, type = AzureOperation.Type.SERVICE)
     public void remove() {
         if (this.exists()) {
-            this.refreshStatus(Status.PENDING);
+            this.status(Status.PENDING);
             Objects.requireNonNull(this.remote()).parent().apps().deleteByName(this.name());
-            this.cluster.refreshChildren();
+            this.cluster.refresh();
         }
     }
 
@@ -254,7 +254,7 @@ public class SpringCloudApp extends AbstractAzureResource<SpringCloudApp, Spring
             final IAzureMessager messager = AzureMessager.getMessager();
             if (!this.skippable) {
                 messager.info(AzureString.format("Start updating app({0})...", this.app.name()));
-                this.app.refreshStatus(Status.PENDING);
+                this.app.status(Status.PENDING);
                 this.app.refresh(this.modifier.apply());
                 this.app.refreshStatus();
                 messager.success(AzureString.format("App({0}) is successfully updated.", this.app.name()));
@@ -278,7 +278,7 @@ public class SpringCloudApp extends AbstractAzureResource<SpringCloudApp, Spring
             final IAzureMessager messager = AzureMessager.getMessager();
             messager.info(AzureString.format("Start creating app({0})...", appName));
             this.app.refresh(this.modifier.create());
-            this.app.cluster.refreshChildren();
+            this.app.cluster.refresh();
             messager.success(AzureString.format("App({0}) is successfully created.", appName));
             return this.app;
         }

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudCluster.java
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudCluster.java
@@ -11,7 +11,6 @@ import com.azure.resourcemanager.appplatform.models.ProvisioningState;
 import com.azure.resourcemanager.appplatform.models.SpringApp;
 import com.azure.resourcemanager.appplatform.models.SpringService;
 import com.azure.resourcemanager.appplatform.models.SpringServices;
-import com.microsoft.azure.toolkit.lib.common.cache.CacheEvict;
 import com.microsoft.azure.toolkit.lib.common.cache.Cacheable;
 import com.microsoft.azure.toolkit.lib.common.entity.AbstractAzureResource;
 import com.microsoft.azure.toolkit.lib.common.event.AzureOperationEvent;
@@ -50,15 +49,7 @@ public class SpringCloudCluster extends AbstractAzureResource<SpringCloudCluster
     }
 
     @Nonnull
-    @Override
-    @CacheEvict(cacheName = "asc/cluster/{}/apps", key = "${this.name()}")
-    @AzureOperation(name = "springcloud|cluster.refresh", params = {"this.name()"}, type = AzureOperation.Type.SERVICE)
-    public SpringCloudCluster refresh() {
-        return super.refresh();
-    }
-
-    @Nonnull
-    @Cacheable(cacheName = "asc/cluster/{}/app/{}", key = "${this.name()}/$name")
+    @Cacheable(cacheName = "resource/{}/child/{}", key = "${this.id()}/$name")
     @AzureOperation(name = "springcloud|app.get.name", params = {"name"}, type = AzureOperation.Type.SERVICE)
     public SpringCloudApp app(final String name) {
         if (this.exists()) {
@@ -88,7 +79,7 @@ public class SpringCloudCluster extends AbstractAzureResource<SpringCloudCluster
     }
 
     @Nonnull
-    @Cacheable(cacheName = "asc/cluster/{}/apps", key = "${this.name()}")
+    @Cacheable(cacheName = "resource/{}/children", key = "${this.id()}")
     @AzureOperation(name = "springcloud|app.list.cluster", params = {"this.name()"}, type = AzureOperation.Type.SERVICE)
     public List<SpringCloudApp> apps() {
         if (this.exists()) {

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudDeployment.java
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudDeployment.java
@@ -66,7 +66,7 @@ public class SpringCloudDeployment extends AbstractAzureResource<SpringCloudDepl
     @AzureOperation(name = "springcloud|deployment.start", params = {"this.name()", "this.app.name()"}, type = AzureOperation.Type.SERVICE)
     public void start() {
         if (this.exists()) {
-            this.refreshStatus(Status.PENDING);
+            this.status(Status.PENDING);
             Objects.requireNonNull(this.remote()).start();
             this.refreshStatus();
         }
@@ -75,7 +75,7 @@ public class SpringCloudDeployment extends AbstractAzureResource<SpringCloudDepl
     @AzureOperation(name = "springcloud|deployment.stop", params = {"this.name()", "this.app.name()"}, type = AzureOperation.Type.SERVICE)
     public void stop() {
         if (this.exists()) {
-            this.refreshStatus(Status.PENDING);
+            this.status(Status.PENDING);
             Objects.requireNonNull(this.remote()).stop();
             this.refreshStatus();
         }
@@ -84,7 +84,7 @@ public class SpringCloudDeployment extends AbstractAzureResource<SpringCloudDepl
     @AzureOperation(name = "springcloud|deployment.restart", params = {"this.entity().getName()", "this.app.name()"}, type = AzureOperation.Type.SERVICE)
     public void restart() {
         if (this.exists()) {
-            this.refreshStatus(Status.PENDING);
+            this.status(Status.PENDING);
             Objects.requireNonNull(this.remote()).restart();
             this.refreshStatus();
         }
@@ -205,14 +205,14 @@ public class SpringCloudDeployment extends AbstractAzureResource<SpringCloudDepl
             if (Objects.isNull(settings) || settings.isEmpty()) {
                 return this.deployment;
             }
-            this.deployment.refreshStatus(Status.PENDING);
+            this.deployment.status(Status.PENDING);
             final IAzureMessager messager = AzureMessager.getMessager();
             messager.info(AzureString.format("Start scaling deployment({0})...", this.deployment.name()));
             final SpringAppDeploymentImpl modifier = ((SpringAppDeploymentImpl) Objects.requireNonNull(this.deployment.remote()).update());
             modifier.withCpu(settings.getCpu()).withMemory(settings.getMemoryInGB()).withInstance(settings.getCapacity());
             this.deployment.entity.setRemote(modifier.apply());
             messager.success(AzureString.format("Deployment({0}) is successfully scaled.", this.deployment.name()));
-            this.deployment.app.refreshChildren();
+            this.deployment.app.refresh();
             return this.deployment;
         }
 
@@ -235,7 +235,7 @@ public class SpringCloudDeployment extends AbstractAzureResource<SpringCloudDepl
             if (this.skippable) {
                 messager.info(AzureString.format("Skip updating deployment({0}) since its properties is not changed.", this.deployment.name()));
             } else {
-                this.deployment.refreshStatus(Status.PENDING);
+                this.deployment.status(Status.PENDING);
                 messager.info(AzureString.format("Start updating deployment({0})...", this.deployment.name()));
                 this.deployment.refresh(this.modifier.apply());
                 messager.success(AzureString.format("Deployment({0}) is successfully updated", this.deployment.name()));
@@ -253,13 +253,13 @@ public class SpringCloudDeployment extends AbstractAzureResource<SpringCloudDepl
 
         @AzureOperation(name = "springcloud|deployment.create", params = {"this.deployment.name()", "this.deployment.app.name()"}, type = AzureOperation.Type.SERVICE)
         public SpringCloudDeployment commit() {
-            this.deployment.refreshStatus(Status.PENDING);
+            this.deployment.status(Status.PENDING);
             final IAzureMessager messager = AzureMessager.getMessager();
             messager.info(AzureString.format("Start creating deployment({0})...", this.deployment.name()));
             this.deployment.refresh(this.modifier.create());
             messager.success(AzureString.format("Deployment({0}) is successfully created", this.deployment.name()));
             final SpringCloudDeployment deployment = this.scale(this.newScaleSettings);
-            this.deployment.app.refreshChildren();
+            this.deployment.app.refresh();
             return deployment;
         }
     }


### PR DESCRIPTION
[AB#1866133](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1866133)
[AB#1862935](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1862935)
`java.beans.`property change framework(`PropertyChangeSupport`/`PropertyChangeEvent`/`PropertyChangeListener`) are widely used to implement "reactive" UI. 

as for Azure resource classes, `STATUS` and `CHILDREN` are the key properties we care.
`PropertyChangeEvent` will be fired when status and children changed.
