### PR TITLE
upgrade `jackson-databind` to `2.13.2.1` to resolve CVE-2020-36518

### DIFF
--- a/azure-toolkit-libs/pom.xml
+++ b/azure-toolkit-libs/pom.xml
@@ -105,7 +105,8 @@
         <gson.version>2.9.0</gson.version>
         <guava.version>31.0.1-jre</guava.version>
         <httpclient.version>4.5.2</httpclient.version>
-        <jackson.version>2.13.1</jackson.version>
+        <jackson.version>2.13.2</jackson.version>
+        <jackson-databind.version>2.13.2.1</jackson-databind.version>
         <jansi.version>2.4.0</jansi.version>
         <jetbrains.annotations.version>22.0.0</jetbrains.annotations.version>
         <json.schema.validator.version>2.2.14</json.schema.validator.version>
@@ -350,7 +351,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson-databind.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.13.2...jackson-databind-2.13.2.1

Does this close any currently open issues?
------------------------------------------
[AB#1929425](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1929425): [Component Governance Alert] - CVE-2020-36518 in com.fasterxml.jackson.core:jackson-databind 2.13.1

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/P

Any other comments?
-------------------
N/P

Has this been tested?
---------------------------
- [x] Tested
