### PR TITLE
Fallback to get storage account from function app settings in case kudu is not initialized during deployment

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/deploy/DeployUtils.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/service/impl/deploy/DeployUtils.java
@@ -10,15 +10,17 @@ import com.azure.resourcemanager.appservice.models.FunctionDeploymentSlot;
 import com.azure.resourcemanager.appservice.models.WebAppBase;
 import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
+import org.apache.commons.lang3.StringUtils;
 
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
-import java.util.Arrays;
 import java.util.Optional;
 
 class DeployUtils {
-    private static final String INTERNAL_STORAGE_NOT_FOUND = "Application setting 'AzureWebJobsStorage' not found or value is invalid, " +
-            "please check the app setting and try deploy later.";
+    private static final String INTERNAL_STORAGE_NOT_FOUND = "Application setting 'AzureWebJobsStorage' is not found, " +
+            "please check the application setting and try again later.";
+    public static final String INVALID_STORAGE_CONNECTION_STRING = "Storage connection string in 'AzureWebJobsStorage' is invalid, " +
+            "please check the application setting and try again later.";
     private static final String INTERNAL_STORAGE_KEY = "AzureWebJobsStorage";
     private static final String UNSUPPORTED_DEPLOYMENT_TARGET = "Unsupported deployment target, only function is supported";
 
@@ -29,19 +31,19 @@ class DeployUtils {
      */
     static CloudStorageAccount getCloudStorageAccount(final WebAppBase functionApp) {
         // Call functionApp.getSiteAppSettings() to get the app settings with key vault reference
-        final String kuduStorageSetting = Optional.ofNullable(functionApp.getSiteAppSettings())
-                .map(map -> map.get(INTERNAL_STORAGE_KEY)).orElse(null);
-        final String storageSetting = Optional.ofNullable(functionApp.getAppSettings())
-                .map(map -> map.get(INTERNAL_STORAGE_KEY)).map(AppSetting::value).orElse(null);
-        for (final String connectionString : Arrays.asList(storageSetting, kuduStorageSetting)) {
-            try {
-                return CloudStorageAccount.parse(connectionString);
-            } catch (InvalidKeyException | URISyntaxException | RuntimeException e) {
-                // swallow exception here
-                continue;
-            }
+        final String connectionString = Optional.ofNullable(functionApp.getSiteAppSettings())
+                .map(map -> map.get(INTERNAL_STORAGE_KEY))
+                .filter(StringUtils::isNotEmpty)
+                .orElseGet(() -> Optional.ofNullable(functionApp.getAppSettings())
+                        .map(map -> map.get(INTERNAL_STORAGE_KEY)).map(AppSetting::value).orElse(null));
+        if (StringUtils.isEmpty(connectionString)) {
+            throw new AzureToolkitRuntimeException(INTERNAL_STORAGE_NOT_FOUND);
         }
-        throw new AzureToolkitRuntimeException(INTERNAL_STORAGE_NOT_FOUND);
+        try {
+            return CloudStorageAccount.parse(connectionString);
+        } catch (InvalidKeyException | URISyntaxException | RuntimeException e) {
+            throw new AzureToolkitRuntimeException(INVALID_STORAGE_CONNECTION_STRING, e);
+        }
     }
 
     static void updateFunctionAppSetting(final WebAppBase deployTarget, final String key, final String value) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Maven toolkit used to get storage account from kudu app settings, however, if create the function and deploy, kudu may not initialized after creation and maven toolkit could not get storage account in this case and will throw exception.

To resolve this issue, add get app settings from ARM api as fallback.

Does this close any currently open issues?
------------------------------------------
N/A


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/A

Any other comments?
-------------------
N/A

Has this been tested?
---------------------------
- [x] Tested
