### PR TITLE
Fix miscellaneous bugs related to app service maven plugin

### DIFF
--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AddMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AddMojo.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -227,7 +227,7 @@ public class AddMojo extends AbstractFunctionMojo {
 
         preparePackageName();
 
-        final Map<String, String> params = new HashMap<>();
+        final Map<String, String> params = new LinkedHashMap<>();
         params.put("functionName", getFunctionName());
         params.put("className", getClassName());
         params.put("packageName", getFunctionPackageName());

--- a/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/src/main/java/com/microsoft/azure/toolkit/lib/applicationinsights/ApplicationInsightDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/src/main/java/com/microsoft/azure/toolkit/lib/applicationinsights/ApplicationInsightDraft.java
@@ -28,8 +28,7 @@ public class ApplicationInsightDraft extends ApplicationInsight implements AzRes
     private static final String REGION_IS_REQUIRED = "'region' is required to create application insight.";
     private static final String START_CREATING_APPLICATION_INSIGHT = "Start creating Application Insight ({0})...";
     private static final String APPLICATION_INSIGHTS_CREATED = "Application Insight ({0}) is successfully created. " +
-            "You can visit {1}/#@/resource{2}}/overview to view your " +
-            "Application Insights component.";
+            "You can visit {1} to view your Application Insights component.";
 
     @Getter
     @Setter
@@ -73,7 +72,7 @@ public class ApplicationInsightDraft extends ApplicationInsight implements AzRes
                 .withExistingResourceGroup(getResourceGroupName())
                 .withKind("web")
                 .withApplicationType(ApplicationType.WEB).create();
-        messager.success(AzureString.format(APPLICATION_INSIGHTS_CREATED, getName(), getPortalUrl(), result.id()));
+        messager.success(AzureString.format(APPLICATION_INSIGHTS_CREATED, getName(), getPortalUrl()));
         return result;
     }
 

--- a/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/src/main/java/com/microsoft/azure/toolkit/lib/applicationinsights/ApplicationInsightsModule.java
+++ b/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/src/main/java/com/microsoft/azure/toolkit/lib/applicationinsights/ApplicationInsightsModule.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 
 public class ApplicationInsightsModule extends AbstractAzResourceModule<ApplicationInsight, ApplicationInsightsResourceManager, ApplicationInsightsComponent> {
 
-    public static final String NAME = "applicationInsights";
+    public static final String NAME = "components";
 
     public ApplicationInsightsModule(@Nonnull ApplicationInsightsResourceManager parent) {
         super(NAME, parent);

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateFunctionAppTask.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateFunctionAppTask.java
@@ -29,6 +29,7 @@ import com.microsoft.azure.toolkit.lib.common.task.AzureTask;
 import com.microsoft.azure.toolkit.lib.common.telemetry.AzureTelemetry;
 import com.microsoft.azure.toolkit.lib.resource.task.CreateResourceGroupTask;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -230,7 +231,8 @@ public class CreateOrUpdateFunctionAppTask extends AzureTask<IFunctionAppBase<?>
                 return new GetOrCreateApplicationInsightsTask(functionAppConfig.subscriptionId(),
                         functionAppConfig.resourceGroup(), functionAppConfig.region(), name).getSupplier().get();
             } catch (final Exception e) {
-                AzureMessager.getMessager().warning(String.format(APPLICATION_INSIGHTS_CREATE_FAILED, e.getMessage()));
+                final String errorMessage = Optional.ofNullable(ExceptionUtils.getRootCause(e)).orElse(e).getMessage();
+                AzureMessager.getMessager().warning(String.format(APPLICATION_INSIGHTS_CREATE_FAILED, errorMessage));
                 return null;
             }
         });

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateFunctionAppTask.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateFunctionAppTask.java
@@ -107,11 +107,13 @@ public class CreateOrUpdateFunctionAppTask extends AzureTask<IFunctionAppBase<?>
     }
 
     private <T> void registerSubTask(AzureTask<T> task, Consumer<T> consumer) {
-        tasks.add(new AzureTask<>(() -> {
-            T result = task.getSupplier().get();
-            consumer.accept(result);
-            return result;
-        }));
+        if (task != null) {
+            tasks.add(new AzureTask<>(() -> {
+                T result = task.getSupplier().get();
+                consumer.accept(result);
+                return result;
+            }));
+        }
     }
 
     private AzureTask<FunctionApp> getCreateFunctionAppTask(final FunctionApp functionApp) {
@@ -238,6 +240,10 @@ public class CreateOrUpdateFunctionAppTask extends AzureTask<IFunctionAppBase<?>
     }
 
     private CreateOrUpdateAppServicePlanTask getServicePlanTask() {
+        if (StringUtils.isNotEmpty(functionAppConfig.deploymentSlotName())) {
+            AzureMessager.getMessager().info("Skip update app service plan for deployment slot");
+            return null;
+        }
         return new CreateOrUpdateAppServicePlanTask(functionAppConfig.getServicePlanConfig());
     }
 

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateFunctionAppTask.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateFunctionAppTask.java
@@ -53,7 +53,7 @@ public class CreateOrUpdateFunctionAppTask extends AzureTask<IFunctionAppBase<?>
     private static final String CUSTOMIZED_FUNCTIONS_WORKER_RUNTIME_WARNING = "App setting `FUNCTIONS_WORKER_RUNTIME` doesn't " +
             "meet the requirement of Azure Java Functions, the value should be `java`.";
     private static final String FUNCTIONS_EXTENSION_VERSION_NAME = "FUNCTIONS_EXTENSION_VERSION";
