### PR TITLE
Bump version for endgame-202203-webapp

### DIFF
--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.17.0-SNAPSHOT</version>
+        <version>1.17.0</version>
     </parent>
 
     <artifactId>azure-functions-maven-plugin</artifactId>

--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.17.0</version>
+        <version>1.18.0-SNAPHSOT</version>
     </parent>
 
     <artifactId>azure-functions-maven-plugin</artifactId>

--- a/azure-maven-plugin-lib/pom.xml
+++ b/azure-maven-plugin-lib/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.17.0</version>
+        <version>1.18.0-SNAPHSOT</version>
     </parent>
 
     <artifactId>azure-maven-plugin-lib</artifactId>

--- a/azure-maven-plugin-lib/pom.xml
+++ b/azure-maven-plugin-lib/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.17.0-SNAPSHOT</version>
+        <version>1.17.0</version>
     </parent>
 
     <artifactId>azure-maven-plugin-lib</artifactId>

--- a/azure-sfmesh-maven-plugin/pom.xml
+++ b/azure-sfmesh-maven-plugin/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.17.0-SNAPSHOT</version>
+        <version>1.17.0</version>
     </parent>
 
     <artifactId>azure-sfmesh-maven-plugin</artifactId>

--- a/azure-sfmesh-maven-plugin/pom.xml
+++ b/azure-sfmesh-maven-plugin/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.17.0</version>
+        <version>1.18.0-SNAPHSOT</version>
     </parent>
 
     <artifactId>azure-sfmesh-maven-plugin</artifactId>

--- a/azure-spring-cloud-maven-plugin/pom.xml
+++ b/azure-spring-cloud-maven-plugin/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.17.0</version>
+        <version>1.18.0-SNAPHSOT</version>
     </parent>
     <name>Azure Spring Cloud Maven Plugin</name>
     <description>Maven Plugin for Azure Spring Cloud</description>

--- a/azure-spring-cloud-maven-plugin/pom.xml
+++ b/azure-spring-cloud-maven-plugin/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.17.0-SNAPSHOT</version>
+        <version>1.17.0</version>
     </parent>
     <name>Azure Spring Cloud Maven Plugin</name>
     <description>Maven Plugin for Azure Spring Cloud</description>

--- a/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0</version>
+        <version>0.19.0-SNAPHSOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0</version>
+        <version>0.19.0-SNAPHSOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0</version>
+        <version>0.19.0-SNAPHSOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-common-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-common-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0</version>
+        <version>0.19.0-SNAPHSOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0</version>
+        <version>0.19.0-SNAPHSOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-database-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-database-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-database-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-database-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0</version>
+        <version>0.19.0-SNAPHSOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-mysql-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-mysql-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-mysql-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-mysql-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0</version>
+        <version>0.19.0-SNAPHSOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-postgre-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-postgre-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-postgre-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-postgre-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0</version>
+        <version>0.19.0-SNAPHSOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-redis-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-redis-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-redis-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-redis-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0</version>
+        <version>0.19.0-SNAPHSOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-resource-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-resource-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-resource-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-resource-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0</version>
+        <version>0.19.0-SNAPHSOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0</version>
+        <version>0.19.0-SNAPHSOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-sqlserver-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-sqlserver-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-sqlserver-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-sqlserver-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0</version>
+        <version>0.19.0-SNAPHSOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.18.0</version>
+        <version>0.19.0-SNAPHSOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/pom.xml
+++ b/azure-toolkit-libs/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-libs</artifactId>
-    <version>0.18.0</version>
+    <version>0.19.0-SNAPHSOT</version>
     <packaging>pom</packaging>
     <name>Libs for Azure Toolkits</name>
     <description>Wrapped libs for Microsoft Azure Toolkits</description>

--- a/azure-toolkit-libs/pom.xml
+++ b/azure-toolkit-libs/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-libs</artifactId>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.0</version>
     <packaging>pom</packaging>
     <name>Libs for Azure Toolkits</name>
     <description>Wrapped libs for Microsoft Azure Toolkits</description>

--- a/azure-webapp-maven-plugin/pom.xml
+++ b/azure-webapp-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>azure-webapp-maven-plugin</artifactId>
-    <version>2.5.0</version>
+    <version>2.6.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
     <name>Maven Plugin for Azure Web Apps</name>
     <description>

