### PR TITLE
Support Azure Functions 4.0 in maven toolkit

### DIFF
--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/toolkit/maven/common/messager/MavenAzureMessager.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/toolkit/maven/common/messager/MavenAzureMessager.java
@@ -8,12 +8,12 @@ package com.microsoft.azure.toolkit.maven.common.messager;
 import com.microsoft.azure.toolkit.lib.common.messager.IAzureMessage;
 import com.microsoft.azure.toolkit.lib.common.messager.IAzureMessager;
 import com.microsoft.azure.toolkit.lib.common.utils.TextUtils;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@Log4j2
+@Slf4j
 public class MavenAzureMessager implements IAzureMessager, IAzureMessage.ValueDecorator {
     @Override
     public boolean show(IAzureMessage message) {

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/AppServiceUtils.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/AppServiceUtils.java
@@ -129,18 +129,19 @@ class AppServiceUtils {
         return String.format("java%s", javaVersion.getValue());
     }
 
-    static FunctionRuntimeStack toFunctionRuntimeStack(@Nonnull Runtime runtime) {
+    static FunctionRuntimeStack toFunctionRuntimeStack(@Nonnull Runtime runtime, String functionExtensionVersion) {
         if (runtime.getOperatingSystem() != OperatingSystem.LINUX) {
             throw new AzureToolkitRuntimeException(String.format("Can not convert %s runtime to FunctionRuntimeStack", runtime.getOperatingSystem()));
         }
+        final String javaVersion;
         if (Objects.equals(runtime.getJavaVersion(), JavaVersion.JAVA_8)) {
-            return FunctionRuntimeStack.JAVA_8;
+            javaVersion = "java|8";
+        } else if (Objects.equals(runtime.getJavaVersion(), JavaVersion.JAVA_11)) {
+            javaVersion = "java|11";
+        } else {
+            javaVersion = String.format("java|%s", runtime.getJavaVersion().getValue());
         }
-        if (Objects.equals(runtime.getJavaVersion(), JavaVersion.JAVA_11)) {
-            return FunctionRuntimeStack.JAVA_11;
-        }
-        final String javaVersion = String.format("java|%s", runtime.getJavaVersion().getValue());
-        return new FunctionRuntimeStack("java", "~3", javaVersion);
+        return new FunctionRuntimeStack("java", functionExtensionVersion, javaVersion);
     }
 
     static com.azure.resourcemanager.appservice.models.WebContainer toWebContainer(Runtime runtime) {

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateFunctionAppTask.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateFunctionAppTask.java
@@ -53,7 +53,7 @@ public class CreateOrUpdateFunctionAppTask extends AzureTask<IFunctionAppBase<?>
     private static final String CUSTOMIZED_FUNCTIONS_WORKER_RUNTIME_WARNING = "App setting `FUNCTIONS_WORKER_RUNTIME` doesn't " +
             "meet the requirement of Azure Java Functions, the value should be `java`.";
     private static final String FUNCTIONS_EXTENSION_VERSION_NAME = "FUNCTIONS_EXTENSION_VERSION";
-    private static final String FUNCTIONS_EXTENSION_VERSION_VALUE = "~3";
+    private static final String FUNCTIONS_EXTENSION_VERSION_VALUE = "~4";
     private static final String SET_FUNCTIONS_EXTENSION_VERSION = "Functions extension version " +
             "isn't configured, setting up the default value.";
     private static final String FUNCTION_APP_NOT_EXIST_FOR_SLOT = "The Function App specified in pom.xml does not exist. " +

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/configurations/FunctionExtensionVersion.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/configurations/FunctionExtensionVersion.java
@@ -9,6 +9,7 @@ public enum FunctionExtensionVersion {
 
     VERSION_2(2, "~2"),
     VERSION_3(3, "~3"),
+    VERSION_4(4, "~4"),
     BETA(Integer.MAX_VALUE, "beta"); // beta refers to the latest version
 
     private int value;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This implement function 4.0 support in maven toolkit
- Change default FUNCTION_EXTENSIONS_VERSION to ~4
- For linux function app, using customized FunctionRuntimeStack instead of original one to support customized function version
- Using Slf4j instead of log4j2 in MavenMessager

Does this close any currently open issues?
------------------------------------------
N/A

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
N/A

Has this been tested?
---------------------------
- [ ] Test team
- [ ] Dev team
- [x] Myself
