### PR TITLE
[Bug#1898672] Migrate to `Scanners.Resources` in `SchemaValidator`

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/validator/SchemaValidator.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/validator/SchemaValidator.java
@@ -49,9 +49,9 @@ public class SchemaValidator {
 
     static {
         // disable invalid warning for schema key word `then`
-        System.setProperty("org.slf4j.simpleLogger.log.com.networknt.schema.JsonMetaSchema", "off");
+        System.setProperty("org.slf4j.simpleLogger.log.com.networknt.schema.JsonMetaSchema", "error");
         // disable diagnostic info from Reflections
-        System.setProperty("org.slf4j.simpleLogger.log.org.reflections.Reflections", "off");
+        System.setProperty("org.slf4j.simpleLogger.log.org.reflections.Reflections", "warn");
     }
 
     private SchemaValidator() {

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/validator/SchemaValidator.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/validator/SchemaValidator.java
@@ -19,7 +19,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.reflections.Reflections;
-import org.reflections.scanners.ResourcesScanner;
+import org.reflections.scanners.Scanners;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.databind.MapperFeature.AUTO_DETECT_CREATORS;
@@ -51,14 +50,15 @@ public class SchemaValidator {
     static {
         // disable invalid warning for schema key word `then`
         System.setProperty("org.slf4j.simpleLogger.log.com.networknt.schema.JsonMetaSchema", "off");
+        // disable diagnostic info from Reflections
+        System.setProperty("org.slf4j.simpleLogger.log.org.reflections.Reflections", "off");
     }
 
     private SchemaValidator() {
-        Optional.of(new Reflections("schema/", new ResourcesScanner()))
-                .filter(reflections -> CollectionUtils.isNotEmpty(reflections.getStore().keySet()))
+        Optional.of(new Reflections("schema", Scanners.Resources))
                 .map(reflections -> {
                     try {
-                        return reflections.getResources(Pattern.compile(".*\\.json"));
+                        return reflections.getResources(".*\\.json");
                     } catch (Exception exception) {
                         return null;
                     }


### PR DESCRIPTION
Migrate to `Scanners.Resources` in `SchemaValidator`, as `ResourceScanner` has been deprecated and could not list resources, refers https://github.com/ronmamo/reflections/releases/tag/0.10.1

[AB#1898672](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1898672)