--- a/azure-webapp-maven-plugin/pom.xml
+++ b/azure-webapp-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.17.0</version>
+        <version>1.18.0-SNAPHSOT</version>
     </parent>
 
     <artifactId>azure-webapp-maven-plugin</artifactId>

--- a/azure-webapp-maven-plugin/pom.xml
+++ b/azure-webapp-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.17.0-SNAPSHOT</version>
+        <version>1.17.0</version>
     </parent>
 
     <artifactId>azure-webapp-maven-plugin</artifactId>

--- a/azure-webapp-maven-plugin/pom.xml
+++ b/azure-webapp-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>azure-webapp-maven-plugin</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
     <packaging>maven-plugin</packaging>
     <name>Maven Plugin for Azure Web Apps</name>
     <description>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.17.0-SNAPSHOT</version>
+        <version>1.17.0</version>
     </parent>
     <artifactId>maven-plugins-build-tools</artifactId>
 </project>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.17.0</version>
+        <version>1.18.0-SNAPHSOT</version>
     </parent>
     <artifactId>maven-plugins-build-tools</artifactId>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-maven-plugins</artifactId>
-    <version>1.17.0-SNAPSHOT</version>
+    <version>1.17.0</version>
     <packaging>pom</packaging>
     <name>Maven Plugins for Azure</name>
     <description>Maven plugins for Microsoft Azure services</description>
@@ -81,7 +81,7 @@
         <maven.javadoc-plugin.version>2.9.1</maven.javadoc-plugin.version>
         <maven.checkstyle-plugin.version>3.1.2</maven.checkstyle-plugin.version>
         <maven.aspectj-plugin.version>1.12.6</maven.aspectj-plugin.version>
-        <azure.maven-plugin-lib.version>1.17.0-SNAPSHOT</azure.maven-plugin-lib.version>
+        <azure.maven-plugin-lib.version>1.17.0</azure.maven-plugin-lib.version>
         <jacoco.version>0.8.7</jacoco.version>
 
         <json.schema-validator.version>1.0.56</json.schema-validator.version>
@@ -258,7 +258,7 @@
                         <dependency>
                             <groupId>com.microsoft.azure</groupId>
                             <artifactId>maven-plugins-build-tools</artifactId>
-                            <version>1.17.0-SNAPSHOT</version>
+                            <version>1.17.0</version>
                         </dependency>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-toolkit-libs</artifactId>
-                <version>0.18.0-SNAPSHOT</version>
+                <version>0.18.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-maven-plugins</artifactId>
-    <version>1.17.0</version>
+    <version>1.18.0-SNAPHSOT</version>
     <packaging>pom</packaging>
     <name>Maven Plugins for Azure</name>
     <description>Maven plugins for Microsoft Azure services</description>
@@ -81,7 +81,7 @@
         <maven.javadoc-plugin.version>2.9.1</maven.javadoc-plugin.version>
         <maven.checkstyle-plugin.version>3.1.2</maven.checkstyle-plugin.version>
         <maven.aspectj-plugin.version>1.12.6</maven.aspectj-plugin.version>
-        <azure.maven-plugin-lib.version>1.17.0</azure.maven-plugin-lib.version>
+        <azure.maven-plugin-lib.version>1.18.0-SNAPHSOT</azure.maven-plugin-lib.version>
         <jacoco.version>0.8.7</jacoco.version>
 
         <json.schema-validator.version>1.0.56</json.schema-validator.version>
@@ -258,7 +258,7 @@
                         <dependency>
                             <groupId>com.microsoft.azure</groupId>
                             <artifactId>maven-plugins-build-tools</artifactId>
-                            <version>1.17.0</version>
+                            <version>1.18.0-SNAPHSOT</version>
                         </dependency>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
bumpup version of azure-toolkit-libs to 0.18.0
bumpup version of azure-maven-plugins to 1.17.0
bumpup version of azure-webapp-maven-plugin to 2.5.0
bumpup version of azure-toolkit-libs to 0.19.0-SNAPSHOT
bumpup version of azure-maven-plugins to 1.18.0-SNAPSHOT
bumpup version of azure-webapp-maven-plugin to 2.6.0-SNAPSHOT

Does this close any currently open issues?
------------------------------------------
N/P

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/P

Any other comments?
-------------------
N/P

Has this been tested?
---------------------------
- [ ] Tested

