### PR TITLE
[Bugfix #1917261] Fail to update deployment after editing deployment

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-resource-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourceDeploymentDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-resource-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourceDeploymentDraft.java
@@ -100,7 +100,9 @@ public class ResourceDeploymentDraft extends ResourceDeployment
         final String newParameters = this.getParametersAsJson();
         final Deployment.Update update = origin.update();
         boolean modified = false;
-        if (!StringUtils.equals(newTemplate, oldTemplate) && StringUtils.isNotBlank(newTemplate)) {
+        if (!StringUtils.equals(newTemplate, oldTemplate) || StringUtils.isNotBlank(newTemplate)) {
+            update.withTemplate(oldTemplate);
+        } else {
             modified = true;
             update.withTemplate(newTemplate);
         }
@@ -110,10 +112,10 @@ public class ResourceDeploymentDraft extends ResourceDeployment
         }
         final IAzureMessager messager = AzureMessager.getMessager();
         if (modified) {
-            messager.info(AzureString.format("Start creating Deployment({0})...", name));
+            messager.info(AzureString.format("Start updating Deployment({0})...", name));
             update.withMode(DeploymentMode.INCREMENTAL);
             origin = update.apply();
-            messager.success(AzureString.format("Deployment({0}) is successfully created.", name));
+            messager.success(AzureString.format("Deployment({0}) is successfully updated.", name));
         } else {
             messager.info(AzureString.format("Nothing to update for {0}.", name));
         }

--- a/azure-toolkit-libs/azure-toolkit-resource-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourceDeploymentModule.java
+++ b/azure-toolkit-libs/azure-toolkit-resource-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourceDeploymentModule.java
@@ -57,7 +57,10 @@ public class ResourceDeploymentModule extends
 
     @Nullable
     @Override
+    @AzureOperation(name = "resource.load_resource.resource|type", params = {"name", "this.getResourceTypeName()"}, type = AzureOperation.Type.SERVICE)
     protected Deployment loadResourceFromAzure(@Nonnull String name, String resourceGroup) {
+        AzureTelemetry.getContext().setProperty("resourceType", this.getFullResourceType());
+        AzureTelemetry.getContext().setProperty("subscriptionId", this.getSubscriptionId());
         try {
             return super.loadResourceFromAzure(name, resourceGroup);
         } catch (Exception e) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
this PR always set `template` when create/update an ARM deployment.

`template` is always required when create/update an ARM deployment, but `template` is not set if it found not changed before this PR, which cause validation exception. 


Does this close any currently open issues?
------------------------------------------
[AB#1917261](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1917261): [Test] Fail to update deployment after editing deployment


Has this been tested?
---------------------------
- [ ] Tested
