### PR TITLE
Prepare release function maven plugin

### DIFF
--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.19.0-SNAPSHOT</version>
+        <version>1.19.0</version>
     </parent>
 
     <artifactId>azure-functions-maven-plugin</artifactId>

--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>azure-functions-maven-plugin</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
     <packaging>maven-plugin</packaging>
     <name>Maven Plugin for Azure Functions</name>
     <description>Maven Plugin for Azure Functions</description>

--- a/azure-maven-plugin-lib/pom.xml
+++ b/azure-maven-plugin-lib/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.19.0-SNAPSHOT</version>
+        <version>1.19.0</version>
     </parent>
 
     <artifactId>azure-maven-plugin-lib</artifactId>

--- a/azure-sfmesh-maven-plugin/pom.xml
+++ b/azure-sfmesh-maven-plugin/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.19.0-SNAPSHOT</version>
+        <version>1.19.0</version>
     </parent>
 
     <artifactId>azure-sfmesh-maven-plugin</artifactId>

--- a/azure-spring-cloud-maven-plugin/pom.xml
+++ b/azure-spring-cloud-maven-plugin/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.19.0-SNAPSHOT</version>
+        <version>1.19.0</version>
     </parent>
     <name>Azure Spring Cloud Maven Plugin</name>
     <description>Maven Plugin for Azure Spring Cloud</description>

--- a/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.20.0-SNAPSHOT</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.20.0-SNAPSHOT</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.20.0-SNAPSHOT</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-common-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.20.0-SNAPSHOT</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.20.0-SNAPSHOT</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-containerregistry-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-containerregistry-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.20.0-SNAPSHOT</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-database-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-database-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.20.0-SNAPSHOT</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-mysql-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-mysql-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.20.0-SNAPSHOT</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-postgre-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-postgre-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.20.0-SNAPSHOT</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-redis-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-redis-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.20.0-SNAPSHOT</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-resource-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-resource-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.20.0-SNAPSHOT</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.20.0-SNAPSHOT</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-sqlserver-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-sqlserver-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.20.0-SNAPSHOT</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.20.0-SNAPSHOT</version>
+        <version>0.19.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/pom.xml
+++ b/azure-toolkit-libs/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-libs</artifactId>
-    <version>0.20.0-SNAPSHOT</version>
+    <version>0.19.2</version>
     <packaging>pom</packaging>
     <name>Libs for Azure Toolkits</name>
     <description>Wrapped libs for Microsoft Azure Toolkits</description>

--- a/azure-webapp-maven-plugin/pom.xml
+++ b/azure-webapp-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.19.0-SNAPSHOT</version>
+        <version>1.19.0</version>
     </parent>
 
     <artifactId>azure-webapp-maven-plugin</artifactId>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.19.0-SNAPSHOT</version>
+        <version>1.19.0</version>
     </parent>
     <artifactId>maven-plugins-build-tools</artifactId>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-toolkit-libs</artifactId>
-                <version>0.20.0-SNAPSHOT</version>
+                <version>0.19.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-maven-plugins</artifactId>
-    <version>1.19.0-SNAPSHOT</version>
+    <version>1.19.0</version>
     <packaging>pom</packaging>
     <name>Maven Plugins for Azure</name>
     <description>Maven plugins for Microsoft Azure services</description>
@@ -81,7 +81,7 @@
         <maven.javadoc-plugin.version>2.9.1</maven.javadoc-plugin.version>
         <maven.checkstyle-plugin.version>3.1.2</maven.checkstyle-plugin.version>
         <maven.aspectj-plugin.version>1.12.6</maven.aspectj-plugin.version>
-        <azure.maven-plugin-lib.version>1.19.0-SNAPSHOT</azure.maven-plugin-lib.version>
+        <azure.maven-plugin-lib.version>1.19.0</azure.maven-plugin-lib.version>
         <jacoco.version>0.8.7</jacoco.version>
 
         <json.schema-validator.version>1.0.56</json.schema-validator.version>
@@ -264,7 +264,7 @@
                         <dependency>
                             <groupId>com.microsoft.azure</groupId>
                             <artifactId>maven-plugins-build-tools</artifactId>
-                            <version>1.19.0-SNAPSHOT</version>
+                            <version>1.19.0</version>
                         </dependency>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Bump toolkit lib to 0.19.2
- Bump maven plugin lib to 1.19.0
- Bump functions maven plugin to 1.18.0

Does this close any currently open issues?
------------------------------------------
N/A


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/A

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
