### PR TITLE
Fix bug: error occurs when evaluate template this.config.getAppName

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/DeployWebAppTask.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/DeployWebAppTask.java
@@ -43,7 +43,7 @@ public class DeployWebAppTask extends AzureTask<IWebApp> {
     }
 
     @Override
-    @AzureOperation(name = "webapp.deploy", params = {"this.config.getAppName()"}, type = AzureOperation.Type.SERVICE)
+    @AzureOperation(name = "webapp.deploy", params = {"this.webApp.entity().getName()"}, type = AzureOperation.Type.SERVICE)
     public IWebApp execute() {
         if (webApp.getRuntime().isDocker()) {
             AzureMessager.getMessager().info(AzureString.format(SKIP_DEPLOYMENT_FOR_DOCKER_APP_SERVICE, "https://" + webApp.hostName()));


### PR DESCRIPTION

error occurs when evaluate template(${this.config.getAppName()}) with bindings({nameFromResourceId=org.codehaus.groovy.runtime.MethodClosure@33be3c0, _this_={name:'<unknown>.<unknown>'}, out=java.io.PrintWriter@5626e7ef})
groovy.lang.MissingPropertyException: No such property: config for class: com.microsoft.azure.toolkit.lib.appservice.task.DeployWebAppTask