### PR TITLE
many error notifications pops if refreshing Azure Explorer after some resource groups are deleted somewhere else

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -186,9 +186,7 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
     }
 
     protected void setRemote(@Nullable R newRemote) {
-        if (this.remoteRef.get() == null || newRemote == null) {
-            this.getSubModules().forEach(AbstractAzResourceModule::clear);
-        }
+        final R oldRemote = this.remoteRef.get();
         synchronized (this.syncTimeRef) {
             log.debug("[{}:{}]:setRemote({})", this.module.getName(), this.getName(), newRemote);
             log.debug("[{}:{}]:setRemote->this.remoteRef.set({})", this.module.getName(), this.getName(), newRemote);
@@ -204,7 +202,10 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
         } else {
             log.debug("[{}:{}]:setRemote->this.setStatus(DISCONNECTED)", this.module.getName(), this.getName());
             this.setStatus(Status.DELETED);
-            this.getSubModules().stream().flatMap(m -> m.list().stream()).forEach(r -> r.setRemote(null));
+            this.getSubModules().stream().flatMap(m -> m.listLocalResources().stream()).forEach(r -> r.setRemote(null));
+        }
+        if (oldRemote == null || newRemote == null) {
+            this.getSubModules().forEach(AbstractAzResourceModule::clear);
         }
     }
 
@@ -238,7 +239,7 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
             if (cause instanceof ManagementException && HttpStatus.SC_NOT_FOUND != ((ManagementException) cause).getResponse().getStatusCode()) {
                 log.debug("[{}]:delete()->deleteResourceFromAzure()=SC_NOT_FOUND", this.name, e);
             } else {
-                this.getSubModules().stream().flatMap(m -> m.list().stream()).forEach(r -> r.setStatus(Status.UNKNOWN));
+                this.getSubModules().stream().flatMap(m -> m.listLocalResources().stream()).forEach(r -> r.setStatus(Status.UNKNOWN));
                 throw e;
             }
         }
@@ -255,7 +256,7 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
             final GenericResourceModule genericResourceModule = resourceGroup.genericResources();
             ((AbstractAzResourceModule) genericResourceModule).deleteResourceFromLocal(this.getId());
         }
-        this.getSubModules().stream().flatMap(m -> m.list().stream()).forEach(AbstractAzResource::deleteFromLocal);
+        this.getSubModules().stream().flatMap(m -> m.listLocalResources().stream()).forEach(AbstractAzResource::deleteFromLocal);
     }
 
     public void setStatus(@Nonnull String status) {
@@ -270,7 +271,7 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
                 }
                 fireEvents.debounce();
                 if (StringUtils.equalsAny(status, Status.DELETING, Status.DELETED)) {
-                    this.getSubModules().stream().flatMap(m -> m.list().stream()).forEach(r -> r.setStatus(status));
+                    this.getSubModules().stream().flatMap(m -> m.listLocalResources().stream()).forEach(r -> r.setStatus(status));
                 }
             }
         }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
@@ -112,6 +112,12 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
         }
     }
 
+    @Nonnull
+    public List<T> listLocalResources() { // getResources
+        return this.resources.values().stream().filter(Optional::isPresent).map(Optional::get)
+            .sorted(Comparator.comparing(AbstractAzResource::getName)).collect(Collectors.toList());
+    }
+
     private void reloadResources() {
         log.debug("[{}]:reload()", this.name);
         Stream<R> loaded;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
[AB#1955565](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1955565): [Test] Many errors pop up when delete a service
[AB#1951335](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1951335): many error notifications pops if refreshing Azure Explorer after some resource groups are deleted somewhere else

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
