### PR TITLE
#1872343: refactor AzureToolkitException/AzureMessager to support both Action id or Action instances.

### DIFF
--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
@@ -118,7 +118,7 @@ public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
 
     protected void validateAppName() {
         if (StringUtils.isBlank(appName)) {
-            throw new AzureToolkitRuntimeException("Please config the <appName> in pom.xml");
+            throw new AzureToolkitRuntimeException("<appName> is not configured in pom");
         }
     }
 

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAppServiceMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAppServiceMojo.java
@@ -194,7 +194,7 @@ public abstract class AbstractAppServiceMojo extends AbstractAzureMojo {
                 printCurrentSubscription(appServiceClient);
                 this.subscriptionId = targetSubscriptionId;
             } catch (AzureLoginException | AzureExecutionException | IOException e) {
-                throw new AzureToolkitRuntimeException(String.format("Cannot authenticate due to error %s", e.getMessage()), e);
+                throw new AzureToolkitRuntimeException("Cannot authenticate", e);
             }
         }
         return appServiceClient;

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/deploy/DeployUtils.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/deploy/DeployUtils.java
@@ -37,7 +37,7 @@ class DeployUtils {
                     try {
                         return CloudStorageAccount.parse(key);
                     } catch (InvalidKeyException | URISyntaxException e) {
-                        throw new AzureToolkitRuntimeException("Cannot parse storage connection string due to error: " + e.getMessage(), e);
+                        throw new AzureToolkitRuntimeException("given Azure Storage Account connection string is invalid", e);
                     }
                 })
                 .orElseThrow(() -> new AzureToolkitRuntimeException(INTERNAL_STORAGE_NOT_FOUND));

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/exception/AzureToolkitAuthenticationException.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/exception/AzureToolkitAuthenticationException.java
@@ -5,14 +5,15 @@
 
 package com.microsoft.azure.toolkit.lib.auth.exception;
 
