### PR TITLE
#1904793: [Test] Deploy spring cloud app with new deployment name failed with error "properties.source.type must be set"

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudDeployment.java
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudDeployment.java
@@ -11,6 +11,7 @@ import com.azure.resourcemanager.appplatform.models.DeploymentSettings;
 import com.azure.resourcemanager.appplatform.models.RuntimeVersion;
 import com.azure.resourcemanager.appplatform.models.Sku;
 import com.azure.resourcemanager.appplatform.models.SpringAppDeployment;
+import com.azure.resourcemanager.appplatform.models.UserSourceType;
 import com.azure.resourcemanager.resources.fluentcore.model.Refreshable;
 import com.google.common.base.Charsets;
 import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
@@ -301,6 +302,7 @@ public class SpringCloudDeployment extends AbstractAzureResource<SpringCloudDepl
         public Creator(SpringCloudDeployment deployment) {
             super(deployment);
             this.modifier = (SpringAppDeploymentImpl) Objects.requireNonNull(this.deployment.app.remote()).deployments().define(deployment.name());
+            this.modifier.withExistingSource(UserSourceType.JAR, "<default>");
         }
 
         @AzureOperation(


### PR DESCRIPTION
[AB#1904793](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1904793): [Test] Deploy spring cloud app with new deployment name failed with error "properties.source.type must be set"