### PR TITLE
[Task #1916305] Fix proxy configuration did not apply to app service

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/AbstractAzureResourceModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/AbstractAzureResourceModule.java
@@ -84,7 +84,8 @@ public abstract class AbstractAzureResourceModule<T extends IAzureBaseResource> 
         final HttpLogDetailLevel logLevel = Optional.ofNullable(config.getLogLevel()).map(HttpLogDetailLevel::valueOf).orElse(HttpLogDetailLevel.NONE);
         final AzureProfile azureProfile = new AzureProfile(null, subscriptionId, account.getEnvironment());
         final TokenCredential tokenCredential = account.getTokenCredential(subscriptionId);
-        final R configurable = configurableSupplier.get().withPolicy(getUserAgentPolicy(userAgent)).withLogLevel(logLevel);
+        final R configurable = configurableSupplier.get().withPolicy(getUserAgentPolicy(userAgent)).withLogLevel(logLevel)
+                .withHttpClient(AzureService.getDefaultHttpClient());
         return authenticationMethod.apply(configurable, tokenCredential, azureProfile);
     }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Using `AzureService.getDefaultHttpClient()` as http client in `AbstractAzureResourceModule`

Does this close any currently open issues?
------------------------------------------
fixes #1922
[AB#1916305](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1916305)

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/A

Any other comments?
-------------------
Currently there are two http client instance in `AzureService` and `AbstractAzResourceManager`, may need to remove the duplicates later.

Has this been tested?
---------------------------
- [x] Tested