+import com.microsoft.azure.toolkit.lib.common.action.Action;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 
 public class AzureToolkitAuthenticationException extends AzureToolkitRuntimeException {
     public AzureToolkitAuthenticationException(String error) {
-        super(error);
+        super(error, Action.AUTHENTICATE);
     }
 
     public AzureToolkitAuthenticationException(String error, Throwable cause) {
-        super(error, cause);
+        super(error, cause, Action.AUTHENTICATE);
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/action/Action.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/action/Action.java
@@ -34,6 +34,7 @@ import java.util.function.Predicate;
 public class Action<D> {
     public static final String SOURCE = "ACTION_SOURCE";
     public static final Id<Runnable> REQUIRE_AUTH = Id.of("action.common.requireAuth");
+    public static final Id<Void> AUTHENTICATE = Id.of("action.common.authenticate");
     @Nonnull
     private List<AbstractMap.SimpleEntry<BiPredicate<D, ?>, BiConsumer<D, ?>>> handlers = new ArrayList<>();
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/exception/AzureExecutionException.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/exception/AzureExecutionException.java
@@ -5,6 +5,10 @@
 
 package com.microsoft.azure.toolkit.lib.common.exception;
 
+/**
+ * @deprecated use {@link AzureToolkitException} or {@link AzureToolkitRuntimeException} instead
+ */
+@Deprecated
 public class AzureExecutionException extends Exception {
     public AzureExecutionException(String errorMessage, Throwable err) {
         super(errorMessage.toString(), err);

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/exception/AzureToolkitException.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/exception/AzureToolkitException.java
@@ -1,23 +1,6 @@
 /*
- * Copyright (c) Microsoft Corporation
- *
- * All rights reserved.
- *
- * MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
- * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
- * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
- * the Software.
- *
- * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
- * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
- * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
 package com.microsoft.azure.toolkit.lib.common.exception;
@@ -26,28 +9,37 @@ import lombok.Getter;
 
 @Getter
 public class AzureToolkitException extends Exception {
-    private final String action;
-    private final String actionId;
+    /**
+     * array of action id or
+     * {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
+     * {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
+     */
+    private final Object[] actions;
 
     public AzureToolkitException(String error) {
-        this(error, null, null);
+        this(error, (Object[]) null);
     }
 
     public AzureToolkitException(String error, Throwable cause) {
-        this(error, cause, null);
+        this(error, cause, (Object[]) null);
     }
 
-    public AzureToolkitException(String error, String action) {
-        this(error, null, action);
+    /**
+     * @param actions array of action id or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
+     */
+    public AzureToolkitException(String error, Object... actions) {
+        this(error, null, actions);
     }
 
-    public AzureToolkitException(String error, Throwable cause, String action) {
-        this(error, cause, action, null);
-    }
-
-    public AzureToolkitException(String message, Throwable cause, String action, String actionId) {
-        super(message, cause);
-        this.action = action;
-        this.actionId = actionId;
+    /**
+     * @param actions array of action id or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
+     */
+    public AzureToolkitException(String error, Throwable cause, Object... actions) {
+        super(error, cause);
+        this.actions = actions;
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/exception/AzureToolkitRuntimeException.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/exception/AzureToolkitRuntimeException.java
@@ -7,6 +7,8 @@ package com.microsoft.azure.toolkit.lib.common.exception;
 
 import lombok.Getter;
 
+import javax.annotation.Nonnull;
+
 @Getter
 public class AzureToolkitRuntimeException extends RuntimeException {
     /**
@@ -16,15 +18,15 @@ public class AzureToolkitRuntimeException extends RuntimeException {
      */
     private final Object[] actions;
 
-    public AzureToolkitRuntimeException(Throwable cause) {
+    public AzureToolkitRuntimeException(@Nonnull Throwable cause) {
         this(null, cause);
     }
 
-    public AzureToolkitRuntimeException(String error) {
-        this(error, (Object[]) null);
+    public AzureToolkitRuntimeException(@Nonnull String cause) {
+        this(cause, (Object[]) null);
     }
 
-    public AzureToolkitRuntimeException(String error, Throwable cause) {
+    public AzureToolkitRuntimeException(String error, @Nonnull Throwable cause) {
         this(error, cause, (Object[]) null);
     }
 
@@ -33,8 +35,9 @@ public class AzureToolkitRuntimeException extends RuntimeException {
      *                {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
      *                {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
      */
-    public AzureToolkitRuntimeException(String error, Object... actions) {
-        this(error, null, actions);
+    public AzureToolkitRuntimeException(@Nonnull String cause, Object... actions) {
+        super(cause);
+        this.actions = actions;
     }
 
     /**
@@ -42,7 +45,7 @@ public class AzureToolkitRuntimeException extends RuntimeException {
      *                {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
      *                {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
      */
-    public AzureToolkitRuntimeException(String error, Throwable cause, Object... actions) {
+    public AzureToolkitRuntimeException(String error, @Nonnull Throwable cause, Object... actions) {
         super(error, cause);
         this.actions = actions;
     }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/exception/AzureToolkitRuntimeException.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/exception/AzureToolkitRuntimeException.java
@@ -1,23 +1,6 @@
 /*
- * Copyright (c) Microsoft Corporation
- *
- * All rights reserved.
- *
- * MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
- * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
- * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
- * the Software.
- *
- * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
- * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
- * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
 package com.microsoft.azure.toolkit.lib.common.exception;
@@ -26,28 +9,41 @@ import lombok.Getter;
 
 @Getter
 public class AzureToolkitRuntimeException extends RuntimeException {
-    private final String action;
-    private final String actionId;
+    /**
+     * array of action id or
+     * {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
+     * {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
+     */
+    private final Object[] actions;
+
+    public AzureToolkitRuntimeException(Throwable cause) {
+        this(null, cause);
+    }
 
     public AzureToolkitRuntimeException(String error) {
-        this(error, null, null);
+        this(error, (Object[]) null);
     }
 
     public AzureToolkitRuntimeException(String error, Throwable cause) {
-        this(error, cause, null);
+        this(error, cause, (Object[]) null);
     }
 
-    public AzureToolkitRuntimeException(String error, String action) {
-        this(error, null, action);
+    /**
+     * @param actions array of action id or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
+     */
+    public AzureToolkitRuntimeException(String error, Object... actions) {
+        this(error, null, actions);
     }
 
-    public AzureToolkitRuntimeException(String error, Throwable cause, String action) {
-        this(error, cause, action, null);
-    }
-
-    public AzureToolkitRuntimeException(String error, Throwable cause, String action, String actionId) {
+    /**
+     * @param actions array of action id or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
+     */
+    public AzureToolkitRuntimeException(String error, Throwable cause, Object... actions) {
         super(error, cause);
-        this.action = action;
-        this.actionId = actionId;
+        this.actions = actions;
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/exception/CommandExecuteException.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/exception/CommandExecuteException.java
@@ -5,7 +5,7 @@
 
 package com.microsoft.azure.toolkit.lib.common.exception;
 
-public class CommandExecuteException extends RuntimeException {
+public class CommandExecuteException extends AzureToolkitRuntimeException {
     private static final long serialVersionUID = 4582230448665092548L;
 
     public CommandExecuteException(String message) {

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/exception/InvalidConfigurationException.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/exception/InvalidConfigurationException.java
@@ -5,7 +5,7 @@
 
 package com.microsoft.azure.toolkit.lib.common.exception;
 
-public class InvalidConfigurationException extends Exception {
+public class InvalidConfigurationException extends AzureToolkitException {
 
     private static final long serialVersionUID = 3122420022403832460L;
 

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/messager/AzureHtmlMessage.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/messager/AzureHtmlMessage.java
@@ -50,14 +50,6 @@ public class AzureHtmlMessage extends AzureMessage {
                 .orElse(null);
     }
 
-    @Nullable
-    @Override
-    protected String getErrorAction(@Nonnull Throwable throwable) {
-        return Optional.ofNullable(super.getErrorAction(throwable))
-                .map(a -> String.format("<p>%s</p>", a))
-                .orElse(null);
-    }
-
     @Override
     protected String getDetailItem(IAzureOperation o) {
         return String.format("<li>%s</li>", super.getDetailItem(o));

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/messager/IAzureMessager.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/messager/IAzureMessager.java
@@ -5,7 +5,6 @@
 
 package com.microsoft.azure.toolkit.lib.common.messager;
 
-import com.microsoft.azure.toolkit.lib.common.action.Action;
 import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
 
 import javax.annotation.Nonnull;
@@ -15,39 +14,84 @@ import java.util.Optional;
 public interface IAzureMessager {
     String DEFAULT_TITLE = "Azure";
 
-    default void success(@Nonnull String message, String title, Action<?>... actions) {
+    /**
+     * @param actions array of action id or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
+     */
+    default void success(@Nonnull String message, String title, Object... actions) {
         this.show(this.buildMessage(IAzureMessage.Type.SUCCESS, AzureString.fromString(message), title, actions, null));
     }
 
-    default void success(@Nonnull AzureString message, String title, Action<?>... actions) {
+    /**
+     * @param actions array of action id or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
+     */
+    default void success(@Nonnull AzureString message, String title, Object... actions) {
         this.show(this.buildMessage(IAzureMessage.Type.SUCCESS, message, title, actions, null));
     }
 
-    default void info(@Nonnull String message, String title, Action<?>... actions) {
+    /**
+     * @param actions array of action id or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
+     */
+    default void info(@Nonnull String message, String title, Object... actions) {
         this.show(this.buildMessage(IAzureMessage.Type.INFO, AzureString.fromString(message), title, actions, null));
     }
 
-    default void info(@Nonnull AzureString message, String title, Action<?>... actions) {
+    /**
+     * @param actions array of action id or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
+     */
+    default void info(@Nonnull AzureString message, String title, Object... actions) {
         this.show(this.buildMessage(IAzureMessage.Type.INFO, message, title, actions, null));
     }
 
-    default void warning(@Nonnull String message, String title, Action<?>... actions) {
+    /**
+     * @param actions array of action id or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
+     */
+    default void warning(@Nonnull String message, String title, Object... actions) {
         this.show(this.buildMessage(IAzureMessage.Type.WARNING, AzureString.fromString(message), title, actions, null));
     }
 
-    default void warning(@Nonnull AzureString message, String title, Action<?>... actions) {
+    /**
+     * @param actions array of action id or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
+     */
+    default void warning(@Nonnull AzureString message, String title, Object... actions) {
         this.show(this.buildMessage(IAzureMessage.Type.WARNING, message, title, actions, null));
     }
 
-    default void error(@Nonnull String message, String title, Action<?>... actions) {
+    /**
+     * @param actions array of action id or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
+     */
+    default void error(@Nonnull String message, String title, Object... actions) {
         this.show(this.buildMessage(IAzureMessage.Type.ERROR, AzureString.fromString(message), title, actions, null));
     }
 
-    default void error(@Nonnull AzureString message, String title, Action<?>... actions) {
+    /**
+     * @param actions array of action id or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
+     */
+    default void error(@Nonnull AzureString message, String title, Object... actions) {
         this.show(this.buildMessage(IAzureMessage.Type.ERROR, message, title, actions, null));
     }
 
-    default void error(@Nonnull Throwable throwable, String title, Action<?>... actions) {
+    /**
+     * @param actions array of action id or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action} or
+     *                {@link com.microsoft.azure.toolkit.lib.common.action.Action.Id}
+     */
+    default void error(@Nonnull Throwable throwable, String title, Object... actions) {
         final String message = Optional.ofNullable(throwable.getMessage()).orElse(throwable.getClass().getSimpleName());
         this.show(this.buildMessage(IAzureMessage.Type.ERROR, AzureString.fromString(message), title, actions, throwable));
     }
@@ -66,42 +110,6 @@ public interface IAzureMessager {
 
     default void alert(@Nonnull AzureString message, String title) {
         this.show(this.buildMessage(IAzureMessage.Type.ALERT, message, title, null, null));
-    }
-
-    default void success(@Nonnull String message, String title) {
-        this.success(message, title, new Action<?>[0]);
-    }
-
-    default void success(@Nonnull AzureString message, String title) {
-        this.success(message, title, new Action<?>[0]);
-    }
-
-    default void info(@Nonnull String message, String title) {
-        this.info(message, title, new Action<?>[0]);
-    }
-
-    default void info(@Nonnull AzureString message, String title) {
-        this.info(message, title, new Action<?>[0]);
-    }
-
-    default void warning(@Nonnull String message, String title) {
-        this.warning(message, title, new Action<?>[0]);
-    }
-
-    default void warning(@Nonnull AzureString message, String title) {
-        this.warning(message, title, new Action<?>[0]);
-    }
-
-    default void error(@Nonnull String message, String title) {
-        this.error(message, title, new Action<?>[0]);
-    }
-
-    default void error(@Nonnull AzureString message, String title) {
-        this.error(message, title, new Action<?>[0]);
-    }
-
-    default void error(@Nonnull Throwable throwable, String title) {
-        this.error(throwable, title, new Action<?>[0]);
     }
 
     default boolean confirm(@Nonnull String message) {
@@ -157,7 +165,7 @@ public interface IAzureMessager {
     }
 
     default IAzureMessage buildMessage(@Nonnull IAzureMessage.Type type, @Nonnull AzureString content,
-                                       @Nullable String title, @Nullable Action<?>[] actions, @Nullable Object payload) {
+                                       @Nullable String title, @Nullable Object[] actions, @Nullable Object payload) {
         final AzureMessage message = new AzureMessage(type, content).setPayload(payload).setActions(actions).setTitle(title);
         if (this instanceof IAzureMessage.ValueDecorator) {
             message.setValueDecorator((IAzureMessage.ValueDecorator) this);

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/operation/AzureOperationAspect.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/operation/AzureOperationAspect.java
@@ -75,7 +75,7 @@ public final class AzureOperationAspect {
         if (source instanceof IAzureBaseResource) {
             ((IAzureBaseResource<?, ?>) source).refresh();
         }
-        if (!(e instanceof RuntimeException)) {
+        if (e instanceof Exception && !(e instanceof RuntimeException)) {
             throw e; // do not wrap checked exception
         }
         throw new AzureOperationException(operation, e);

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/operation/AzureOperationException.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/operation/AzureOperationException.java
@@ -8,26 +8,12 @@ package com.microsoft.azure.toolkit.lib.common.operation;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import lombok.Getter;
 
-import java.util.Optional;
-
 @Getter
 public class AzureOperationException extends AzureToolkitRuntimeException {
     private final IAzureOperation operation;
 
-    AzureOperationException(final IAzureOperation operation, final Throwable cause) {
-        this(operation, cause, null);
-    }
-
-    AzureOperationException(final IAzureOperation operation, final String action) {
-        this(operation, null, action);
-    }
-
-    AzureOperationException(final IAzureOperation operation, final Throwable cause, final String action) {
-        this(operation, cause, action, null);
-    }
-
-    AzureOperationException(final IAzureOperation operation, final Throwable cause, final String action, final String actionId) {
-        super(Optional.ofNullable(operation.getTitle()).map(Object::toString).orElse(null), cause, action, actionId);
+    public AzureOperationException(final IAzureOperation operation, final Throwable cause) {
+        super(cause);
         this.operation = operation;
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/operation/SimpleOperation.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/operation/SimpleOperation.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.common.operation;
+
+import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import javax.annotation.Nonnull;
+
+@RequiredArgsConstructor
+public class SimpleOperation implements IAzureOperation {
+
+    @Getter
+    @Nonnull
+    private final AzureString title;
+    @Nonnull
+    private final AzureOperation.Type type;
+    @Getter
+    @Setter
+    private IAzureOperation parent;
+
+    @Nonnull
+    @Override
+    public String getType() {
+        return this.type.name();
+    }
+}

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/task/DeployExternalResourcesTask.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/task/DeployExternalResourcesTask.java
@@ -55,7 +55,7 @@ public class DeployExternalResourcesTask extends AzureTask<IWebAppBase<?>> {
                 uploadResource(externalResource, ftpClient);
             }
         } catch (IOException e) {
-            throw new AzureToolkitRuntimeException(e.getMessage(), e);
+            throw new AzureToolkitRuntimeException(e);
         }
     }
 


### PR DESCRIPTION
[AB#1872343](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1872343): refactor AzureToolkitException/AzureMessager to support both Action id or Action instances.