### PR TITLE
[Bug fix] fix wrong value for `authLevel` in function schema

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/bindings.json
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/bindings.json
@@ -1,6 +1,6 @@
 {
   "$schema": "<TBD>",
-  "contentVersion": "1.0.0",
+  "contentVersion": "1.14.0",
   "variables": {
     "storageConnStringLabel": "$variables_storageConnStringLabel",
     "appSettingsHelp": "$variables_appSettingsHelp",
@@ -102,15 +102,15 @@
           "value": "enum",
           "enum": [
             {
-              "value": "function",
+              "value": "FUNCTION",
               "display": "Function"
             },
             {
-              "value": "anonymous",
+              "value": "ANONYMOUS",
               "display": "Anonymous"
             },
             {
-              "value": "admin",
+              "value": "ADMIN",
               "display": "Admin"
             }
           ],

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/templates.json
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/templates.json
@@ -1,6 +1,6 @@
 {
   "$schema": "<TBD>",
-  "contentVersion": "1.0.0",
+  "contentVersion": "1.14.0",
   "templates": [
     {
       "id": "HttpTrigger-Java",


### PR DESCRIPTION
### Issue to Resolve
Values for `authLevel` is in lower cases in schema, differs with values in [AuthorizationLevel](https://github.com/Azure/azure-functions-java-library/blob/dev/src/main/java/com/microsoft/azure/functions/annotation/AuthorizationLevel.java), which may have compile issue if we use values in schema directly.

### Solution
Keep values in schema consistent with values in correspond enum