### PR TITLE
remove dependency on log4j v2 since maven supports slf4j natively

### DIFF
--- a/azure-maven-plugin-lib/pom.xml
+++ b/azure-maven-plugin-lib/pom.xml
@@ -105,14 +105,6 @@
             <artifactId>commons-net</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.beryx</groupId>
             <artifactId>text-io</artifactId>
         </dependency>

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
@@ -93,10 +93,6 @@
             <artifactId>commons-net</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
         </dependency>

--- a/azure-toolkit-libs/azure-toolkit-common-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/pom.xml
@@ -37,10 +37,6 @@
             <artifactId>commons-exec</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>

--- a/azure-toolkit-libs/pom.xml
+++ b/azure-toolkit-libs/pom.xml
@@ -115,7 +115,7 @@
         <mockito.version>3.10.0</mockito.version>
         <rx.version>1.3.8</rx.version>
         <snakeyaml.version>1.28</snakeyaml.version>
-        <log4j.version>2.17.1</log4j.version>
+        <slf4j-api.version>1.7.32</slf4j-api.version>
         <spring-test.version>5.3.7</spring-test.version>
         <google.jsr305.version>3.0.2</google.jsr305.version>
         <free.port.finder.version>1.1.1</free.port.finder.version>
@@ -610,14 +610,9 @@
                 <version>${jjwt.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>${log4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-core</artifactId>
-                <version>${log4j.version}</version>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vdurmont</groupId>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
this PR totally removes dependency on log4j v2 from our side.
for maven, it natively supports `slf4j` since 3.1,  refer to https://maven.apache.org/maven-logging.html
for intellij, it's switching to use `java.util.logging` in the coming 2022.1. for 2021.2/2021.3, we only need to add a bridge to log4j in intellij's module, as it natively provides log4j.

Does this close any currently open issues?
------------------------------------------
N/P

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/P


Has this been tested?
---------------------------
- [ ] Tested
