### PR TITLE
Fix validation issue for service principal authentication with `<serverId>`

### DIFF
--- a/azure-maven-plugin-lib/src/main/resources/schema/maven/AzureAppServiceMavenPlugin.json
+++ b/azure-maven-plugin-lib/src/main/resources/schema/maven/AzureAppServiceMavenPlugin.json
@@ -63,16 +63,88 @@
     },
     "auth": {
       "title": "AuthConfiguration",
-      "description": "The auth config for accessing azure resources for maven",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "The auth config for accessing azure resources",
       "type": "object",
       "properties": {
+        "type": {
+          "$ref": "classpath:///schema/common/AuthConfiguration.json#/definitions/auth-type"
+        },
+        "client": {
+          "description": "Client ID",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "Tenant ID",
+          "type": "string"
+        },
         "serverId": {
           "$ref": "classpath:///schema/common/NonEmptyString.json"
+        },
+        "key": {
+          "description": "Password",
+          "type": "string"
+        },
+        "certificate": {
+          "description": "The absolute path of your certificate",
+          "type": "string"
+        },
+        "certificatePassword": {
+          "description": "The password for your certificate, if there is any",
+          "type": "string"
+        },
+        "environment": {
+          "$ref": "classpath:///schema/common/AzureEnvironment.json"
         }
       },
       "allOf": [
-        {"$ref": "classpath:///schema/common/AuthConfiguration.json"}
-      ]
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "pattern": "(?i)^service_principal$"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "anyOf": [
+              {
+                "required": [
+                  "client",
+                  "tenant",
+                  "key"
+                ]
+              },
+              {
+                "required": [
+                  "client",
+                  "tenant",
+                  "certificate"
+                ]
+              },
+              {
+                "required": [
+                  "serverId"
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "not": {
+        "required": [
+          "key",
+          "certificate"
+        ]
+      },
+      "dependencies": {
+        "certificatePassword": [
+          "certificate"
+        ]
+      }
     }
   }
 }

--- a/azure-maven-plugin-lib/src/main/resources/schema/maven/AzureAppServiceMavenPlugin.json
+++ b/azure-maven-plugin-lib/src/main/resources/schema/maven/AzureAppServiceMavenPlugin.json
@@ -71,12 +71,10 @@
           "$ref": "classpath:///schema/common/AuthConfiguration.json#/definitions/auth-type"
         },
         "client": {
-          "description": "Client ID",
-          "type": "string"
+          "$ref": "classpath:///schema/common/UUID.json"
         },
         "tenant": {
-          "description": "Tenant ID",
-          "type": "string"
+          "$ref": "classpath:///schema/common/UUID.json"
         },
         "serverId": {
           "$ref": "classpath:///schema/common/NonEmptyString.json"


### PR DESCRIPTION
### Issues to resolve
We use to share schema between `AuthConfiguration` and `MavenAuthConfiguration`, however, `MavenAuthConfiguration` support get client/tenant/key from `<servers>` in maven `settings.xml`, which was not supported in `AuthConfiguration`, and users will meet following exception when they auth maven plugin with service principal in settings.xml

![image](https://user-images.githubusercontent.com/12445236/129697603-4ad48376-56a6-4437-adc5-fce31290698d.png)


### Solution
Create new schema for maven plugin auth configuration, support  `<serverId>` for service principal authentication
