### PR TITLE
Support storage and Azure spot in compute library

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/utils/Utils.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/utils/Utils.java
@@ -18,18 +18,20 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Predicate;
 
 public class Utils {
     private static final boolean isWindows = System.getProperty("os.name").contains("Windows");
@@ -38,6 +40,11 @@ public class Utils {
     private static final String WAR = "war";
     private static final String EAR = "ear";
     private static final String SUBSCRIPTIONS = "subscriptions";
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyMMddHHmmss");
+
+    public static String getTimestamp() {
+        return DATE_FORMAT.format(new Date());
+    }
 
     public static String getArtifactCompileVersion(File artifact) throws AzureExecutionException {
         try (JarFile jarFile = new JarFile(artifact)) {

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/AbstractAzureResource.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/AbstractAzureResource.java
@@ -13,6 +13,7 @@ import com.microsoft.azure.toolkit.lib.common.event.AzureEventBus;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 
@@ -20,16 +21,14 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
+@NoArgsConstructor
 public abstract class AbstractAzureResource<T extends HasId, P extends IAzureBaseResource> implements IAzureBaseResource<AbstractAzureResource<T, P>, P> {
-    @Nonnull
     @Getter
-    protected final String name;
+    protected String name;
     @Getter
-    @Nonnull
-    protected final String resourceGroup;
+    protected String resourceGroup;
     @Getter
-    @Nonnull
-    protected final String subscriptionId;
+    protected String subscriptionId;
     @Getter
     protected String id;
 

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/ip/DraftPublicIpAddress.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/ip/DraftPublicIpAddress.java
@@ -5,10 +5,12 @@
 
 package com.microsoft.azure.toolkit.lib.compute.ip;
 
+import com.azure.resourcemanager.resources.fluentcore.arm.models.HasId;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.compute.AzureResourceDraft;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
 
@@ -17,6 +19,7 @@ import java.util.Optional;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 public class DraftPublicIpAddress extends PublicIpAddress implements AzureResourceDraft<PublicIpAddress> {
     private Region region;
@@ -24,6 +27,23 @@ public class DraftPublicIpAddress extends PublicIpAddress implements AzureResour
 
     public DraftPublicIpAddress(@Nonnull final String subscriptionId, @Nonnull final String resourceGroup, @Nonnull final String name) {
         super(getResourceId(subscriptionId, resourceGroup, name), null);
+    }
+
+    public void setSubscriptionId(final String subscriptionId) {
+        this.subscriptionId = subscriptionId;
+    }
+
+    public void setResourceGroup(final String resourceGroup) {
+        this.resourceGroup = resourceGroup;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getId() {
+        return Optional.ofNullable(remote).map(HasId::id).orElseGet(() -> getResourceId(subscriptionId, resourceGroup, name));
     }
 
     PublicIpAddress create(AzurePublicIpAddress module) {

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/ip/DraftPublicIpAddress.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/ip/DraftPublicIpAddress.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.toolkit.lib.compute.ip;
 
 import com.azure.resourcemanager.resources.fluentcore.arm.models.HasId;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
+import com.microsoft.azure.toolkit.lib.common.utils.Utils;
 import com.microsoft.azure.toolkit.lib.compute.AzureResourceDraft;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -27,6 +28,12 @@ public class DraftPublicIpAddress extends PublicIpAddress implements AzureResour
 
     public DraftPublicIpAddress(@Nonnull final String subscriptionId, @Nonnull final String resourceGroup, @Nonnull final String name) {
         super(getResourceId(subscriptionId, resourceGroup, name), null);
+    }
+
+    public static DraftPublicIpAddress getDefaultPublicIpAddressDraft() {
+        final DraftPublicIpAddress publicIpAddress = new DraftPublicIpAddress();
+        publicIpAddress.setName(String.format("public-ip-%s", Utils.getTimestamp()));
+        return publicIpAddress;
     }
 
     public void setSubscriptionId(final String subscriptionId) {

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/ip/PublicIpAddress.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/ip/PublicIpAddress.java
@@ -10,10 +10,12 @@ import com.microsoft.azure.toolkit.lib.common.entity.IAzureModule;
 import com.microsoft.azure.toolkit.lib.common.event.AzureOperationEvent;
 import com.microsoft.azure.toolkit.lib.compute.AbstractAzureResource;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 public class PublicIpAddress extends AbstractAzureResource<com.azure.resourcemanager.network.models.PublicIpAddress, IAzureBaseResource>
         implements AzureOperationEvent.Source<PublicIpAddress> {

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/ip/PublicIpAddress.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/ip/PublicIpAddress.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.toolkit.lib.compute.ip;
 import com.microsoft.azure.toolkit.lib.common.entity.IAzureBaseResource;
 import com.microsoft.azure.toolkit.lib.common.entity.IAzureModule;
 import com.microsoft.azure.toolkit.lib.common.event.AzureOperationEvent;
+import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.compute.AbstractAzureResource;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -35,6 +36,10 @@ public class PublicIpAddress extends AbstractAzureResource<com.azure.resourceman
     @Override
     public IAzureModule<? extends AbstractAzureResource<com.azure.resourcemanager.network.models.PublicIpAddress, IAzureBaseResource>, ? extends IAzureBaseResource> module() {
         return module;
+    }
+
+    public Region getRegion() {
+        return Region.fromName(remote().regionName());
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/network/DraftNetwork.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/network/DraftNetwork.java
@@ -6,11 +6,13 @@
 package com.microsoft.azure.toolkit.lib.compute.network;
 
 import com.azure.resourcemanager.network.models.Network.DefinitionStages.WithCreateAndSubnet;
+import com.azure.resourcemanager.resources.fluentcore.arm.models.HasId;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.compute.AzureResourceDraft;
 import com.microsoft.azure.toolkit.lib.compute.network.model.Subnet;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
@@ -22,6 +24,7 @@ import java.util.Optional;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 public class DraftNetwork extends Network implements AzureResourceDraft<Network> {
 
@@ -33,6 +36,23 @@ public class DraftNetwork extends Network implements AzureResourceDraft<Network>
 
     public DraftNetwork(@Nonnull final String subscriptionId, @Nonnull final String resourceGroup, @Nonnull final String name) {
         super(getResourceId(subscriptionId, resourceGroup, name), null);
+    }
+
+    public void setSubscriptionId(final String subscriptionId) {
+        this.subscriptionId = subscriptionId;
+    }
+
+    public void setResourceGroup(final String resourceGroup) {
+        this.resourceGroup = resourceGroup;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getId() {
+        return Optional.ofNullable(remote).map(HasId::id).orElseGet(() -> getResourceId(subscriptionId, resourceGroup, name));
     }
 
     Network create(final AzureNetwork module) {

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/network/DraftNetwork.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/network/DraftNetwork.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.toolkit.lib.compute.network;
 import com.azure.resourcemanager.network.models.Network.DefinitionStages.WithCreateAndSubnet;
 import com.azure.resourcemanager.resources.fluentcore.arm.models.HasId;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
+import com.microsoft.azure.toolkit.lib.common.utils.Utils;
 import com.microsoft.azure.toolkit.lib.compute.AzureResourceDraft;
 import com.microsoft.azure.toolkit.lib.compute.network.model.Subnet;
 import lombok.EqualsAndHashCode;
@@ -36,6 +37,15 @@ public class DraftNetwork extends Network implements AzureResourceDraft<Network>
 
     public DraftNetwork(@Nonnull final String subscriptionId, @Nonnull final String resourceGroup, @Nonnull final String name) {
         super(getResourceId(subscriptionId, resourceGroup, name), null);
+    }
+
+    public static DraftNetwork getDefaultNetworkDraft() {
+        final DraftNetwork draftNetwork = new DraftNetwork();
+        draftNetwork.setName(String.format("network-%s", Utils.getTimestamp()));
+        draftNetwork.setAddressSpace("10.0.2.0/24");
+        draftNetwork.setSubnet("default");
+        draftNetwork.setSubnetAddressSpace("10.0.2.0/24");
+        return draftNetwork;
     }
 
     public void setSubscriptionId(final String subscriptionId) {

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/network/Network.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/network/Network.java
@@ -11,12 +11,14 @@ import com.microsoft.azure.toolkit.lib.common.event.AzureOperationEvent;
 import com.microsoft.azure.toolkit.lib.compute.AbstractAzureResource;
 import com.microsoft.azure.toolkit.lib.compute.network.model.Subnet;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 public class Network extends AbstractAzureResource<com.azure.resourcemanager.network.models.Network, IAzureBaseResource>
         implements AzureOperationEvent.Source<Network> {

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/network/Network.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/network/Network.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.toolkit.lib.compute.network;
 import com.microsoft.azure.toolkit.lib.common.entity.IAzureBaseResource;
 import com.microsoft.azure.toolkit.lib.common.entity.IAzureModule;
 import com.microsoft.azure.toolkit.lib.common.event.AzureOperationEvent;
+import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.compute.AbstractAzureResource;
 import com.microsoft.azure.toolkit.lib.compute.network.model.Subnet;
 import lombok.EqualsAndHashCode;
@@ -42,6 +43,10 @@ public class Network extends AbstractAzureResource<com.azure.resourcemanager.net
     public IAzureModule<? extends AbstractAzureResource<com.azure.resourcemanager.network.models.Network, IAzureBaseResource>,
             ? extends IAzureBaseResource> module() {
         return module;
+    }
+
+    public Region getRegion() {
+        return Region.fromName(remote().regionName());
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/security/DraftNetworkSecurityGroup.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/security/DraftNetworkSecurityGroup.java
@@ -11,12 +11,15 @@ import com.azure.resourcemanager.network.models.NetworkSecurityRule.DefinitionSt
 import com.azure.resourcemanager.network.models.NetworkSecurityRule.DefinitionStages.WithSourceAddressOrSecurityGroup;
 import com.azure.resourcemanager.network.models.NetworkSecurityRule.DefinitionStages.WithSourcePort;
 import com.azure.resourcemanager.network.models.SecurityRuleProtocol;
+import com.azure.resourcemanager.resources.fluentcore.arm.models.HasId;
 import com.microsoft.azure.toolkit.lib.common.entity.IAzureBaseResource;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.compute.AzureResourceDraft;
 import com.microsoft.azure.toolkit.lib.compute.security.model.SecurityRule;
 import io.jsonwebtoken.lang.Collections;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.annotation.Nonnull;
@@ -26,6 +29,8 @@ import java.util.Optional;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class DraftNetworkSecurityGroup extends NetworkSecurityGroup implements AzureResourceDraft<NetworkSecurityGroup> {
     private static final int BASE_PRIORITY = 300;
     private static final int PRIORITY_STEP = 20;
@@ -35,6 +40,23 @@ public class DraftNetworkSecurityGroup extends NetworkSecurityGroup implements A
 
     public DraftNetworkSecurityGroup(@Nonnull final String subscriptionId, @Nonnull final String resourceGroup, @Nonnull final String name) {
         super(getResourceId(subscriptionId, resourceGroup, name), null);
+    }
+
+    public void setSubscriptionId(final String subscriptionId) {
+        this.subscriptionId = subscriptionId;
+    }
+
+    public void setResourceGroup(final String resourceGroup) {
+        this.resourceGroup = resourceGroup;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getId() {
+        return Optional.ofNullable(remote).map(HasId::id).orElseGet(() -> getResourceId(subscriptionId, resourceGroup, name));
     }
 
     NetworkSecurityGroup create(final AzureNetworkSecurityGroup module) {

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/security/NetworkSecurityGroup.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/security/NetworkSecurityGroup.java
@@ -9,11 +9,14 @@ import com.microsoft.azure.toolkit.lib.common.entity.IAzureBaseResource;
 import com.microsoft.azure.toolkit.lib.common.entity.IAzureModule;
 import com.microsoft.azure.toolkit.lib.common.event.AzureOperationEvent;
 import com.microsoft.azure.toolkit.lib.compute.AbstractAzureResource;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class NetworkSecurityGroup extends AbstractAzureResource<com.azure.resourcemanager.network.models.NetworkSecurityGroup, IAzureBaseResource>
         implements AzureOperationEvent.Source<NetworkSecurityGroup> {
 

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/security/NetworkSecurityGroup.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/security/NetworkSecurityGroup.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.toolkit.lib.compute.security;
 import com.microsoft.azure.toolkit.lib.common.entity.IAzureBaseResource;
 import com.microsoft.azure.toolkit.lib.common.entity.IAzureModule;
 import com.microsoft.azure.toolkit.lib.common.event.AzureOperationEvent;
+import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.compute.AbstractAzureResource;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -37,6 +38,10 @@ public class NetworkSecurityGroup extends AbstractAzureResource<com.azure.resour
     public IAzureModule<? extends AbstractAzureResource<com.azure.resourcemanager.network.models.NetworkSecurityGroup, IAzureBaseResource>,
             ? extends IAzureBaseResource> module() {
         return module;
+    }
+
+    public Region getRegion() {
+        return Region.fromName(remote().regionName());
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/AzureImage.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/AzureImage.java
@@ -18,6 +18,28 @@ import javax.annotation.Nonnull;
 
 @EqualsAndHashCode
 public class AzureImage {
+    public static final AzureImage WINDOWS_DESKTOP_10_20H1_PRO = new AzureImage(KnownWindowsVirtualMachineImage.WINDOWS_DESKTOP_10_20H1_PRO);
+    public static final AzureImage WINDOWS_SERVER_2019_DATACENTER = new AzureImage(KnownWindowsVirtualMachineImage.WINDOWS_SERVER_2019_DATACENTER);
+    public static final AzureImage WINDOWS_SERVER_2019_DATACENTER_WITH_CONTAINER =
+            new AzureImage(KnownWindowsVirtualMachineImage.WINDOWS_SERVER_2019_DATACENTER_WITH_CONTAINERS);
+    public static final AzureImage WINDOWS_SERVER_2016_DATACENTER = new AzureImage(KnownWindowsVirtualMachineImage.WINDOWS_SERVER_2016_DATACENTER);
+    public static final AzureImage WINDOWS_SERVER_2012_R2_DATACENTER = new AzureImage(KnownWindowsVirtualMachineImage.WINDOWS_SERVER_2012_R2_DATACENTER);
+    public static final AzureImage UBUNTU_SERVER_16_04_LTS = new AzureImage(KnownLinuxVirtualMachineImage.UBUNTU_SERVER_16_04_LTS);
+    public static final AzureImage UBUNTU_SERVER_18_04_LTS = new AzureImage(KnownLinuxVirtualMachineImage.UBUNTU_SERVER_18_04_LTS);
+    public static final AzureImage DEBIAN_9 = new AzureImage(KnownLinuxVirtualMachineImage.DEBIAN_9);
+    public static final AzureImage DEBIAN_10 = new AzureImage(KnownLinuxVirtualMachineImage.DEBIAN_10);
+    public static final AzureImage CENTOS_8_1 = new AzureImage(KnownLinuxVirtualMachineImage.CENTOS_8_1);
+    public static final AzureImage CENTOS_8_3 = new AzureImage(KnownLinuxVirtualMachineImage.CENTOS_8_3);
+    @Deprecated
+    public static final AzureImage OPENSUSE_LEAP_15_1 = new AzureImage(KnownLinuxVirtualMachineImage.OPENSUSE_LEAP_15_1);
+    public static final AzureImage OPENSUSE_LEAP_15 = new AzureImage(KnownLinuxVirtualMachineImage.OPENSUSE_LEAP_15);
+    @Deprecated
+    public static final AzureImage SLES_15_SP1 = new AzureImage(KnownLinuxVirtualMachineImage.SLES_15_SP1);
+    public static final AzureImage SLES_15 = new AzureImage(KnownLinuxVirtualMachineImage.SLES_15);
+    public static final AzureImage REDHAT_RHEL_8_2 = new AzureImage(KnownLinuxVirtualMachineImage.REDHAT_RHEL_8_2);
+    public static final AzureImage ORACLE_LINUX_8_1 = new AzureImage(KnownLinuxVirtualMachineImage.ORACLE_LINUX_8_1);
+
+
     @Nonnull
     @Getter(value = AccessLevel.PACKAGE)
     @EqualsAndHashCode.Exclude

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/AzureImage.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/AzureImage.java
@@ -20,43 +20,43 @@ import javax.annotation.Nonnull;
 public class AzureImage {
     @Nonnull
     @Getter(value = AccessLevel.PACKAGE)
+    @EqualsAndHashCode.Exclude
     private final ImageReference imageReference;
+
     @Nonnull
     @Getter
     private final OperatingSystem operatingSystem;
+    @Getter
+    private final String id;
+    @Getter
+    private final String publisherName;
+    @Getter
+    private final String offer;
+    @Getter
+    private final String sku;
+    @Getter
+    private final String version;
 
-    AzureImage(@Nonnull VirtualMachineImage virtualMachineImage) {
-        this.operatingSystem = OperatingSystem.fromString(virtualMachineImage.osDiskImage().operatingSystem().name());
-        this.imageReference = virtualMachineImage.imageReference();
+    public AzureImage(@Nonnull VirtualMachineImage virtualMachineImage) {
+        this(OperatingSystem.fromString(virtualMachineImage.osDiskImage().operatingSystem().name()), virtualMachineImage.imageReference());
     }
 
     public AzureImage(@Nonnull KnownWindowsVirtualMachineImage windowsVirtualMachineImage) {
-        this.operatingSystem = OperatingSystem.Windows;
-        this.imageReference = windowsVirtualMachineImage.imageReference();
+        this(OperatingSystem.Windows, windowsVirtualMachineImage.imageReference());
     }
 
-    AzureImage(@Nonnull KnownLinuxVirtualMachineImage linuxVirtualMachineImage) {
-        this.operatingSystem = OperatingSystem.Linux;
-        this.imageReference = linuxVirtualMachineImage.imageReference();
+    public AzureImage(@Nonnull KnownLinuxVirtualMachineImage linuxVirtualMachineImage) {
+        this(OperatingSystem.Linux, linuxVirtualMachineImage.imageReference());
     }
 
-    public String id() {
-        return imageReference.id();
-    }
+    public AzureImage(final OperatingSystem operatingSystem, final ImageReference imageReference) {
+        this.operatingSystem = operatingSystem;
+        this.id = imageReference.id();
+        this.publisherName = imageReference.publisher();
+        this.offer = imageReference.offer();
+        this.sku = imageReference.sku();
+        this.version = imageReference.version();
 
-    public String publisherName() {
-        return imageReference.publisher();
-    }
-
-    public String offer() {
-        return imageReference.offer();
-    }
-
-    public String sku() {
-        return imageReference.sku();
-    }
-
-    public String version() {
-        return imageReference.version();
+        this.imageReference = imageReference;
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/AzureImage.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/AzureImage.java
@@ -39,7 +39,6 @@ public class AzureImage {
     public static final AzureImage REDHAT_RHEL_8_2 = new AzureImage(KnownLinuxVirtualMachineImage.REDHAT_RHEL_8_2);
     public static final AzureImage ORACLE_LINUX_8_1 = new AzureImage(KnownLinuxVirtualMachineImage.ORACLE_LINUX_8_1);
 
-
     @Nonnull
     @Getter(value = AccessLevel.PACKAGE)
     @EqualsAndHashCode.Exclude

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/AzureVirtualMachineSize.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/AzureVirtualMachineSize.java
@@ -12,6 +12,13 @@ import lombok.Getter;
 @Getter
 @EqualsAndHashCode
 public class AzureVirtualMachineSize {
+    public static final AzureVirtualMachineSize Standard_D2 = new AzureVirtualMachineSize("Standard_D2");
+    public static final AzureVirtualMachineSize Standard_D2_v2 = new AzureVirtualMachineSize("Standard_D2_v2");
+    public static final AzureVirtualMachineSize Standard_DS2 = new AzureVirtualMachineSize("Standard_DS2");
+    public static final AzureVirtualMachineSize Standard_D2s_v3 = new AzureVirtualMachineSize("Standard_D2s_v3");
+    public static final AzureVirtualMachineSize Standard_D4s_v3 = new AzureVirtualMachineSize("Standard_D4s_v3");
+    public static final AzureVirtualMachineSize Standard_E2s_v3 = new AzureVirtualMachineSize("Standard_E2s_v3");
+
     private final String name;
 
     public AzureVirtualMachineSize(final ComputeSku size) {

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/DraftVirtualMachine.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/DraftVirtualMachine.java
@@ -10,18 +10,27 @@ import com.azure.resourcemanager.compute.models.VirtualMachine.DefinitionStages.
 import com.azure.resourcemanager.compute.models.VirtualMachine.DefinitionStages.WithLinuxCreateManagedOrUnmanaged;
 import com.azure.resourcemanager.compute.models.VirtualMachine.DefinitionStages.WithLinuxRootPasswordOrPublicKeyManagedOrUnmanaged;
 import com.azure.resourcemanager.compute.models.VirtualMachine.DefinitionStages.WithProximityPlacementGroup;
-import com.azure.resourcemanager.compute.models.VirtualMachine.DefinitionStages.WithPublicIPAddress;
+import com.azure.resourcemanager.compute.models.VirtualMachineEvictionPolicyTypes;
+import com.azure.resourcemanager.network.models.NetworkInterface;
 import com.azure.resourcemanager.resources.fluentcore.arm.models.HasId;
+import com.azure.resourcemanager.storage.models.StorageAccount;
+import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
+import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
+import com.microsoft.azure.toolkit.lib.common.utils.Utils;
 import com.microsoft.azure.toolkit.lib.compute.AzureResourceDraft;
+import com.microsoft.azure.toolkit.lib.compute.ip.DraftPublicIpAddress;
 import com.microsoft.azure.toolkit.lib.compute.ip.PublicIpAddress;
+import com.microsoft.azure.toolkit.lib.compute.network.DraftNetwork;
 import com.microsoft.azure.toolkit.lib.compute.network.Network;
 import com.microsoft.azure.toolkit.lib.compute.network.model.Subnet;
+import com.microsoft.azure.toolkit.lib.compute.security.DraftNetworkSecurityGroup;
 import com.microsoft.azure.toolkit.lib.compute.security.NetworkSecurityGroup;
 import com.microsoft.azure.toolkit.lib.compute.vm.model.AuthenticationType;
 import com.microsoft.azure.toolkit.lib.compute.vm.model.AzureSpotConfig;
 import com.microsoft.azure.toolkit.lib.compute.vm.model.OperatingSystem;
-import com.microsoft.azure.toolkit.lib.storage.service.StorageAccount;
+import com.microsoft.azure.toolkit.lib.storage.StorageManagerFactory;
+import com.microsoft.azure.toolkit.lib.storage.model.StorageAccountConfig;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -30,6 +39,10 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.Nonnull;
 import java.util.Optional;
+
+import static com.azure.resourcemanager.compute.models.VirtualMachineEvictionPolicyTypes.DEALLOCATE;
+import static com.azure.resourcemanager.compute.models.VirtualMachineEvictionPolicyTypes.DELETE;
+import static com.microsoft.azure.toolkit.lib.compute.vm.model.AzureSpotConfig.EvictionPolicy.StopAndDeallocate;
 
 @Getter
 @Setter
@@ -47,11 +60,22 @@ public class DraftVirtualMachine extends VirtualMachine implements AzureResource
     private String sshKey;
     private AzureVirtualMachineSize size;
     private String availabilitySet;
-    private StorageAccount storageAccount;
+    private StorageAccountConfig storageAccount;
     private AzureSpotConfig azureSpotConfig;
 
     public DraftVirtualMachine(@Nonnull final String subscriptionId, @Nonnull final String resourceGroup, @Nonnull final String name) {
         super(getResourceId(subscriptionId, resourceGroup, name), null);
+    }
+
+    public static DraftVirtualMachine getDefaultVirtualMachineDraft() {
+        final DraftVirtualMachine virtualMachine = new DraftVirtualMachine();
+        virtualMachine.setRegion(Region.US_CENTRAL);
+        virtualMachine.setImage(AzureImage.UBUNTU_SERVER_18_04_LTS);
+        virtualMachine.setSize(AzureVirtualMachineSize.Standard_D2s_v3);
+        virtualMachine.setNetwork(DraftNetwork.getDefaultNetworkDraft());
+        virtualMachine.setIpAddress(DraftPublicIpAddress.getDefaultPublicIpAddressDraft());
+        virtualMachine.setSecurityGroup(new DraftNetworkSecurityGroup());
+        return virtualMachine;
     }
 
     public void setSubscriptionId(final String subscriptionId) {
@@ -84,31 +108,49 @@ public class DraftVirtualMachine extends VirtualMachine implements AzureResource
 
     VirtualMachine create(final AzureVirtualMachine module) {
         this.module = module;
-        final WithPublicIPAddress withPublicIPAddress = module.getVirtualMachinesManager(subscriptionId).define(this.getName())
+        final NetworkInterface.DefinitionStages.WithCreate interfaceWithCreate = module.getVirtualMachinesManager(subscriptionId).manager().networkManager()
+                .networkInterfaces().define(name + "-interface-" + Utils.getTimestamp())
                 .withRegion(this.getRegion().getName())
                 .withExistingResourceGroup(this.getResourceGroup())
                 .withExistingPrimaryNetwork(this.getNetworkClient())
                 .withSubnet(subnet.getName())
                 .withPrimaryPrivateIPAddressDynamic();
-        final WithProximityPlacementGroup withProximityPlacementGroup = ipAddress != null ?
-                withPublicIPAddress.withExistingPrimaryPublicIPAddress(getPublicIpAddressClient()) : withPublicIPAddress.withoutPrimaryPublicIPAddress();
+        if (ipAddress != null) {
+            final com.azure.resourcemanager.network.models.PublicIpAddress publicIpAddressClient = getPublicIpAddressClient();
+            if (publicIpAddressClient.hasAssignedNetworkInterface()) {
+                AzureMessager.getMessager().warning(AzureString.format("Can not assign public ip %s to vm %s, which has been assigned to %s",
+                        ipAddress.getName(), name, publicIpAddressClient.getAssignedNetworkInterfaceIPConfiguration().name()));
+            } else {
+                interfaceWithCreate.withExistingPrimaryPublicIPAddress(getPublicIpAddressClient());
+            }
+        }
+        if (securityGroup != null) {
+            interfaceWithCreate.withExistingNetworkSecurityGroup(getSecurityGroupClient());
+        }
+        final NetworkInterface networkInterface = interfaceWithCreate.create();
+        final WithProximityPlacementGroup withProximityPlacementGroup = module.getVirtualMachinesManager(subscriptionId).define(this.getName())
+                .withRegion(this.getRegion().getName())
+                .withExistingResourceGroup(this.getResourceGroup())
+                .withExistingPrimaryNetworkInterface(networkInterface);
         final WithCreate withCreate = configureImage(withProximityPlacementGroup);
         if (StringUtils.isNotEmpty(availabilitySet)) {
             withCreate.withExistingAvailabilitySet(getAvailabilitySetClient());
         }
         if (storageAccount != null) {
-            // todo: implement storage account
+            withCreate.withExistingStorageAccount(getStorageAccountClient());
         }
         if (azureSpotConfig != null) {
-            // todo: implement azure spot related configs
+            final VirtualMachineEvictionPolicyTypes evictionPolicyTypes = azureSpotConfig.getPolicy() == StopAndDeallocate ? DEALLOCATE : DELETE;
+            withCreate.withSpotPriority(evictionPolicyTypes).withMaxPrice(azureSpotConfig.getMaximumPrice());
         }
         this.remote = withCreate.create();
-        if (securityGroup != null) {
-            this.remote.getPrimaryNetworkInterface().update().withExistingNetworkSecurityGroup(getSecurityGroupClient()).apply();
-        }
         refreshStatus();
         module.refresh();
         return this;
+    }
+
+    private StorageAccount getStorageAccountClient() {
+        return StorageManagerFactory.create(subscriptionId).storageAccounts().getById(storageAccount.getId());
     }
 
     private WithCreate configureImage(final WithProximityPlacementGroup withCreate) {

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/DraftVirtualMachine.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/DraftVirtualMachine.java
@@ -11,6 +11,7 @@ import com.azure.resourcemanager.compute.models.VirtualMachine.DefinitionStages.
 import com.azure.resourcemanager.compute.models.VirtualMachine.DefinitionStages.WithLinuxRootPasswordOrPublicKeyManagedOrUnmanaged;
 import com.azure.resourcemanager.compute.models.VirtualMachine.DefinitionStages.WithProximityPlacementGroup;
 import com.azure.resourcemanager.compute.models.VirtualMachine.DefinitionStages.WithPublicIPAddress;
+import com.azure.resourcemanager.resources.fluentcore.arm.models.HasId;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.compute.AzureResourceDraft;
 import com.microsoft.azure.toolkit.lib.compute.ip.PublicIpAddress;
@@ -22,6 +23,7 @@ import com.microsoft.azure.toolkit.lib.compute.vm.model.AzureSpotConfig;
 import com.microsoft.azure.toolkit.lib.compute.vm.model.OperatingSystem;
 import com.microsoft.azure.toolkit.lib.storage.service.StorageAccount;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
@@ -31,6 +33,7 @@ import java.util.Optional;
 
 @Getter
 @Setter
+@NoArgsConstructor
 public class DraftVirtualMachine extends VirtualMachine implements AzureResourceDraft<VirtualMachine> {
     private Region region;
     private AzureImage image;
@@ -49,6 +52,23 @@ public class DraftVirtualMachine extends VirtualMachine implements AzureResource
 
     public DraftVirtualMachine(@Nonnull final String subscriptionId, @Nonnull final String resourceGroup, @Nonnull final String name) {
         super(getResourceId(subscriptionId, resourceGroup, name), null);
+    }
+
+    public void setSubscriptionId(final String subscriptionId) {
+        this.subscriptionId = subscriptionId;
+    }
+
+    public void setResourceGroup(final String resourceGroup) {
+        this.resourceGroup = resourceGroup;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getId() {
+        return Optional.ofNullable(remote).map(HasId::id).orElseGet(() -> getResourceId(subscriptionId, resourceGroup, name));
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/DraftVirtualMachine.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/DraftVirtualMachine.java
@@ -103,7 +103,9 @@ public class DraftVirtualMachine extends VirtualMachine implements AzureResource
             // todo: implement azure spot related configs
         }
         this.remote = withCreate.create();
-        this.remote.getPrimaryNetworkInterface().update().withExistingNetworkSecurityGroup(getSecurityGroupClient()).apply();
+        if (securityGroup != null) {
+            this.remote.getPrimaryNetworkInterface().update().withExistingNetworkSecurityGroup(getSecurityGroupClient()).apply();
+        }
         refreshStatus();
         module.refresh();
         return this;

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/VirtualMachine.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/VirtualMachine.java
@@ -11,11 +11,13 @@ import com.microsoft.azure.toolkit.lib.common.entity.IAzureModule;
 import com.microsoft.azure.toolkit.lib.common.entity.Removable;
 import com.microsoft.azure.toolkit.lib.common.event.AzureOperationEvent;
 import com.microsoft.azure.toolkit.lib.compute.AbstractAzureResource;
+import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@NoArgsConstructor
 public class VirtualMachine extends AbstractAzureResource<com.azure.resourcemanager.compute.models.VirtualMachine, IAzureBaseResource>
         implements AzureOperationEvent.Source<VirtualMachine>, Removable {
 

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/VirtualMachine.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/VirtualMachine.java
@@ -10,6 +10,7 @@ import com.microsoft.azure.toolkit.lib.common.entity.IAzureBaseResource;
 import com.microsoft.azure.toolkit.lib.common.entity.IAzureModule;
 import com.microsoft.azure.toolkit.lib.common.entity.Removable;
 import com.microsoft.azure.toolkit.lib.common.event.AzureOperationEvent;
+import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.compute.AbstractAzureResource;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -42,6 +43,28 @@ public class VirtualMachine extends AbstractAzureResource<com.azure.resourcemana
         return module;
     }
 
+    public void start() {
+        this.status(Status.PENDING);
+        remote().start();
+        this.refreshStatus();
+    }
+
+    public void stop() {
+        this.status(Status.PENDING);
+        remote().powerOff();
+        this.refreshStatus();
+    }
+
+    public void restart() {
+        this.status(Status.PENDING);
+        remote().restart();
+        this.refreshStatus();
+    }
+
+    public Region getRegion() {
+        return Region.fromName(remote().regionName());
+    }
+
     @Override
     protected String loadStatus() {
         final String powerState = Optional.ofNullable(remote().powerState()).map(Objects::toString).orElse(StringUtils.EMPTY);
@@ -61,24 +84,6 @@ public class VirtualMachine extends AbstractAzureResource<com.azure.resourcemana
     @Override
     protected com.azure.resourcemanager.compute.models.VirtualMachine loadRemote() {
         return module.getVirtualMachinesManager(subscriptionId).getByResourceGroup(resourceGroup, name);
-    }
-
-    public void start() {
-        this.status(Status.PENDING);
-        remote().start();
-        this.refreshStatus();
-    }
-
-    public void stop() {
-        this.status(Status.PENDING);
-        remote().powerOff();
-        this.refreshStatus();
-    }
-
-    public void restart() {
-        this.status(Status.PENDING);
-        remote().restart();
-        this.refreshStatus();
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/VirtualMachine.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/vm/VirtualMachine.java
@@ -16,6 +16,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.Optional;
 
 @NoArgsConstructor
 public class VirtualMachine extends AbstractAzureResource<com.azure.resourcemanager.compute.models.VirtualMachine, IAzureBaseResource>
@@ -42,7 +44,7 @@ public class VirtualMachine extends AbstractAzureResource<com.azure.resourcemana
 
     @Override
     protected String loadStatus() {
-        final String powerState = remote().powerState().toString();
+        final String powerState = Optional.ofNullable(remote().powerState()).map(Objects::toString).orElse(StringUtils.EMPTY);
         if (StringUtils.equalsIgnoreCase(powerState, PowerState.RUNNING.toString())) {
             return Status.RUNNING;
         } else if (StringUtils.equalsAnyIgnoreCase(powerState, PowerState.DEALLOCATING.toString(), PowerState.STOPPING.toString(),

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/model/StorageAccountConfig.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/model/StorageAccountConfig.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.common.model.ResourceGroup;
 import com.microsoft.azure.toolkit.lib.common.model.Subscription;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -17,6 +18,7 @@ import java.util.Objects;
 @Getter
 @Setter
 @Builder
+@EqualsAndHashCode
 public class StorageAccountConfig implements IStorageAccountEntity {
 
     private String name;


### PR DESCRIPTION
- Support storage and Azure spot during VM creation
- Add no args constructor for draft resources
- Add constants for parameters and default constructor for draft resources
- Resolve issues in tests