### PR TITLE
add support for managed identity in CLI tools (Maven/Gradle plugins)

### DIFF
--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -26,6 +26,7 @@ import com.microsoft.azure.toolkit.lib.auth.core.devicecode.DeviceCodeAccount;
 import com.microsoft.azure.toolkit.lib.auth.exception.AzureLoginException;
 import com.microsoft.azure.toolkit.lib.auth.exception.AzureToolkitAuthenticationException;
 import com.microsoft.azure.toolkit.lib.auth.exception.LoginFailureException;
+import com.microsoft.azure.toolkit.lib.auth.model.AuthConfiguration;
 import com.microsoft.azure.toolkit.lib.auth.model.AuthType;
 import com.microsoft.azure.toolkit.lib.auth.util.AzureEnvironmentUtils;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureExecutionException;
@@ -377,7 +378,7 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
         if (auth.getType() == null || auth.getType() == AuthType.AUTO) {
             if (StringUtils.isAllBlank(auth.getCertificate(), auth.getCertificatePassword(), auth.getKey())) {
                 // not service principal configuration, will list accounts and try them one by one
-                final Account account = findFirstAvailableAccount().block();
+                final Account account = findFirstAvailableAccount(auth).block();
                 // prompt if oauth or device code
                 promptForOAuthOrDeviceCodeLogin(account.getAuthType());
                 return handleDeviceCodeAccount(Azure.az(AzureAccount.class).loginAsync(account, false).block());
@@ -414,8 +415,8 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
         }
     }
 
-    private static Mono<Account> findFirstAvailableAccount() {
-        final List<Account> accounts = Azure.az(AzureAccount.class).accounts();
+    private static Mono<Account> findFirstAvailableAccount(AuthConfiguration auth) {
+        final List<Account> accounts = Azure.az(AzureAccount.class).initAccounts(auth);
         if (accounts.isEmpty()) {
             return Mono.error(new AzureToolkitAuthenticationException("there are no subscriptions available."));
         }

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/Account.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/Account.java
@@ -130,7 +130,7 @@ public abstract class Account implements IAccount {
         }
     }
 
-    private Mono<TokenCredentialManager> initializeTokenCredentialManager() {
+    protected Mono<TokenCredentialManager> initializeTokenCredentialManager() {
         return createTokenCredentialManager().doOnSuccess(tokenCredentialManager -> this.credentialManager = tokenCredentialManager);
     }
 

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/core/managedidentity/ManagedIdentityAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/core/managedidentity/ManagedIdentityAccount.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.auth.core.managedidentity;
+
+import com.azure.core.management.AzureEnvironment;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.auth.Account;
+import com.microsoft.azure.toolkit.lib.auth.AzureCloud;
+import com.microsoft.azure.toolkit.lib.auth.TokenCredentialManager;
+import com.microsoft.azure.toolkit.lib.auth.TokenCredentialManagerWithCache;
+import com.microsoft.azure.toolkit.lib.auth.model.AuthConfiguration;
+import com.microsoft.azure.toolkit.lib.auth.model.AuthType;
+import reactor.core.publisher.Mono;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+public class ManagedIdentityAccount extends Account {
+
+    @Nullable
+    private final AuthConfiguration config;
+
+    public ManagedIdentityAccount(@Nullable final AuthConfiguration config) {
+        this.config = config;
+    }
+
+    @Override
+    public AuthType getAuthType() {
+        return AuthType.MANAGED_IDENTITY;
+    }
+
+    @Override
+    public String getClientId() {
+        return Optional.ofNullable(this.config).map(AuthConfiguration::getClient).orElse(null);
+    }
+
+    protected Mono<Boolean> preLoginCheck() {
+        // TODO: remove log error(from com.azure.core.implementation.AccessTokenCache#L153) when managed identity is not available
+        return Mono.fromCallable(() -> this.initializeTokenCredentialManager()
+                .map(TokenCredentialManager::listTenants).flatMapIterable(Mono::block)
+                .count().blockOptional().filter(s -> s > 0).isPresent());
+    }
+
+    protected Mono<TokenCredentialManager> createTokenCredentialManager() {
+        final AzureEnvironment env = Optional.ofNullable(this.config).map(AuthConfiguration::getEnvironment)
+                .orElseGet(() -> Azure.az(AzureCloud.class).getOrDefault());
+        return Mono.just(new ManagementIdentityTokenCredentialManager(env, this.getClientId()));
+    }
+
+    static class ManagementIdentityTokenCredentialManager extends TokenCredentialManagerWithCache {
+        public ManagementIdentityTokenCredentialManager(@Nonnull AzureEnvironment environment, @Nullable String clientId) {
+            this.environment = environment;
+            rootCredentialSupplier = () -> new ManagedIdentityCredentialBuilder().clientId(clientId).build();
+            credentialSupplier = (tenantId) -> new ManagedIdentityCredentialBuilder().clientId(clientId).build();
+        }
+    }
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
implement `ManagedIdentityAccount` based on `ManagedIdentityCredentialBuilder`


Does this close any currently open issues?
------------------------------------------
[AB#1956427](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1956427): add support for authenticating with managed identity in maven(gradle) plugins so that user can use it more conveniently on Azure services.


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
