### PR TITLE
Validate `CreateOrUpdateAppServicePlanTask` with SchemaValidator

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/config/AppServicePlanConfig.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/config/AppServicePlanConfig.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.toolkit.lib.appservice.config;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.microsoft.azure.toolkit.lib.appservice.model.OperatingSystem;
 import com.microsoft.azure.toolkit.lib.appservice.model.PricingTier;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
@@ -15,6 +16,7 @@ import lombok.experimental.Accessors;
 @Getter
 @Setter
 @Accessors(fluent = true)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class AppServicePlanConfig {
     private String subscriptionId;
 

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/OperatingSystem.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/OperatingSystem.java
@@ -5,11 +5,10 @@
 
 package com.microsoft.azure.toolkit.lib.appservice.model;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
@@ -17,6 +16,7 @@ import java.util.Arrays;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public enum OperatingSystem {
     WINDOWS("windows"),
     LINUX("linux"),

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/PricingTier.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/PricingTier.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.toolkit.lib.appservice.model;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.google.common.collect.Sets;
 import com.microsoft.azure.toolkit.lib.common.model.ExpandableParameter;
 import lombok.AllArgsConstructor;
@@ -24,6 +25,7 @@ import java.util.Set;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class PricingTier implements ExpandableParameter {
     public static final PricingTier BASIC_B1 = new PricingTier("Basic", "B1");
     public static final PricingTier BASIC_B2 = new PricingTier("Basic", "B2");

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/schema/appservice/AppServicePlan.json
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/schema/appservice/AppServicePlan.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "App Service Plan - Update",
+  "description": "Schema for AppServicePlanConfig when update existing service plan",
+  "properties": {
+    "subscriptionId": {
+      "$ref": "classpath:///schema/common/UUID.json"
+    },
+    "servicePlanResourceGroup": {
+      "$ref": "classpath:///schema/common/ResourceGroupName.json"
+    },
+    "servicePlanName": {
+      "$ref": "classpath:///schema/appservice/AppServicePlanName.json"
+    },
+    "region": {
+      "$ref": "classpath:///schema/common/NonEmptyString.json"
+    },
+    "os": {
+      "$ref": "classpath:///schema/appservice/Runtime.json#/definitions/os"
+    },
+    "region": {
+      "type": "object"
+    },
+    "pricingTier": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "subscriptionId",
+    "servicePlanName",
+    "servicePlanResourceGroup"
+  ]
+}

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/schema/appservice/CreateAppServicePlan.json
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/schema/appservice/CreateAppServicePlan.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "App Service Plan - Update",
+  "description": "Schema for AppServicePlanConfig when update existing service plan",
+  "allOf": [
+    {
+      "$ref": "classpath:///schema/appservice/UpdateAppServicePlan.json"
+    }
+  ],
+  "required": [
+    "os",
+    "region",
+    "pricingTier"
+  ]
+}

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/Region.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/Region.java
@@ -4,6 +4,7 @@
  */
 package com.microsoft.azure.toolkit.lib.common.model;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.google.common.collect.Sets;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -21,6 +22,7 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class Region implements ExpandableParameter {
     public static final Region US_EAST = new Region("eastus", "East US");
     public static final Region US_EAST2 = new Region("eastus2", "East US 2");

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/validator/SchemaValidator.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/validator/SchemaValidator.java
@@ -115,7 +115,7 @@ public class SchemaValidator {
         }
     }
 
-    private static final String getSchemaId(final String path) {
+    private static String getSchemaId(final String path) {
         try {
             final Path schemaPath = Paths.get(FilenameUtils.removeExtension(path));
             final Path relativePath = SCHEMA_ROOT.relativize(schemaPath);

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/resources/schema/appservice/Runtime.json
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/resources/schema/appservice/Runtime.json
@@ -5,9 +5,7 @@
   "type": "object",
   "properties": {
     "os": {
-      "description": "The operating system for app service",
-      "type": "string",
-      "pattern": "(?i)^(windows|linux|docker)$"
+      "$ref": "#/definitions/os"
     },
     "webContainer": {
       "$ref": "classpath:///schema/common/NonEmptyString.json"
@@ -73,5 +71,12 @@
         ]
       }
     }
-  ]
+  ],
+  "definitions": {
+    "os": {
+      "description": "The operating system for app service",
+      "type": "string",
+      "pattern": "(?i)^(windows|linux|docker)$"
+    }
+  }
 }


### PR DESCRIPTION
### Issues to resolve
Our current schema validation for web app command line plugin will only affect on the startup, so we could not determine whether to create or update existing resource, and could not apply validation for resource creation. 

### Solution
Create multi schema for different tasks, we could reuse existing schema with `ref` and "extend" existing schema with `allOf`

### Commits
- Support validate and throw exception in `SchemaValidator`
- Add new schema for app service plan creation/update and validate configuration during task execution
- Add schema relative path to id and fix reflection issues when no schema founded
