### PR TITLE
[Task #1872026] Deprecate entity in app service, move the get method to related resource

### DIFF
--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
@@ -167,7 +167,7 @@ public class DeployMojo extends AbstractFunctionMojo {
         mergeAppServiceConfig(config, defaultConfig);
         if (!newFunctionApp && !config.disableAppInsights() && StringUtils.isEmpty(config.appInsightsKey())) {
             // fill ai key from existing app settings
-            config.appInsightsKey(app.entity().getAppSettings().get(CreateOrUpdateFunctionAppTask.APPINSIGHTS_INSTRUMENTATION_KEY));
+            config.appInsightsKey(app.getAppSettings().get(CreateOrUpdateFunctionAppTask.APPINSIGHTS_INSTRUMENTATION_KEY));
         }
         return new CreateOrUpdateFunctionAppTask(config).execute();
     }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/IAppService.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/IAppService.java
@@ -8,11 +8,14 @@ import com.microsoft.azure.toolkit.lib.appservice.entity.AppServiceBaseEntity;
 import com.microsoft.azure.toolkit.lib.appservice.model.DiagnosticConfig;
 import com.microsoft.azure.toolkit.lib.appservice.model.PublishingProfile;
 import com.microsoft.azure.toolkit.lib.appservice.model.Runtime;
+import com.microsoft.azure.toolkit.lib.appservice.service.impl.AppServicePlan;
 import com.microsoft.azure.toolkit.lib.common.entity.IAzureResource;
 import com.microsoft.azure.toolkit.lib.common.entity.Removable;
+import com.microsoft.azure.toolkit.lib.common.model.Region;
 import reactor.core.publisher.Flux;
 
 import java.io.InputStream;
+import java.util.Map;
 
 public interface IAppService<T extends AppServiceBaseEntity> extends IFileClient, IProcessClient, IAzureResource<T>, Removable {
     void start();
@@ -30,6 +33,12 @@ public interface IAppService<T extends AppServiceBaseEntity> extends IFileClient
     String state();
 
     Runtime getRuntime();
+
+    AppServicePlan getAppServicePlan();
+
+    Map<String, String> getAppSettings();
+
+    Region getRegion();
 
     @Deprecated
     T getRawEntity();

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/AbstractAppService.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/AbstractAppService.java
@@ -10,6 +10,8 @@ import com.azure.resourcemanager.appservice.models.PublishingProfileFormat;
 import com.azure.resourcemanager.appservice.models.WebAppBase;
 import com.azure.resourcemanager.appservice.models.WebSiteBase;
 import com.microsoft.azure.arm.resources.ResourceId;
+import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.appservice.AzureAppServicePlan;
 import com.microsoft.azure.toolkit.lib.appservice.entity.AppServiceBaseEntity;
 import com.microsoft.azure.toolkit.lib.appservice.manager.AppServiceKuduManager;
 import com.microsoft.azure.toolkit.lib.appservice.model.AppServiceFile;
@@ -22,8 +24,12 @@ import com.microsoft.azure.toolkit.lib.appservice.model.TunnelStatus;
 import com.microsoft.azure.toolkit.lib.appservice.service.IAppService;
 import com.microsoft.azure.toolkit.lib.appservice.service.IFileClient;
 import com.microsoft.azure.toolkit.lib.appservice.service.IProcessClient;
+import com.microsoft.azure.toolkit.lib.appservice.utils.Utils;
+import com.microsoft.azure.toolkit.lib.common.cache.CacheManager;
+import com.microsoft.azure.toolkit.lib.common.cache.Cacheable;
 import com.microsoft.azure.toolkit.lib.common.event.AzureEventBus;
 import com.microsoft.azure.toolkit.lib.common.event.AzureOperationEvent;
+import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTaskManager;
 import org.apache.commons.lang3.StringUtils;
@@ -34,6 +40,7 @@ import javax.annotation.Nullable;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -69,6 +76,12 @@ abstract class AbstractAppService<T extends WebAppBase, R extends AppServiceBase
         super.refresh();
         this.entity = Optional.ofNullable(this.remote).map(this::getEntityFromRemoteResource).orElse(null);
         this.refreshStatus();
+        try {
+            CacheManager.evictCache("appservice/{}/runtime", this.id());
+            CacheManager.evictCache("appservice/{}/appSettings", this.id());
+        } catch (Throwable e) {
+            // swallow exception for cache
+        }
     }
 
     @Override
@@ -102,6 +115,7 @@ abstract class AbstractAppService<T extends WebAppBase, R extends AppServiceBase
 
     @Override
     @Nonnull
+    @Deprecated
     public synchronized R entity() {
         if (entity == null) {
             entity = getEntityFromRemoteResource(remote());
@@ -122,11 +136,6 @@ abstract class AbstractAppService<T extends WebAppBase, R extends AppServiceBase
     @Override
     public String state() {
         return remote().state();
-    }
-
-    @Override
-    public Runtime getRuntime() {
-        return entity().getRuntime();
     }
 
     @Override
@@ -226,6 +235,28 @@ abstract class AbstractAppService<T extends WebAppBase, R extends AppServiceBase
 
     public final void refreshStatus() {
         AzureTaskManager.getInstance().runOnPooledThread(() -> this.status(this.loadStatus()));
+    }
+
+    @Override
+    public AppServicePlan getAppServicePlan() {
+        return Azure.az(AzureAppServicePlan.class).get(remote().appServicePlanId());
+    }
+
+    @Override
+    public Region getRegion() {
+        return Region.fromName(remote().regionName());
+    }
+
+    @Override
+    @Cacheable(cacheName = "appservice/{}/appSettings", key = "${this.getId()}")
+    public Map<String, String> getAppSettings() {
+        return Utils.normalizeAppSettings(remote().getAppSettings());
+    }
+
+    @Override
+    @Cacheable(cacheName = "appservice/{}/runtime", key = "${this.getId()}")
+    public Runtime getRuntime() {
+        return AppServiceUtils.getRuntimeFromAppService(remote());
     }
 
     protected final void status(@Nonnull String status) {

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/AppServicePlan.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/AppServicePlan.java
@@ -63,11 +63,25 @@ public class AppServicePlan extends AbstractAzureManager<com.azure.resourcemanag
         return String.format(APP_SERVICE_PLAN_ID_TEMPLATE, subscriptionId, resourceGroup, name);
     }
 
+    @Deprecated
     public AppServicePlanEntity entity() {
         if (remote == null) {
             refresh();
         }
         return entity;
+    }
+
+    public PricingTier getPricingTier() {
+        final com.azure.resourcemanager.appservice.models.PricingTier pricingTier = remote().pricingTier();
+        return PricingTier.fromString(pricingTier.toSkuDescription().tier(), pricingTier.toSkuDescription().size());
+    }
+
+    public Region getRegion() {
+        return Region.fromName(remote().regionName());
+    }
+
+    public OperatingSystem getOperatingSystem() {
+        return OperatingSystem.fromString(remote().operatingSystem().name());
     }
 
     public List<WebApp> webapps() {

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/AppServiceUtils.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/AppServiceUtils.java
@@ -57,7 +57,7 @@ class AppServiceUtils {
     private static final String ENTRY_POINT = "entryPoint";
     private static final String BINDINGS = "bindings";
 
-    static Runtime getRuntimeFromAppService(WebAppBase webAppBase) {
+    public static Runtime getRuntimeFromAppService(WebAppBase webAppBase) {
         if (StringUtils.startsWithIgnoreCase(webAppBase.linuxFxVersion(), "docker")) {
             return Runtime.DOCKER;
         }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/FunctionApp.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/FunctionApp.java
@@ -302,11 +302,10 @@ public class FunctionApp extends FunctionAppBase<com.azure.resourcemanager.appse
         }
 
         private Update updateAppServicePlan(Update update, AppServicePlanEntity newServicePlan) {
-            final String servicePlanId = remote().appServicePlanId();
-            final AppServicePlanEntity currentServicePlan = Azure.az(AzureAppServicePlan.class).get(servicePlanId).entity();
-            if (StringUtils.equalsIgnoreCase(currentServicePlan.getId(), newServicePlan.getId()) ||
-                (StringUtils.equalsIgnoreCase(currentServicePlan.getName(), newServicePlan.getName()) &&
-                    StringUtils.equalsIgnoreCase(currentServicePlan.getResourceGroup(), newServicePlan.getResourceGroup()))) {
+            final com.microsoft.azure.toolkit.lib.appservice.service.impl.AppServicePlan plan = FunctionApp.this.getAppServicePlan();
+            if (StringUtils.equalsIgnoreCase(plan.getId(), newServicePlan.getId()) ||
+                    (StringUtils.equalsIgnoreCase(plan.getName(), newServicePlan.getName()) &&
+                            StringUtils.equalsIgnoreCase(plan.getResourceGroupName(), newServicePlan.getResourceGroup()))) {
                 return update;
             }
             final AppServicePlan newPlanServiceModel = AppServiceUtils.getAppServicePlan(newServicePlan, azureClient);

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/FunctionAppBase.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/FunctionAppBase.java
@@ -1,9 +1,11 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
 package com.microsoft.azure.toolkit.lib.appservice.service.impl;
 
 import com.azure.resourcemanager.appservice.models.WebAppBase;
 import com.azure.resourcemanager.appservice.models.WebSiteBase;
-import com.microsoft.azure.toolkit.lib.Azure;
-import com.microsoft.azure.toolkit.lib.appservice.AzureAppService;
 import com.microsoft.azure.toolkit.lib.appservice.entity.AppServiceBaseEntity;
 import com.microsoft.azure.toolkit.lib.appservice.manager.AzureFunctionsResourceManager;
 import com.microsoft.azure.toolkit.lib.appservice.model.FunctionDeployType;
@@ -61,7 +63,7 @@ public abstract class FunctionAppBase<T extends WebAppBase, R extends AppService
         if (getRuntime().getOperatingSystem() == OperatingSystem.WINDOWS) {
             return FunctionDeployType.RUN_FROM_ZIP;
         }
-        final PricingTier pricingTier = Azure.az(AzureAppService.class).appServicePlan(remote().appServicePlanId()).entity().getPricingTier();
+        final PricingTier pricingTier = getAppServicePlan().getPricingTier();
         return StringUtils.equalsAnyIgnoreCase(pricingTier.getTier(), "Dynamic", "ElasticPremium") ?
                 FunctionDeployType.RUN_FROM_BLOB : FunctionDeployType.RUN_FROM_ZIP;
     }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/FunctionAppDeploymentSlot.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/FunctionAppDeploymentSlot.java
@@ -101,9 +101,8 @@ public class FunctionAppDeploymentSlot extends FunctionAppBase<FunctionDeploymen
 
     @Override
     public String getMasterKey() {
-        final String resourceGroup = entity().getResourceGroup();
-        final String name = String.format("%s/slots/%s", entity().getFunctionAppName(), entity().getName());
-        return remote().manager().serviceClient().getWebApps().listHostKeysAsync(resourceGroup, name).map(HostKeysInner::masterKey).block();
+        final String name = String.format("%s/slots/%s", parent.getName(), this.getName());
+        return remote().manager().serviceClient().getWebApps().listHostKeysAsync(this.getResourceGroupName(), name).map(HostKeysInner::masterKey).block();
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/WebApp.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/WebApp.java
@@ -260,11 +260,10 @@ public class WebApp extends AbstractAppService<com.azure.resourcemanager.appserv
         }
 
         private Update updateAppServicePlan(Update update, AppServicePlanEntity newServicePlan) {
-            final String servicePlanId = remote().appServicePlanId();
-            final AppServicePlanEntity currentServicePlan = Azure.az(AzureAppServicePlan.class).get(servicePlanId).entity();
-            if (StringUtils.equalsIgnoreCase(currentServicePlan.getId(), newServicePlan.getId()) ||
-                (StringUtils.equalsIgnoreCase(currentServicePlan.getName(), newServicePlan.getName()) &&
-                    StringUtils.equalsIgnoreCase(currentServicePlan.getResourceGroup(), newServicePlan.getResourceGroup()))) {
+            final com.microsoft.azure.toolkit.lib.appservice.service.impl.AppServicePlan appServicePlan = WebApp.this.getAppServicePlan();
+            if (StringUtils.equalsIgnoreCase(appServicePlan.getId(), newServicePlan.getId()) ||
+                (StringUtils.equalsIgnoreCase(appServicePlan.getName(), newServicePlan.getName()) &&
+                    StringUtils.equalsIgnoreCase(appServicePlan.getResourceGroupName(), newServicePlan.getResourceGroup()))) {
                 return update;
             }
             final AppServicePlan newPlanServiceModel = AppServiceUtils.getAppServicePlan(newServicePlan, azureClient);

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateAppServicePlanTask.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateAppServicePlanTask.java
@@ -10,7 +10,6 @@ import com.microsoft.azure.toolkit.lib.appservice.AzureAppService;
 import com.microsoft.azure.toolkit.lib.appservice.config.AppServicePlanConfig;
 import com.microsoft.azure.toolkit.lib.appservice.service.impl.AppServicePlan;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
-import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import com.microsoft.azure.toolkit.lib.common.task.AzureTask;
 import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemetry;
@@ -47,11 +46,11 @@ public class CreateOrUpdateAppServicePlanTask extends AzureTask<AppServicePlan> 
                 .commit();
             AzureMessager.getMessager().info(String.format(CREATE_APP_SERVICE_PLAN_DONE, appServicePlan.name()));
         } else {
-            if (config.region() != null && !Objects.equals(config.region(), Region.fromName(appServicePlan.entity().getRegion()))) {
+            if (config.region() != null && !Objects.equals(config.region(), appServicePlan.getRegion())) {
                 AzureMessager.getMessager().warning(String.format("Skip region update for existing service plan '%s' since it is not allowed.",
                     appServicePlan.name()));
             }
-            if (config.pricingTier() != null && !Objects.equals(config.pricingTier(), appServicePlan.entity().getPricingTier())) {
+            if (config.pricingTier() != null && !Objects.equals(config.pricingTier(), appServicePlan.getPricingTier())) {
                 // apply pricing tier to service plan
                 appServicePlan.update().withPricingTier(config.pricingTier()).commit();
             }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/utils/AppServiceConfigUtils.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/utils/AppServiceConfigUtils.java
@@ -32,14 +32,13 @@ public class AppServiceConfigUtils {
         AppServiceConfig config = new AppServiceConfig();
         config.appName(appService.name());
 
-        config.resourceGroup(appService.entity().getResourceGroup());
+        config.resourceGroup(appService.getResourceGroupName());
         config.subscriptionId(Utils.getSubscriptionId(appService.id()));
-        config.region(appService.entity().getRegion());
-        config.pricingTier(servicePlan.entity().getPricingTier());
+        config.region(appService.getRegion());
         RuntimeConfig runtimeConfig = new RuntimeConfig();
         if (AppServiceUtils.isDockerAppService(appService)) {
             runtimeConfig.os(OperatingSystem.DOCKER);
-            final Map<String, String> settings = appService.entity().getAppSettings();
+            final Map<String, String> settings = appService.getAppSettings();
 
             final String imageSetting = settings.get(SETTING_DOCKER_IMAGE);
             if (StringUtils.isNotBlank(imageSetting)) {
@@ -57,11 +56,9 @@ public class AppServiceConfigUtils {
             runtimeConfig.javaVersion(appService.getRuntime().getJavaVersion());
         }
         config.runtime(runtimeConfig);
-        if (servicePlan.entity() != null) {
-            config.pricingTier(servicePlan.entity().getPricingTier());
-            config.servicePlanName(servicePlan.name());
-            config.servicePlanResourceGroup(servicePlan.entity().getResourceGroup());
-        }
+        config.pricingTier(servicePlan.getPricingTier());
+        config.servicePlanName(servicePlan.name());
+        config.servicePlanResourceGroup(servicePlan.getResourceGroupName());
         return config;
     }
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
@@ -534,7 +534,7 @@ public class ConfigMojo extends AbstractWebAppMojo {
                 .region(appServiceConfig.region());
         builder.os(appServiceConfig.runtime().os());
         if (AppServiceUtils.isDockerAppService(webapp)) {
-            final Map<String, String> settings = webapp.entity().getAppSettings();
+            final Map<String, String> settings = webapp.getAppSettings();
             builder.image(appServiceConfig.runtime().image());
             builder.registryUrl(appServiceConfig.runtime().registryUrl());
             final String dockerUsernameSetting = settings.get(SETTING_REGISTRY_USERNAME);


### PR DESCRIPTION
### Issue to resolve
Currently we will send unnecessary requests when get runtime configuration or app settings of app service, as we use leverage the `entity()` method to get the parameters. However, entity() will load all properties of app service and in most cases we just care about specific properties like runtime, and the unnecessary requests may affect our performance.

### Solution
Add method with cache to get properties directly in app service library 

[AB#1872026](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1872026)