### PR TITLE
should set status before exit `setRemote`

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -138,14 +138,17 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
     protected synchronized void setRemote(@Nullable R newRemote) {
         final R oldRemote = this.remoteRef.get();
         if (Objects.equals(oldRemote, newRemote) && Objects.isNull(newRemote)) {
+            this.setStatus(Status.UNKNOWN);
             return;
         }
         if (this.syncTimeRef.get() > 0 && Objects.equals(oldRemote, newRemote)) {
+            this.setStatus(Status.LOADING);
             AzureTaskManager.getInstance().runOnPooledThread(this::reloadStatus);
         } else {
             this.syncTimeRef.set(System.currentTimeMillis());
             this.remoteRef.set(newRemote);
             if (Objects.nonNull(newRemote)) {
+                this.setStatus(Status.LOADING);
                 AzureTaskManager.getInstance().runOnPooledThread(this::reloadStatus);
             } else {
                 this.setStatus(Status.DISCONNECTED);


### PR DESCRIPTION
[AB#1908312](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1908312): [Test] Inconsistent showing status for failed resources