### PR TITLE
[Bugfix #1920299, #1920274] npe When there is no deployment, give a non-exist deployment‘s name to deploy and report an error

### DIFF
--- a/azure-maven-plugin-lib/src/main/resources/bundles/com/microsoft/azure/toolkit/operation.properties
+++ b/azure-maven-plugin-lib/src/main/resources/bundles/com/microsoft/azure/toolkit/operation.properties
@@ -1,5 +1,24 @@
 service.refresh.service=refresh Azure Module({0})
 resource.refresh.resource=refresh Azure Resource({0})
+resource.connect_resource.resource=connect to resource ({0})
+resource.create_resource.service=create resource under ({0})
+resource.delete_resource.resource=delete ({0})
+resource.deploy_resource.resource=deploy artifacts to ({0})
+resource.open_portal_url.resource=open ({0}) in Azure Portal
+resource.restart_resource.resource=restart ({0})
+resource.show_properties.resource=show properties view of ({0})
+resource.start_resource.resource=start ({0})
+resource.stop_resource.resource=stop ({0})
+resource.list_resources.type=list ({0})s
+resource.load_resource.resource|type=load {1} ({0})
+resource.delete_resource.resource|type=delete {1} ({0})
+resource.create_resource.resource|type=create {1} ({0})
+resource.update_resource.resource|type=update {1} ({0})
+resource.draft_for_create.resource|type=initialize draft to create {1} ({0})
+resource.draft_for_update.resource|type=initialize draft to update {1} ({0})
+resource.reload.resource|type=reload {1} ({0}) from Azure
+resource.reload_status.resource|type=refresh status of {1} ({0})
+resource.list_supported_regions.type=list supported regions of resource type ({0})
 
 group.create.rg=check resource group ({0})
 

--- a/azure-spring-cloud-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/DeployMojo.java
+++ b/azure-spring-cloud-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/DeployMojo.java
@@ -28,6 +28,7 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Deploy your project to target Azure Spring Cloud app. If target app doesn't exist, it will be created.
@@ -91,7 +92,8 @@ public class DeployMojo extends AbstractMojoBase {
         try {
             final IPrompter prompter = new DefaultPrompter();
             System.out.println(CONFIRM_PROMPT_START);
-            tasks.stream().filter(t -> StringUtils.isNotBlank(t.getTitle().toString())).forEach((t) -> System.out.printf("\t- %s%n", t.getTitle()));
+            tasks.stream().filter(t -> Objects.nonNull(t.getTitle()) && StringUtils.isNotBlank(t.getTitle().toString()))
+                .forEach((t) -> System.out.printf("\t- %s%n", t.getTitle()));
             return prompter.promoteYesNo(CONFIRM_PROMPT_CONFIRM, true, true);
         } catch (IOException e) {
             throw new MojoFailureException(e.getMessage(), e);

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/task/DeploySpringCloudAppTask.java
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/task/DeploySpringCloudAppTask.java
@@ -45,7 +45,8 @@ public class DeploySpringCloudAppTask extends AzureTask<SpringCloudDeployment> {
         final String appName = config.getAppName();
         final String resourceGroup = config.getResourceGroup();
         final SpringCloudCluster cluster = Azure.az(AzureSpringCloud.class).clusters(config.getSubscriptionId()).get(clusterName, resourceGroup);
-        Optional.ofNullable(cluster).orElseThrow(() -> new AzureToolkitRuntimeException(String.format("Service(%s) is not found", clusterName)));
+        Optional.ofNullable(cluster).orElseThrow(() -> new AzureToolkitRuntimeException(
+            String.format("Service(%s) in subscription(%s) is not found", clusterName, config.getSubscriptionId())));
         final SpringCloudAppDraft app = cluster.apps().updateOrCreate(appName, resourceGroup);
         final String deploymentName = StringUtils.firstNonBlank(
             deploymentConfig.getDeploymentName(),
@@ -63,7 +64,7 @@ public class DeploySpringCloudAppTask extends AzureTask<SpringCloudDeployment> {
         AzureTelemetry.getContext().setProperty("isCreateDeployment", String.valueOf(toCreateDeployment));
         AzureTelemetry.getContext().setProperty("isDeploymentNameGiven", String.valueOf(StringUtils.isNotEmpty(deploymentConfig.getDeploymentName())));
 
-        final AzureString CREATE_APP_TITLE = AzureString.format("Create new app({0}) on service({1})", appName, clusterName);
+        final AzureString CREATE_APP_TITLE = AzureString.format("Create new app({0}) in service({1})", appName, clusterName);
         final AzureString UPDATE_APP_TITLE = AzureString.format("Update app({0}) of service({1})", appName, clusterName);
         final AzureString CREATE_DEPLOYMENT_TITLE = AzureString.format("Create new deployment({0}) in app({1})", deploymentName, appName);
         final AzureString UPDATE_DEPLOYMENT_TITLE = AzureString.format("Update deployment({0}) of app({1})", deploymentName, appName);


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
1. title of task is possibly null, filter them out.
2. add missing message in corresponding message bundle.


Does this close any currently open issues?
------------------------------------------
[AB#1920299](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1920299): npe When there is no deployment, give a non-exist deployment‘s name to deploy and report an error.
[AB#1920274](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1920274): Error message includes '!!' and "|"when deploy spring cloud app failed.


Has this been tested?
---------------------------
- [ ] Tested
