### PR TITLE
support configuring spring apps with both `resource group` and `clusterName`

### DIFF
--- a/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/AbstractMojoBase.java
+++ b/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/AbstractMojoBase.java
@@ -46,6 +46,13 @@ public abstract class AbstractMojoBase extends AbstractAzureMojo {
     protected Boolean isPublic;
 
     /**
+     * Name of the resource group
+     */
+    @Getter
+    @Parameter(property = "resourceGroup")
+    protected String resourceGroup; // optional
+
+    /**
      * Name of the spring apps
      */
     @Getter

--- a/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/DeployMojo.java
+++ b/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/DeployMojo.java
@@ -46,9 +46,9 @@ public class DeployMojo extends AbstractMojoBase {
     private static final String PROJECT_SKIP = "Packaging type is pom, taking no actions.";
     private static final String PROJECT_NO_CONFIGURATION = "Configuration does not exist, taking no actions.";
     private static final String PROJECT_NOT_SUPPORT = "`azure-spring-apps:deploy` does not support maven project with " +
-        "packaging %s, only jar is supported";
+            "packaging %s, only jar is supported";
     private static final String GET_DEPLOYMENT_STATUS_TIMEOUT = "Deployment succeeded but the app is still starting, " +
-        "you can check the app status from Azure Portal.";
+            "you can check the app status from Azure Portal.";
     private static final String CONFIRM_PROMPT_START = "`azure-spring-apps:deploy` will perform the following tasks";
     private static final String CONFIRM_PROMPT_CONFIRM = "Perform the above tasks? (Y/n):";
 
@@ -75,7 +75,7 @@ public class DeployMojo extends AbstractMojoBase {
         final SpringCloudAppConfig appConfig = this.getConfiguration();
         final SpringCloudDeploymentConfig deploymentConfig = appConfig.getDeployment();
         Optional.ofNullable(deploymentConfig).map(SpringCloudDeploymentConfig::getArtifact).map(IArtifact::getFile)
-            .orElseThrow(() -> new AzureToolkitRuntimeException("No artifact is specified to deploy."));
+                .orElseThrow(() -> new AzureToolkitRuntimeException("No artifact is specified to deploy."));
         final DeploySpringCloudAppTask task = new DeploySpringCloudAppTask(appConfig);
 
         final List<AzureTask<?>> tasks = task.getSubTasks();
@@ -85,7 +85,7 @@ public class DeployMojo extends AbstractMojoBase {
             return;
         }
         final SpringCloudDeployment deployment = task.doExecute();
-        if (!noWait && Optional.ofNullable(deploymentConfig).map(SpringCloudDeploymentConfig::getArtifact).map(IArtifact::getFile).isPresent()) {
+        if (!noWait && Optional.of(deploymentConfig).map(SpringCloudDeploymentConfig::getArtifact).map(IArtifact::getFile).isPresent()) {
             if (!deployment.waitUntilReady(GET_STATUS_TIMEOUT)) {
                 log.warn(GET_DEPLOYMENT_STATUS_TIMEOUT);
             }
@@ -95,8 +95,7 @@ public class DeployMojo extends AbstractMojoBase {
     }
 
     protected boolean confirm(List<AzureTask<?>> tasks) throws MojoFailureException {
-        try {
-            final IPrompter prompter = new DefaultPrompter();
+        try (final IPrompter prompter = new DefaultPrompter()) {
             System.out.println(CONFIRM_PROMPT_START);
             tasks.stream().map(AzureTask::getDescription).filter(t -> Objects.nonNull(t) && StringUtils.isNotBlank(t.toString()))
                 .forEach((t) -> System.out.printf("\t- %s%n", t));
@@ -128,8 +127,8 @@ public class DeployMojo extends AbstractMojoBase {
     protected void printStatus(SpringCloudDeployment deployment) {
         log.info("Deployment Status: {}", color(deployment.getStatus()));
         deployment.getInstances().forEach(instance ->
-            log.info(String.format("  InstanceName:%-10s  Status:%-10s Reason:%-10s DiscoverStatus:%-10s",
-                instance.name(), color(instance.status()), instance.reason(), instance.discoveryStatus())));
+                log.info(String.format("  InstanceName:%-10s  Status:%-10s Reason:%-10s DiscoverStatus:%-10s",
+                        instance.name(), color(instance.status()), instance.reason(), instance.discoveryStatus())));
     }
 
     private static String color(String status) {

--- a/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/config/AppRawConfig.java
+++ b/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/config/AppRawConfig.java
@@ -10,6 +10,7 @@ import lombok.Data;
 @Data
 public class AppRawConfig {
     private String subscriptionId;
+    private String resourceGroup; // optional
     private String clusterName;
     private String appName;
     private String isPublic;

--- a/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/config/ConfigurationParser.java
+++ b/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/config/ConfigurationParser.java
@@ -22,6 +22,7 @@ public class ConfigurationParser {
         final SpringCloudDeploymentConfig config = ConfigurationParser.toDeploymentConfig(rawConfig, springMojo);
         return SpringCloudAppConfig.builder()
             .appName(springMojo.getAppName())
+            .resourceGroup(springMojo.getResourceGroup())
             .clusterName(springMojo.getClusterName())
             .deployment(config)
             .runtimeVersion(config.getRuntimeVersion())

--- a/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/config/ConfigurationUpdater.java
+++ b/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/config/ConfigurationUpdater.java
@@ -53,6 +53,7 @@ public class ConfigurationUpdater {
     public static Map<String, Object> toMap(AppRawConfig app) {
         return MapUtils.putAll(new LinkedHashMap<>(), new Map.Entry[]{
             new DefaultMapEntry<>("subscriptionId", app.getSubscriptionId()),
+            new DefaultMapEntry<>("resourceGroup", app.getResourceGroup()),
             new DefaultMapEntry<>("clusterName", app.getClusterName()),
             new DefaultMapEntry<>("appName", app.getAppName()),
             new DefaultMapEntry<>("isPublic", app.getIsPublic())


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
[AB#1942389](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1942389), [AB#1945863](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1945863): add `resource group` to spring apps maven plugin configuration and use it to locate spring apps


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
