### PR TITLE
reload resources/remote from Azure automatically if local cache is older than 30min

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -129,7 +129,8 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
                     this.syncTimeRef.set(-1);
                 }
             }
-            if (this.syncTimeRef.compareAndSet(-1, 0)) {
+            final boolean cacheExpired = System.currentTimeMillis() - this.syncTimeRef.get() > CACHE_LIFETIME;
+            if (this.syncTimeRef.compareAndSet(-1, 0) || cacheExpired) {
                 log.debug("[{}:{}]:getRemote->reload()", this.module.getName(), this.getName());
                 this.reloadRemote();
             }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
@@ -103,7 +103,8 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
                     this.syncTimeRef.set(-1);
                 }
             }
-            if (this.syncTimeRef.compareAndSet(-1, 0)) {
+            final boolean cacheExpired = System.currentTimeMillis() - this.syncTimeRef.get() > AzResource.CACHE_LIFETIME;
+            if (this.syncTimeRef.compareAndSet(-1, 0) || cacheExpired) {
                 log.debug("[{}]:list->this.reload()", this.name);
                 this.reloadResources();
             }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
@@ -114,7 +114,7 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
     }
 
     @Nonnull
-    public List<T> listLocalResources() { // getResources
+    public List<T> listCachedResources() { // getResources
         return this.resources.values().stream().filter(Optional::isPresent).map(Optional::get)
             .sorted(Comparator.comparing(AbstractAzResource::getName)).collect(Collectors.toList());
     }
@@ -158,7 +158,7 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
             log.debug("[{}]:reload.deleted->deleteResourceFromLocal", this.name);
             deleted.forEach(id -> this.resources.get(id).ifPresent(r -> {
                 r.setRemote(null);
-                r.deleteFromLocal();
+                r.deleteFromCache();
             }));
             log.debug("[{}]:reload.added->addResourceToLocal", this.name);
             added.forEach(id -> this.addResourceToLocal(id, loadedResources.get(id), true));

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AzResource.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 
 public interface AzResource<T extends AzResource<T, P, R>, P extends AzResource<P, ?, ?>, R>
     extends AzResourceBase, Refreshable {
+    long CACHE_LIFETIME = 30 * 60 * 1000; // 30 minutes
 
     None NONE = new None();
     String RESOURCE_GROUP_PLACEHOLDER = "${rg}";

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourceGroup.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourceGroup.java
@@ -60,7 +60,7 @@ public class ResourceGroup extends AbstractAzResource<ResourceGroup, ResourcesSe
 
     @Override
     public void delete() {
-        final List<? extends AbstractAzResource<?, ?, ?>> localResources = this.genericResources().listLocalResources().stream()
+        final List<? extends AbstractAzResource<?, ?, ?>> localResources = this.genericResources().listCachedResources().stream()
             .map(GenericResource::toConcreteResource)
             .filter(r -> !(r instanceof GenericResource)).collect(Collectors.toList());
         localResources.forEach(r -> r.setStatus(Status.DELETING));


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
check the age of cached data when getting/listing and reload from Azure if it's older than 30 mins.


Does this close any currently open issues?
------------------------------------------
[AB#1974375](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1974375): refresh local cache of Azure resources automatically to avoid/weaken cross-process inconsistence.


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
