### PR TITLE
Remove outdated application insights dependency from azure toolkit lib

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
@@ -48,13 +48,6 @@
             <artifactId>azure-toolkit-auth-lib</artifactId>
         </dependency>
 
-
-        <!-- https://mvnrepository.com/artifact/com.microsoft.azure.applicationinsights.v2015_05_01/azure-mgmt-insights -->
-        <dependency>
-            <groupId>com.microsoft.azure.applicationinsights.v2015_05_01</groupId>
-            <artifactId>azure-mgmt-insights</artifactId>
-            <version>1.0.0-beta</version>
-        </dependency>
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>
             <artifactId>azure-functions-java-library</artifactId>

--- a/azure-toolkit-libs/pom.xml
+++ b/azure-toolkit-libs/pom.xml
@@ -68,7 +68,6 @@
         <azure.appplatform-sdk.version>1.0.0-beta</azure.appplatform-sdk.version>
         <azure.resourcemanager-applicationinsights.version>1.0.0-beta.1</azure.resourcemanager-applicationinsights.version>
         <azure.azure-mgmt-appplatform.version>1.0.0-beta</azure.azure-mgmt-appplatform.version>
-        <azure.mgmt-insights.version>1.0.0-beta</azure.mgmt-insights.version>
         <azure.client.version>1.7.12</azure.client.version>
         <azure.identity.version>1.3.0</azure.identity.version>
         <azure.resourcemanager.version>2.5.0</azure.resourcemanager.version>
@@ -301,11 +300,6 @@
                 <groupId>com.microsoft.azure.appplatform.v2020_07_01</groupId>
                 <artifactId>azure-mgmt-appplatform</artifactId>
                 <version>${azure.azure-mgmt-appplatform.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure.applicationinsights.v2015_05_01</groupId>
-                <artifactId>azure-mgmt-insights</artifactId>
-                <version>${azure.mgmt-insights.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.azure</groupId>


### PR DESCRIPTION
### Issues to resolve:
We used to leverage track1 app insights SDK for app insights creation for Function App, which bring dependency warning for maven toolkit, now we have migrated to track2 SDK but the dependency was not removed and the warning still exists
![image](https://user-images.githubusercontent.com/12445236/129530723-c91d525c-bdbc-4a0a-90a5-40774e2a829a.png)

### Solution
Remove outdated library `com.microsoft.azure.applicationinsights.v2015_05_01`

Resolves #1109, Resolves #1359, Resolves #1652
