### PR TITLE
Clean up reference for app service entity in app service library

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/IAppService.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/IAppService.java
@@ -32,6 +32,8 @@ public interface IAppService<T extends AppServiceBaseEntity> extends IFileClient
 
     String state();
 
+    String linuxFxVersion();
+
     Runtime getRuntime();
 
     AppServicePlan getAppServicePlan();

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/AbstractAppService.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/AbstractAppService.java
@@ -74,8 +74,8 @@ abstract class AbstractAppService<T extends WebAppBase, R extends AppServiceBase
     public void refresh() {
         this.status(Status.PENDING);
         super.refresh();
-        this.entity = Optional.ofNullable(this.remote).map(this::getEntityFromRemoteResource).orElse(null);
         this.refreshStatus();
+        this.entity = null;
         try {
             CacheManager.evictCache("appservice/{}/runtime", this.id());
             CacheManager.evictCache("appservice/{}/appSettings", this.id());
@@ -136,6 +136,11 @@ abstract class AbstractAppService<T extends WebAppBase, R extends AppServiceBase
     @Override
     public String state() {
         return remote().state();
+    }
+
+    @Override
+    public String linuxFxVersion() {
+        return remote().linuxFxVersion();
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/AppServiceUtils.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/AppServiceUtils.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 class AppServiceUtils {
@@ -224,7 +223,7 @@ class AppServiceUtils {
 
         final String linuxFxVersion = webAppBase.linuxFxVersion();
         if (StringUtils.startsWithIgnoreCase(linuxFxVersion, "docker")) {
-            builder.dockerImageName(getDockerImageNameFromLinuxFxVersion(linuxFxVersion));
+            builder.dockerImageName(Utils.getDockerImageNameFromLinuxFxVersion(linuxFxVersion));
         }
         return builder.build();
     }
@@ -399,16 +398,4 @@ class AppServiceUtils {
                 .properties(bindingProperties).build();
     }
 
-    private static String getDockerImageNameFromLinuxFxVersion(String linuxFxVersion) {
-        String[] segments = linuxFxVersion.split(Pattern.quote("|"));
-        if (segments.length != 2) {
-            return null;
-        }
-        final String image = segments[1];
-        if (!image.contains("/")) {
-            return image;
-        }
-        segments = image.split(Pattern.quote("/"));
-        return segments[segments.length - 1].trim();
-    }
 }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/utils/AppServiceConfigUtils.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/utils/AppServiceConfigUtils.java
@@ -44,7 +44,7 @@ public class AppServiceConfigUtils {
             if (StringUtils.isNotBlank(imageSetting)) {
                 runtimeConfig.image(imageSetting);
             } else {
-                runtimeConfig.image(appService.entity().getDockerImageName());
+                runtimeConfig.image(Utils.getDockerImageNameFromLinuxFxVersion(appService.linuxFxVersion()));
             }
             final String registryServerSetting = settings.get(SETTING_REGISTRY_SERVER);
             if (StringUtils.isNotBlank(registryServerSetting)) {

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/utils/Utils.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/utils/Utils.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class Utils {
@@ -86,5 +87,18 @@ public class Utils {
     public static void throwForbidCreateResourceWarning(String resourceType, String name) {
         throw new AzureToolkitRuntimeException(String.format("%s(%s) cannot be found, if you want to create azure resources please remove command line arguments: " +
             "`-Dazure.resource.create.skip=true` or `-DskipCreateAzureResource`.", resourceType, name));
+    }
+
+    public static String getDockerImageNameFromLinuxFxVersion(String linuxFxVersion) {
+        String[] segments = linuxFxVersion.split(Pattern.quote("|"));
+        if (segments.length != 2) {
+            return null;
+        }
+        final String image = segments[1];
+        if (!image.contains("/")) {
+            return image;
+        }
+        segments = image.split(Pattern.quote("/"));
+        return segments[segments.length - 1].trim();
     }
 }


### PR DESCRIPTION
### Issue to resolve
Toolkit may list web app successfully but meet exception have no permission to get app settings for webapp, as library called refresh entity during refresh app service resource, which will send unnecessary request to get app settings.

### What this PR do
- clean up entity but do not get it while `refresh` for app service
- clean up other reference for `IAppservice.entity()` in app service library