### PR TITLE
Disable invalid warning for schema keyword then

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
@@ -118,17 +118,6 @@
             <artifactId>jansi</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.java-json-tools</groupId>
-            <artifactId>json-schema-validator</artifactId>
-            <version>2.2.14</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-toolkit-resource-lib</artifactId>
         </dependency>

--- a/azure-toolkit-libs/azure-toolkit-common-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/pom.xml
@@ -15,7 +15,6 @@
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>1.0.56</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/validator/SchemaValidator.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/validator/SchemaValidator.java
@@ -41,6 +41,11 @@ public class SchemaValidator {
     private final ObjectMapper objectMapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
             .disable(AUTO_DETECT_CREATORS, AUTO_DETECT_GETTERS, AUTO_DETECT_IS_GETTERS);
 
+    static {
+        // disable invalid warning for schema key word `then`
+        System.setProperty("org.slf4j.simpleLogger.log.com.networknt.schema.JsonMetaSchema", "off");
+    }
+
     private SchemaValidator() {
         final Set<String> resources = new Reflections("schema", new ResourcesScanner()).getResources(Pattern.compile(".*\\.json"));
         resources.stream().map(resource -> Pair.of(resource, SchemaValidator.class.getResourceAsStream("/" + resource)))

--- a/azure-toolkit-libs/pom.xml
+++ b/azure-toolkit-libs/pom.xml
@@ -139,6 +139,7 @@
         <plexus-interpolation.version>1.26</plexus-interpolation.version>
         <powermock.version>2.0.9</powermock.version>
         <azure-resourcemanager-mysql.version>1.0.0</azure-resourcemanager-mysql.version>
+        <networknt.json-schema-validator.version>1.0.57</networknt.json-schema-validator.version>
     </properties>
 
     <dependencyManagement>
@@ -707,6 +708,11 @@
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
                 <version>${jaxb.runtime.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.networknt</groupId>
+                <artifactId>json-schema-validator</artifactId>
+                <version>${networknt.json-schema-validator.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.java-json-tools</groupId>

--- a/azure-webapp-maven-plugin/pom.xml
+++ b/azure-webapp-maven-plugin/pom.xml
@@ -117,10 +117,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.networknt</groupId>
-            <artifactId>json-schema-validator</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,11 +90,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.networknt</groupId>
-                <artifactId>json-schema-validator</artifactId>
-                <version>${json.schema-validator.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-toolkit-libs</artifactId>
                 <version>0.11.0-SNAPSHOT</version>


### PR DESCRIPTION
### Issues to resolve:
`JsonMetaSchema` will prompt fake warning for json schema with `then` key word, refers https://github.com/networknt/json-schema-validator/pull/418

![image](https://user-images.githubusercontent.com/12445236/129540362-39f812d3-d641-4bc2-9a3a-0a16c4778d5b.png)


### What this PR do
- Disable warning for `JsonMetaSchema`
- Upgrade jason schema validator and clean up unused dependency
