### PR TITLE
sync resource adding/deleting between app-centric resource group and type-centric views.

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/IAccountActions.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/IAccountActions.java
@@ -8,7 +8,7 @@ package com.microsoft.azure.toolkit.lib.auth;
 import com.microsoft.azure.toolkit.lib.common.action.Action;
 
 public interface IAccountActions {
-    Action.Id<Void> TRY_AZURE = Action.Id.of("action.account.try_azure");
-    Action.Id<Void> SELECT_SUBS = Action.Id.of("action.account.select_subs");
-    Action.Id<Void> AUTHENTICATE = Action.AUTHENTICATE;
+    Action.Id<Object> TRY_AZURE = Action.Id.of("action.account.try_azure");
+    Action.Id<Object> SELECT_SUBS = Action.Id.of("action.account.select_subs");
+    Action.Id<Object> AUTHENTICATE = Action.AUTHENTICATE;
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/action/Action.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/action/Action.java
@@ -35,7 +35,7 @@ public class Action<D> {
     public static final String SOURCE = "ACTION_SOURCE";
     public static final String RESOURCE_TYPE = "resourceType";
     public static final Id<Runnable> REQUIRE_AUTH = Id.of("action.common.requireAuth");
-    public static final Id<Void> AUTHENTICATE = Id.of("action.account.authenticate");
+    public static final Id<Object> AUTHENTICATE = Id.of("action.account.authenticate");
     @Nonnull
     private List<AbstractMap.SimpleEntry<BiPredicate<D, ?>, BiConsumer<D, ?>>> handlers = new ArrayList<>();
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -178,7 +178,9 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
         log.debug("[{}:{}]:delete->module.deleteResourceFromLocal({})", this.module.getName(), this.getName(), this.getName());
         this.getModule().deleteResourceFromLocal(this.getName());
         final ResourceId id = ResourceId.fromString(this.getId());
-        if (Objects.isNull(id.parent())) { // resource group manages top resources only
+        if (Objects.isNull(id.parent()) &&
+            !StringUtils.equalsIgnoreCase(id.subscriptionId(), NONE.getName()) &&
+            !StringUtils.equalsAnyIgnoreCase(id.resourceGroupName(), NONE.getName(), RESOURCE_GROUP_PLACEHOLDER)) { // resource group manages top resources only
             final String rg = id.resourceGroupName();
             final String subId = id.subscriptionId();
             final GenericResourceModule genericResourceModule = Azure.az(AzureResources.class).groups(subId).getOrInit(rg, rg).genericResources();

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AzResource.java
@@ -101,7 +101,7 @@ public interface AzResource<T extends AzResource<T, P, R>, P extends AzResource<
 
     @Getter
     final class None extends AbstractAzResource<None, None, Void> {
-        private static final String NONE = "$NONE$";
+        public static final String NONE = "$NONE$";
         private final String id = NONE;
         private final String name = NONE;
         private final String status = NONE;

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AzResourceModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AzResourceModule.java
@@ -74,7 +74,7 @@ public interface AzResourceModule<T extends AzResource<T, P, R>, P extends AzRes
     @Getter
     final class None extends AbstractAzResourceModule<AzResource.None, AzResource.None, Void> {
         public None() {
-            super("NONE", AzResource.NONE);
+            super(AzResource.None.NONE, AzResource.NONE);
         }
 
         @Nonnull
@@ -92,7 +92,7 @@ public interface AzResourceModule<T extends AzResource<T, P, R>, P extends AzRes
         @Nonnull
         @Override
         public String getResourceTypeName() {
-            return "NONE";
+            return AzResource.None.NONE;
         }
 
         @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/AzureResources.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/AzureResources.java
@@ -7,7 +7,6 @@ package com.microsoft.azure.toolkit.lib.resource;
 
 import com.azure.resourcemanager.resources.ResourceManager;
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
-import com.microsoft.azure.toolkit.lib.common.event.AzureEventBus;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzService;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzServiceSubscription;
 import lombok.extern.slf4j.Slf4j;
@@ -22,10 +21,6 @@ public class AzureResources extends AbstractAzService<ResourcesServiceSubscripti
 
     public AzureResources() {
         super("Microsoft.Resources");
-        AzureEventBus.on("account.logout.account", new AzureEventBus.EventListener((e) -> {
-            this.clear();
-            this.refresh();
-        }));
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/GenericResourceModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/GenericResourceModule.java
@@ -9,6 +9,7 @@ import com.azure.resourcemanager.resources.ResourceManager;
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import com.azure.resourcemanager.resources.fluentcore.arm.models.HasId;
 import com.azure.resourcemanager.resources.models.GenericResources;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 
@@ -56,6 +57,11 @@ public class GenericResourceModule extends
     @Nonnull
     protected GenericResource newResource(@Nonnull String resourceId, @Nullable String resourceGroupName) {
         return new GenericResource(resourceId, this);
+    }
+
+    @Nonnull
+    public GenericResource newResource(@Nonnull AbstractAzResource<?, ?, ?> concrete) {
+        return new GenericResource(concrete, this);
     }
 
     @Nonnull


### PR DESCRIPTION
…type-centric views.

What does this implement/fix? Explain your changes.
---------------------------------------------------
deleting/adding in ResourceGroup at the same time when resource is being added/deleted from its parent module.


Does this close any currently open issues?
------------------------------------------
[AB#1939937](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1939937): sync resource adding/deleting between app-centric and type-centric views.
[AB#1920258](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1920258): children resources should also be deleted from local cache after parent resource is deleted

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
