### PR TITLE
#1920741: [Test]The pricing tier of redis is displayed as Basic C0 no matter what you choose

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/messager/AzureMessage.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/messager/AzureMessage.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -152,11 +154,9 @@ public class AzureMessage implements IAzureMessage {
                 .filter(p -> p instanceof Throwable)
                 .map(p -> getExceptionOperations((Throwable) p))
                 .orElse(new ArrayList<>());
-        final Map<String, IAzureOperation> operations = new HashMap<>();
-        Streams.concat(contextOperations.stream(), exceptionOperations.stream())
-                .filter(o -> !operations.containsKey(o.getName()))
-                .forEachOrdered(o -> operations.put(o.getName(), o));
-        return new ArrayList<>(operations.values());
+        final Set<Object> seen = ConcurrentHashMap.newKeySet();
+        return Streams.concat(contextOperations.stream(), exceptionOperations.stream())
+            .filter(t -> seen.add(t.getName())).collect(Collectors.toList());
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-redis-lib/src/main/java/com/microsoft/azure/toolkit/redis/model/PricingTier.java
+++ b/azure-toolkit-libs/azure-toolkit-redis-lib/src/main/java/com/microsoft/azure/toolkit/redis/model/PricingTier.java
@@ -47,7 +47,9 @@ public class PricingTier {
     public static final PricingTier PREMIUM_C4 = new PricingTier(PREMIUM, "P4");
     public static final PricingTier PREMIUM_C5 = new PricingTier(PREMIUM, "P5");
 
+    @EqualsAndHashCode.Include
     private final String family;
+    @EqualsAndHashCode.Include
     private final String capacity;
 
     public static PricingTier from(Sku sku) {

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageAccount.java
@@ -10,6 +10,7 @@ import com.azure.resourcemanager.resources.fluentcore.utils.ResourceManagerUtils
 import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.auth.AzureCloud;
 import com.microsoft.azure.toolkit.lib.common.entity.Removable;
+import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
@@ -69,7 +70,11 @@ public class StorageAccount extends AbstractAzResource<StorageAccount, StorageRe
 
     @AzureOperation(name = "storage.get_key.account", params = {"this.getName()"}, type = AzureOperation.Type.SERVICE)
     public String getKey() {
-        return Objects.requireNonNull(this.getRemote()).getKeys().get(0).value();
+        final com.azure.resourcemanager.storage.models.StorageAccount remote = this.getRemote();
+        if (Objects.isNull(remote)) {
+            throw new AzureToolkitRuntimeException(String.format("Storage Account(%s) doesn't exist.", this.getName()));
+        }
+        return remote.getKeys().get(0).value();
     }
 
     @Nullable


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
the cause of [AB#1920741](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1920741) is: 
`equals` and `hashcode` are not correctly implemented, which cause all pricing tiers are equal to each other.
this PR judges `equal` by both `family` and `name`

it seems the cause of [AB#1919439](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1919439) is: the jedis pool is not correctly closed after the redis cache is deleted, so close it right before the redis cache is closed.

the cause of [AB#1881645](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1881645) is resource connection tries to get the key of the deleted storage account.


Does this close any currently open issues?
------------------------------------------
[AB#1920741](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1920741): [Test]The pricing tier of redis is displayed as Basic C0 no matter what you choose
[AB#1919439](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1919439): [Test] Exception during deleting redis caches with redis explorer opening
[AB#1881645](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1881645): [Test] Shows an error after delete storage account which is connected to a project

Has this been tested?
---------------------------
- [x] Tested
