### PR TITLE
#1931543: [Test] Failed to "start streaming log" operation on slot of web apps

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/FunctionAppDeploymentSlotDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/FunctionAppDeploymentSlotDraft.java
@@ -176,7 +176,7 @@ public class FunctionAppDeploymentSlotDraft extends FunctionAppDeploymentSlot
 
     @Nullable
     public DiagnosticConfig getDiagnosticConfig() {
-        return Optional.ofNullable(config).map(Config::getDiagnosticConfig).orElse(null);
+        return Optional.ofNullable(config).map(Config::getDiagnosticConfig).orElseGet(super::getDiagnosticConfig);
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/FunctionAppDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/FunctionAppDraft.java
@@ -267,7 +267,7 @@ public class FunctionAppDraft extends FunctionApp implements AzResource.Draft<Fu
 
     @Nullable
     public DiagnosticConfig getDiagnosticConfig() {
-        return Optional.ofNullable(config).map(Config::getDiagnosticConfig).orElse(null);
+        return Optional.ofNullable(config).map(Config::getDiagnosticConfig).orElseGet(super::getDiagnosticConfig);
     }
 
     public void setAppSettings(Map<String, String> appSettings) {

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/webapp/WebAppDeploymentSlotDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/webapp/WebAppDeploymentSlotDraft.java
@@ -179,7 +179,7 @@ public class WebAppDeploymentSlotDraft extends WebAppDeploymentSlot implements A
 
     @Nullable
     public DiagnosticConfig getDiagnosticConfig() {
-        return Optional.ofNullable(config).map(Config::getDiagnosticConfig).orElse(null);
+        return Optional.ofNullable(config).map(Config::getDiagnosticConfig).orElseGet(super::getDiagnosticConfig);
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/webapp/WebAppDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/webapp/WebAppDraft.java
@@ -228,7 +228,7 @@ public class WebAppDraft extends WebApp implements AzResource.Draft<WebApp, WebS
 
     @Nullable
     public DiagnosticConfig getDiagnosticConfig() {
-        return Optional.ofNullable(config).map(Config::getDiagnosticConfig).orElse(null);
+        return Optional.ofNullable(config).map(Config::getDiagnosticConfig).orElseGet(super::getDiagnosticConfig);
     }
 
     public void setAppSettings(Map<String, String> appSettings) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
`config` is reset after committing, we should read the properties from `remote` instead of `config` after committing


Does this close any currently open issues?
------------------------------------------
[AB#1931543](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1931543): [Test] Failed to "start streaming log" operation on slot of web app


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
