### PR TITLE
[Task #1896353] Migrate to ConsoleTextTerminal instead of JLineTextTerminal

### DIFF
--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -57,8 +57,7 @@ import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.apache.maven.shared.filtering.MavenResourcesFiltering;
-import org.beryx.textio.TextIO;
-import org.beryx.textio.TextIoFactory;
+import org.beryx.textio.console.ConsoleTextTerminal;
 import reactor.core.publisher.Mono;
 
 import javax.annotation.Nonnull;
@@ -282,8 +281,7 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
                 .sorted()
                 .collect(Collectors.toList());
         final SubscriptionOption defaultValue = wrapSubs.get(0);
-        final TextIO textIO = TextIoFactory.getTextIO();
-        final SubscriptionOption subscriptionOptionSelected = new CustomTextIoStringListReader<SubscriptionOption>(textIO::getTextTerminal, null)
+        final SubscriptionOption subscriptionOptionSelected = new CustomTextIoStringListReader<SubscriptionOption>(ConsoleTextTerminal::new, null)
                 .withCustomPrompt(String.format("Please choose a subscription%s: ",
                         highlightDefaultValue(defaultValue == null ? null : defaultValue.getSubscriptionName())))
                 .withNumberedPossibleValues(wrapSubs).withDefaultValue(defaultValue).read("Available subscriptions:");

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/queryer/QueryFactory.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/queryer/QueryFactory.java
@@ -6,12 +6,11 @@
 package com.microsoft.azure.maven.queryer;
 
 import org.apache.maven.settings.Settings;
-import org.beryx.textio.TextIoFactory;
 
 public class QueryFactory {
     public static MavenPluginQueryer getQueryer(Settings settings) {
         return (settings != null && !settings.isInteractiveMode()) ?
             new MavenPluginQueryerBatchModeDefaultImpl() :
-            new TextIOMavenPluginQueryer(TextIoFactory.getTextIO());
+            new TextIOMavenPluginQueryer();
     }
 }

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/queryer/TextIOMavenPluginQueryer.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/queryer/TextIOMavenPluginQueryer.java
@@ -5,20 +5,22 @@
 package com.microsoft.azure.maven.queryer;
 
 import com.microsoft.azure.toolkit.lib.common.logging.Log;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoFailureException;
-import org.beryx.textio.TextIO;
+import org.beryx.textio.GenericInputReader;
+import org.beryx.textio.StringInputReader;
+import org.beryx.textio.console.ConsoleTextTerminal;
 
 import java.util.List;
 
 public class TextIOMavenPluginQueryer extends MavenPluginQueryer {
     private static final String FOUND_VALID_VALUE = "Found valid value. Skip user input.";
     private static final String PROMPT_STRING_WITHOUT_DEFAULTVALUE = "Define value for %s";
-    private TextIO textIO;
 
-    public TextIOMavenPluginQueryer(TextIO textIO) {
-        this.textIO = textIO;
+    private ConsoleTextTerminal terminal;
+
+    public TextIOMavenPluginQueryer() {
+        this.terminal = new ConsoleTextTerminal();
     }
 
     @Override
@@ -29,7 +31,7 @@ public class TextIOMavenPluginQueryer extends MavenPluginQueryer {
             return initValue;
         }
         prompt = StringUtils.isEmpty(prompt) ? getPromptString(attribute) : prompt;
-        return textIO.<String>newGenericInputReader(null)
+        return new GenericInputReader<String>(() -> terminal, null)
                 .withNumberedPossibleValues(options).withDefaultValue(defaultValue).withEqualsFunc(StringUtils::equalsIgnoreCase).read(prompt);
     }
 
@@ -43,7 +45,7 @@ public class TextIOMavenPluginQueryer extends MavenPluginQueryer {
         }
 
         prompt = StringUtils.isEmpty(prompt) ? getPromptString(attribute) : prompt;
-        return textIO.newStringInputReader().withPattern(regex).withDefaultValue(defaultValue).withMinLength(0).read(prompt);
+        return new StringInputReader(() -> terminal).withPattern(regex).withDefaultValue(defaultValue).withMinLength(0).read(prompt);
     }
 
     private String getPromptString(String attributeName) {
@@ -52,6 +54,6 @@ public class TextIOMavenPluginQueryer extends MavenPluginQueryer {
 
     @Override
     public void close() {
-        textIO.dispose();
+        terminal.dispose();
     }
 }


### PR DESCRIPTION
Migrate to `ConsoleTextTerminal` instead of `JLineTextTerminal` as jline shipped with TextIO was not supported within maven 3.8.2+, refers https://github.com/quarkusio/quarkus/issues/19491#issuecomment-901806380

[AB#1896353](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1896353)