-    private static final String FUNCTIONS_EXTENSION_VERSION_VALUE = "~4";
+    private static final String FUNCTIONS_EXTENSION_VERSION_VALUE = "~3";
     private static final String SET_FUNCTIONS_EXTENSION_VERSION = "Functions extension version " +
             "isn't configured, setting up the default value.";
     private static final String FUNCTION_APP_NOT_EXIST_FOR_SLOT = "The Function App specified in pom.xml does not exist. " +

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateFunctionAppTask.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateFunctionAppTask.java
@@ -91,7 +91,8 @@ public class CreateOrUpdateFunctionAppTask extends AzureTask<IFunctionAppBase<?>
                 this.instrumentationKey = functionAppConfig.appInsightsKey();
             } else if (StringUtils.isNotEmpty(functionAppConfig.appInsightsInstance()) || !app.exists()) {
                 // create AI instance by default when create new function
-                registerSubTask(getApplicationInsightsTask(), result -> this.instrumentationKey = result.getInstrumentationKey());
+                registerSubTask(getApplicationInsightsTask(),
+                        result -> this.instrumentationKey = Optional.ofNullable(result).map(ApplicationInsight::getInstrumentationKey).orElse(null));
             }
         }
         if (StringUtils.isEmpty(functionAppConfig.deploymentSlotName())) {

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateWebAppTask.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateWebAppTask.java
@@ -43,9 +43,9 @@ public class CreateOrUpdateWebAppTask extends AzureTask<WebApp> {
     private static final String CREATE_NEW_WEB_APP = "createNewWebApp";
 
     private static final String CREATE_WEBAPP = "Creating web app %s...";
-    private static final String CREATE_WEB_APP_DONE = "Successfully created Web App %s.";
-    private static final String UPDATE_WEBAPP = "Updating target Web App %s...";
-    private static final String UPDATE_WEBAPP_DONE = "Successfully updated Web App %s.";
+    private static final String CREATE_WEB_APP_DONE = "Successfully created web app %s.";
+    private static final String UPDATE_WEBAPP = "Updating target web app %s...";
+    private static final String UPDATE_WEBAPP_DONE = "Successfully updated web app %s.";
 
     private final AppServiceConfig config;
     private final List<AzureTask<?>> subTasks;

--- a/azure-toolkit-libs/azure-toolkit-resource-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourceGroupDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-resource-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourceGroupDraft.java
@@ -63,7 +63,7 @@ public class ResourceGroupDraft extends ResourceGroup implements AzResource.Draf
         }
         final ResourceManager manager = Objects.requireNonNull(this.getParent().getRemote());
         final IAzureMessager messager = AzureMessager.getMessager();
-        messager.info(AzureString.format("Start creating Resource Group({0})...", name));
+        messager.info(AzureString.format("Start creating Resource Group({0}) in region ({1})...", name, region.getLabel()));
         final com.azure.resourcemanager.resources.models.ResourceGroup group =
             manager.resourceGroups().define(name).withRegion(region.getName()).create();
         messager.success(AzureString.format("Resource Group({0}) is successfully created.", name));


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Resolve issues for app service plugin end game tests


Does this close any currently open issues?
------------------------------------------
Revert default function extension version to ~3, [AB#1920721](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1920721)
Fix wrong url for application insights in function app deployment log, [AB#1921217](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1921217)
Unify wording for web app task, [AB#1921653](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1921653)
Add region info in resource group creating message, [AB#1921657](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1921657)
Skip create/update app service plan for function deployment slot, [AB#1921250](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1921250)
Keep order of parameters in summary for azure-functions:add, [AB#1921222](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1921222)
Fix NPE for application insights creation in create function app task, [AB#1921238](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1921238)
Fix error message for create application insights is shown as null in create function app task, [AB#1924440](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1924440)

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/A

Any other comments?
-------------------
N/A

Has this been tested?
---------------------------
- [ ] Tested
