### PR TITLE
invalidate local cache of the resource and its children resources on refreshing

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/src/main/java/com/microsoft/azure/toolkit/lib/applicationinsights/ApplicationInsight.java
+++ b/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/src/main/java/com/microsoft/azure/toolkit/lib/applicationinsights/ApplicationInsight.java
@@ -30,7 +30,6 @@ public class ApplicationInsight extends AbstractAzResource<ApplicationInsight, A
 
     protected ApplicationInsight(@Nonnull ApplicationInsightsComponent remote, @Nonnull ApplicationInsightsModule module) {
         super(remote.name(), ResourceId.fromString(remote.id()).resourceGroupName(), module);
-        this.setRemote(remote);
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/src/main/java/com/microsoft/azure/toolkit/lib/applicationinsights/ApplicationInsightsServiceSubscription.java
+++ b/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/src/main/java/com/microsoft/azure/toolkit/lib/applicationinsights/ApplicationInsightsServiceSubscription.java
@@ -30,7 +30,6 @@ public class ApplicationInsightsServiceSubscription extends AbstractAzServiceSub
 
     protected ApplicationInsightsServiceSubscription(@Nonnull ApplicationInsightsManager manager, @Nonnull AzureApplicationInsights service) {
         this(manager.serviceClient().getSubscriptionId(), service);
-        this.setRemote(manager);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/AppServiceAppBase.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/AppServiceAppBase.java
@@ -86,7 +86,7 @@ public abstract class AppServiceAppBase<
     public synchronized F getFullRemote() {
         WebSiteBase remote = this.getRemote();
         if (Objects.nonNull(remote) && !(remote instanceof WebAppBase)) {
-            this.refresh();
+            this.invalidateCache();
             remote = this.getRemote();
         }
         //noinspection unchecked

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/AppServiceServiceSubscription.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/AppServiceServiceSubscription.java
@@ -46,7 +46,6 @@ public class AppServiceServiceSubscription extends AbstractAzServiceSubscription
 
     protected AppServiceServiceSubscription(@Nonnull AppServiceManager remote, @Nonnull AzureAppService service) {
         this(remote.subscriptionId(), service);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/FunctionApp.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/FunctionApp.java
@@ -46,7 +46,6 @@ public class FunctionApp extends FunctionAppBase<FunctionApp, AppServiceServiceS
     protected FunctionApp(@Nonnull FunctionAppBasic remote, @Nonnull FunctionAppModule module) {
         super(remote.name(), remote.resourceGroupName(), module);
         this.deploymentModule = new FunctionAppDeploymentSlotModule(this);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/FunctionAppDeploymentSlot.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/FunctionAppDeploymentSlot.java
@@ -29,7 +29,6 @@ public class FunctionAppDeploymentSlot extends FunctionAppBase<FunctionAppDeploy
 
     protected FunctionAppDeploymentSlot(@Nonnull FunctionDeploymentSlotBasic remote, @Nonnull FunctionAppDeploymentSlotModule module) {
         super(remote.name(), module);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/plan/AppServicePlan.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/plan/AppServicePlan.java
@@ -46,7 +46,6 @@ public class AppServicePlan extends AbstractAzResource<AppServicePlan, AppServic
 
     protected AppServicePlan(@Nonnull com.azure.resourcemanager.appservice.models.AppServicePlan remote, @Nonnull AppServicePlanModule module) {
         super(remote.name(), remote.resourceGroupName(), module);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/webapp/WebApp.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/webapp/WebApp.java
@@ -39,7 +39,6 @@ public class WebApp extends WebAppBase<WebApp, AppServiceServiceSubscription, co
     protected WebApp(@Nonnull WebAppBasic remote, @Nonnull WebAppModule module) {
         super(remote.name(), remote.resourceGroupName(), module);
         this.deploymentModule = new WebAppDeploymentSlotModule(this);
-        this.setRemote(remote);
     }
 
     public void swap(String slotName) {

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/webapp/WebAppDeploymentSlot.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/webapp/WebAppDeploymentSlot.java
@@ -28,7 +28,6 @@ public class WebAppDeploymentSlot extends WebAppBase<WebAppDeploymentSlot, WebAp
 
     protected WebAppDeploymentSlot(@Nonnull WebDeploymentSlotBasic remote, @Nonnull WebAppDeploymentSlotModule module) {
         super(remote.name(), module);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -170,6 +170,10 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
     protected synchronized void setRemote(@Nullable R newRemote) {
         final R oldRemote = this.remoteRef.get();
         log.debug("[{}:{}]:setRemote({})", this.module.getName(), this.getName(), newRemote);
+        if (oldRemote == null || newRemote == null) {
+            log.debug("[{}:{}]:setRemote->subModules.invalidateCache()", this.module.getName(), this.getName());
+            this.getSubModules().forEach(AbstractAzResourceModule::invalidateCache);
+        }
         log.debug("[{}:{}]:setRemote->this.remoteRef.set({})", this.module.getName(), this.getName(), newRemote);
         this.remoteRef.set(newRemote);
         this.syncTimeRef.set(System.currentTimeMillis());
@@ -184,9 +188,6 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
             this.updateAdditionalProperties(null, oldRemote);
             this.setStatus(Status.DELETED);
             this.getSubModules().stream().flatMap(m -> m.listCachedResources().stream()).forEach(r -> r.setRemote(null));
-        }
-        if (oldRemote == null || newRemote == null) {
-            this.getSubModules().forEach(AbstractAzResourceModule::invalidateCache);
         }
     }
 

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -177,15 +177,21 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
             log.debug("[{}:{}]:setRemote->setStatus(LOADING)", this.module.getName(), this.getName());
             this.setStatus(Status.LOADING);
             log.debug("[{}:{}]:setRemote->this.loadStatus", this.module.getName(), this.getName());
+            this.updateAdditionalProperties(newRemote, oldRemote);
             Optional.of(newRemote).map(this::loadStatus).ifPresent(this::setStatus);
         } else {
             log.debug("[{}:{}]:setRemote->this.setStatus(DISCONNECTED)", this.module.getName(), this.getName());
+            this.updateAdditionalProperties(null, oldRemote);
             this.setStatus(Status.DELETED);
             this.getSubModules().stream().flatMap(m -> m.listCachedResources().stream()).forEach(r -> r.setRemote(null));
         }
         if (oldRemote == null || newRemote == null) {
             this.getSubModules().forEach(AbstractAzResourceModule::invalidateCache);
         }
+    }
+
+    protected void updateAdditionalProperties(R newRemote, R oldRemote) {
+
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -111,10 +111,18 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
     @Override
     public void refresh() {
         log.debug("[{}:{}]:refresh()", this.module.getName(), this.getName());
-        this.syncTimeRef.set(-1);
-        log.debug("[{}:{}]:refresh->subModules.refresh()", this.module.getName(), this.getName());
-        this.getSubModules().forEach(AzResourceModule::refresh);
+        this.invalidateCache();
         AzureEventBus.emit("resource.refreshed.resource", this);
+    }
+
+    void invalidateCache() {
+        log.debug("[{}]:invalidateCache()", this.name);
+        synchronized (this.syncTimeRef) {
+            this.syncTimeRef.set(-1);
+            this.syncTimeRef.notifyAll();
+            log.debug("[{}:{}]:refresh->subModules.invalidateCache()", this.module.getName(), this.getName());
+            this.getSubModules().forEach(AbstractAzResourceModule::invalidateCache);
+        }
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -96,16 +96,6 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
         this.syncTimeRef = origin.syncTimeRef;
     }
 
-    protected void copyFrom(@Nonnull AbstractAzResource<T, P, R> origin) {
-        if (Objects.equals(this, origin)) {
-            this.remoteRef.set(origin.remoteRef.get());
-            this.statusRef.set(origin.statusRef.get());
-            this.syncTimeRef.set(origin.syncTimeRef.get());
-        } else {
-            throw new AzureToolkitRuntimeException("can not copy from another resource");
-        }
-    }
-
     public boolean exists() {
         final P parent = this.getParent();
         if (StringUtils.equals(this.statusRef.get(), Status.DELETED)) {
@@ -167,7 +157,7 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
         }, Status.LOADING);
     }
 
-    protected synchronized void setRemote(@Nullable R newRemote) {
+    synchronized void setRemote(@Nullable R newRemote) {
         final R oldRemote = this.remoteRef.get();
         log.debug("[{}:{}]:setRemote({})", this.module.getName(), this.getName(), newRemote);
         if (oldRemote == null || newRemote == null) {

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -57,12 +57,12 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
     private final AbstractAzResourceModule<T, P, R> module;
     @Nonnull
     @ToString.Include
-    final AtomicLong syncTimeRef; // 0:loading, <0:invalidated
+    private final AtomicLong syncTimeRef; // 0:loading, <0:invalidated
     @Nonnull
-    final AtomicReference<R> remoteRef;
+    private final AtomicReference<R> remoteRef;
     @Nonnull
     @ToString.Include
-    final AtomicReference<String> statusRef;
+    private final AtomicReference<String> statusRef;
     @Nonnull
     private final Debouncer fireEvents = new TailingDebouncer(this::fireStatusChangedEvent, 300);
 
@@ -87,7 +87,7 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
     /**
      * copy constructor
      */
-    protected AbstractAzResource(@Nonnull T origin) {
+    protected AbstractAzResource(@Nonnull AbstractAzResource<T, P, R> origin) {
         this.name = origin.getName();
         this.resourceGroupName = origin.getResourceGroupName();
         this.module = origin.getModule();
@@ -96,7 +96,7 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
         this.syncTimeRef = origin.syncTimeRef;
     }
 
-    protected void copyFrom(T origin) {
+    protected void copyFrom(@Nonnull AbstractAzResource<T, P, R> origin) {
         if (Objects.equals(this, origin)) {
             this.remoteRef.set(origin.remoteRef.get());
             this.statusRef.set(origin.statusRef.get());

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzService.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzService.java
@@ -13,7 +13,6 @@ import com.microsoft.azure.toolkit.lib.common.cache.Preload;
 import com.microsoft.azure.toolkit.lib.common.event.AzureEventBus;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import com.microsoft.azure.toolkit.lib.common.operation.OperationContext;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzService.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzService.java
@@ -68,12 +68,6 @@ public abstract class AbstractAzService<T extends AbstractAzServiceSubscription<
         return Objects.requireNonNull(this.get(subscriptionId, null));
     }
 
-    @Override
-    public void refresh() {
-        super.refresh();
-        this.list().forEach(AbstractAzResource::refresh);
-    }
-
     @Nonnull
     @Override
     @AzureOperation(name = "resource.list_resources.type", params = {"this.getResourceTypeName()"}, type = AzureOperation.Type.SERVICE)

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AzResource.java
@@ -69,9 +69,6 @@ public interface AzResource<T extends AzResource<T, P, R>, P extends AzResource<
 
     void delete();
 
-    @Nullable
-    R getRemote();
-
     @Nonnull
     String getStatus();
 

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/utils/TailingDebouncer.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/utils/TailingDebouncer.java
@@ -28,11 +28,17 @@ public class TailingDebouncer implements Debouncer {
             this.timer.unsubscribe();
         }
         this.timer = Observable.timer(this.delay, TimeUnit.MILLISECONDS)
-                .subscribeOn(Schedulers.io())
-                .subscribe(ignore -> {
-                    this.debounced.run();
-                    this.clearTimer();
-                }, (e) -> this.clearTimer());
+            .subscribeOn(Schedulers.io())
+            .subscribe(ignore -> {
+                this.debounced.run();
+                this.clearTimer();
+            }, (e) -> this.clearTimer());
+    }
+
+    public synchronized void cancel() {
+        if (this.isPending()) {
+            this.timer.unsubscribe();
+        }
     }
 
     public synchronized boolean isPending() {

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/GenericResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/GenericResource.java
@@ -42,14 +42,11 @@ public class GenericResource extends AbstractAzResource<GenericResource, Resourc
     protected GenericResource(@Nonnull HasId remote, @Nonnull GenericResourceModule module) {
         super(remote.id(), module.getParent().getResourceGroupName(), module);
         this.resourceId = ResourceId.fromString(remote.id());
-        this.setRemote(remote);
     }
 
     protected GenericResource(@Nonnull AbstractAzResource<?, ?, ?> concrete, @Nonnull GenericResourceModule module) {
-        super(concrete.getId(), module.getParent().getResourceGroupName(), module);
+        this(concrete::getId, module);
         this.concrete = concrete;
-        this.resourceId = ResourceId.fromString(concrete.getId());
-        this.setRemote(concrete::getId);
     }
 
     public synchronized AbstractAzResource<?, ?, ?> toConcreteResource() {

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourceDeployment.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourceDeployment.java
@@ -44,7 +44,6 @@ public class ResourceDeployment extends AbstractAzResource<ResourceDeployment, R
 
     protected ResourceDeployment(@Nonnull Deployment remote, @Nonnull ResourceDeploymentModule module) {
         super(remote.name(), remote.resourceGroupName(), module);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourceGroup.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourceGroup.java
@@ -45,7 +45,6 @@ public class ResourceGroup extends AbstractAzResource<ResourceGroup, ResourcesSe
         super(remote.name(), remote.name(), module);
         this.deploymentModule = new ResourceDeploymentModule(this);
         this.resourceModule = new GenericResourceModule(this);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourcesServiceSubscription.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourcesServiceSubscription.java
@@ -31,7 +31,6 @@ public class ResourcesServiceSubscription extends AbstractAzServiceSubscription<
 
     ResourcesServiceSubscription(@Nonnull ResourceManager remote, @Nonnull AzureResources service) {
         this(remote.subscriptionId(), service);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/ComputeServiceSubscription.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/ComputeServiceSubscription.java
@@ -38,7 +38,6 @@ public class ComputeServiceSubscription extends AbstractAzServiceSubscription<Co
 
     ComputeServiceSubscription(@Nonnull ComputeManager remote, @Nonnull AzureCompute service) {
         this(remote.subscriptionId(), service);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/virtualmachine/VirtualMachine.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/virtualmachine/VirtualMachine.java
@@ -42,7 +42,6 @@ public class VirtualMachine extends AbstractAzResource<VirtualMachine, ComputeSe
 
     protected VirtualMachine(@Nonnull com.azure.resourcemanager.compute.models.VirtualMachine remote, @Nonnull VirtualMachineModule module) {
         super(remote.name(), remote.resourceGroupName(), module);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/network/NetworkServiceSubscription.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/network/NetworkServiceSubscription.java
@@ -40,7 +40,6 @@ public class NetworkServiceSubscription extends AbstractAzServiceSubscription<Ne
 
     NetworkServiceSubscription(@Nonnull NetworkManager remote, @Nonnull AzureNetwork service) {
         this(remote.subscriptionId(), service);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/network/networksecuritygroup/NetworkSecurityGroup.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/network/networksecuritygroup/NetworkSecurityGroup.java
@@ -30,7 +30,6 @@ public class NetworkSecurityGroup extends AbstractAzResource<NetworkSecurityGrou
 
     protected NetworkSecurityGroup(@Nonnull com.azure.resourcemanager.network.models.NetworkSecurityGroup remote, @Nonnull NetworkSecurityGroupModule module) {
         super(remote.name(), remote.resourceGroupName(), module);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/network/publicipaddress/PublicIpAddress.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/network/publicipaddress/PublicIpAddress.java
@@ -30,7 +30,6 @@ public class PublicIpAddress extends AbstractAzResource<PublicIpAddress, Network
 
     protected PublicIpAddress(@Nonnull com.azure.resourcemanager.network.models.PublicIpAddress remote, @Nonnull PublicIpAddressModule module) {
         super(remote.name(), remote.resourceGroupName(), module);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/network/virtualnetwork/Network.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/network/virtualnetwork/Network.java
@@ -32,7 +32,6 @@ public class Network extends AbstractAzResource<Network, NetworkServiceSubscript
 
     protected Network(@Nonnull com.azure.resourcemanager.network.models.Network remote, @Nonnull NetworkModule module) {
         super(remote.name(), remote.resourceGroupName(), module);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-containerservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/containerservice/ContainerServiceSubscription.java
+++ b/azure-toolkit-libs/azure-toolkit-containerservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/containerservice/ContainerServiceSubscription.java
@@ -28,7 +28,6 @@ public class ContainerServiceSubscription extends AbstractAzServiceSubscription<
 
     protected ContainerServiceSubscription(@Nonnull ContainerServiceManager manager, @Nonnull AzureContainerService service) {
         this(manager.serviceClient().getSubscriptionId(), service);
-        this.setRemote(manager);
     }
 
     public KubernetesClusterModule kubernetes() {

--- a/azure-toolkit-libs/azure-toolkit-containerservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/containerservice/KubernetesCluster.java
+++ b/azure-toolkit-libs/azure-toolkit-containerservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/containerservice/KubernetesCluster.java
@@ -41,7 +41,6 @@ public class KubernetesCluster extends AbstractAzResource<KubernetesCluster, Con
     protected KubernetesCluster(@Nonnull com.azure.resourcemanager.containerservice.models.KubernetesCluster remote, @Nonnull KubernetesClusterModule module) {
         super(remote.name(), ResourceId.fromString(remote.id()).resourceGroupName(), module);
         this.agentPoolModule = new KubernetesClusterAgentPoolModule(this);
-        this.setRemote(remote);
     }
 
     public ContainerServiceNetworkProfile getContainerServiceNetworkProfile() {

--- a/azure-toolkit-libs/azure-toolkit-containerservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/containerservice/KubernetesClusterAgentPool.java
+++ b/azure-toolkit-libs/azure-toolkit-containerservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/containerservice/KubernetesClusterAgentPool.java
@@ -29,7 +29,6 @@ public class KubernetesClusterAgentPool extends AbstractAzResource<KubernetesClu
     public KubernetesClusterAgentPool(@Nonnull com.azure.resourcemanager.containerservice.models.KubernetesClusterAgentPool remote,
                                       @Nonnull KubernetesClusterAgentPoolModule module) {
         super(remote.name(), module);
-        this.setRemote(remote);
     }
 
     public int getNodeCount() {

--- a/azure-toolkit-libs/azure-toolkit-mysql-lib/src/main/java/com/microsoft/azure/toolkit/lib/mysql/MySqlDatabase.java
+++ b/azure-toolkit-libs/azure-toolkit-mysql-lib/src/main/java/com/microsoft/azure/toolkit/lib/mysql/MySqlDatabase.java
@@ -24,7 +24,6 @@ public class MySqlDatabase extends AbstractAzResource<MySqlDatabase, MySqlServer
 
     protected MySqlDatabase(@Nonnull Database remote, @Nonnull MySqlDatabaseModule module) {
         super(remote.name(), module);
-        this.setRemote(remote);
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-mysql-lib/src/main/java/com/microsoft/azure/toolkit/lib/mysql/MySqlFirewallRule.java
+++ b/azure-toolkit-libs/azure-toolkit-mysql-lib/src/main/java/com/microsoft/azure/toolkit/lib/mysql/MySqlFirewallRule.java
@@ -30,7 +30,6 @@ public class MySqlFirewallRule extends AbstractAzResource<MySqlFirewallRule, MyS
 
     protected MySqlFirewallRule(@Nonnull FirewallRule remote, @Nonnull MySqlFirewallRuleModule module) {
         super(remote.name(), module);
-        this.setRemote(remote);
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-mysql-lib/src/main/java/com/microsoft/azure/toolkit/lib/mysql/MySqlServer.java
+++ b/azure-toolkit-libs/azure-toolkit-mysql-lib/src/main/java/com/microsoft/azure/toolkit/lib/mysql/MySqlServer.java
@@ -56,7 +56,6 @@ public class MySqlServer extends AbstractAzResource<MySqlServer, MySqlServiceSub
         super(remote.name(), ResourceId.fromString(remote.id()).resourceGroupName(), module);
         this.databaseModule = new MySqlDatabaseModule(this);
         this.firewallRuleModule = new MySqlFirewallRuleModule(this);
-        this.setRemote(remote);
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-mysql-lib/src/main/java/com/microsoft/azure/toolkit/lib/mysql/MySqlServiceSubscription.java
+++ b/azure-toolkit-libs/azure-toolkit-mysql-lib/src/main/java/com/microsoft/azure/toolkit/lib/mysql/MySqlServiceSubscription.java
@@ -37,7 +37,6 @@ public class MySqlServiceSubscription extends AbstractAzServiceSubscription<MySq
 
     MySqlServiceSubscription(@Nonnull MySqlManager manager, @Nonnull AzureMySql service) {
         this(manager.serviceClient().getSubscriptionId(), service);
-        this.setRemote(manager);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-postgre-lib/src/main/java/com/microsoft/azure/toolkit/lib/postgre/PostgreSqlDatabase.java
+++ b/azure-toolkit-libs/azure-toolkit-postgre-lib/src/main/java/com/microsoft/azure/toolkit/lib/postgre/PostgreSqlDatabase.java
@@ -24,7 +24,6 @@ public class PostgreSqlDatabase extends AbstractAzResource<PostgreSqlDatabase, P
 
     protected PostgreSqlDatabase(@Nonnull Database remote, @Nonnull PostgreSqlDatabaseModule module) {
         super(remote.name(), module);
-        this.setRemote(remote);
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-postgre-lib/src/main/java/com/microsoft/azure/toolkit/lib/postgre/PostgreSqlFirewallRule.java
+++ b/azure-toolkit-libs/azure-toolkit-postgre-lib/src/main/java/com/microsoft/azure/toolkit/lib/postgre/PostgreSqlFirewallRule.java
@@ -30,7 +30,6 @@ public class PostgreSqlFirewallRule extends AbstractAzResource<PostgreSqlFirewal
 
     protected PostgreSqlFirewallRule(@Nonnull FirewallRule remote, @Nonnull PostgreSqlFirewallRuleModule module) {
         super(remote.name(), module);
-        this.setRemote(remote);
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-postgre-lib/src/main/java/com/microsoft/azure/toolkit/lib/postgre/PostgreSqlServer.java
+++ b/azure-toolkit-libs/azure-toolkit-postgre-lib/src/main/java/com/microsoft/azure/toolkit/lib/postgre/PostgreSqlServer.java
@@ -57,7 +57,6 @@ public class PostgreSqlServer extends AbstractAzResource<PostgreSqlServer, Postg
         super(remote.name(), ResourceId.fromString(remote.id()).resourceGroupName(), module);
         this.databaseModule = new PostgreSqlDatabaseModule(this);
         this.firewallRuleModule = new PostgreSqlFirewallRuleModule(this);
-        this.setRemote(remote);
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-postgre-lib/src/main/java/com/microsoft/azure/toolkit/lib/postgre/PostgreSqlServiceSubscription.java
+++ b/azure-toolkit-libs/azure-toolkit-postgre-lib/src/main/java/com/microsoft/azure/toolkit/lib/postgre/PostgreSqlServiceSubscription.java
@@ -37,7 +37,6 @@ public class PostgreSqlServiceSubscription extends AbstractAzServiceSubscription
 
     PostgreSqlServiceSubscription(@Nonnull PostgreSqlManager manager, @Nonnull AzurePostgreSql service) {
         this(manager.serviceClient().getSubscriptionId(), service);
-        this.setRemote(manager);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-redis-lib/src/main/java/com/microsoft/azure/toolkit/redis/RedisCache.java
+++ b/azure-toolkit-libs/azure-toolkit-redis-lib/src/main/java/com/microsoft/azure/toolkit/redis/RedisCache.java
@@ -42,7 +42,6 @@ public class RedisCache extends AbstractAzResource<RedisCache, RedisServiceSubsc
 
     protected RedisCache(@Nonnull com.azure.resourcemanager.redis.models.RedisCache remote, @Nonnull RedisCacheModule module) {
         super(remote.name(), remote.resourceGroupName(), module);
-        this.setRemote(remote);
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-redis-lib/src/main/java/com/microsoft/azure/toolkit/redis/RedisServiceSubscription.java
+++ b/azure-toolkit-libs/azure-toolkit-redis-lib/src/main/java/com/microsoft/azure/toolkit/redis/RedisServiceSubscription.java
@@ -38,7 +38,6 @@ public class RedisServiceSubscription extends AbstractAzServiceSubscription<Redi
 
     RedisServiceSubscription(@Nonnull RedisManager remote, @Nonnull AzureRedis service) {
         this(remote.subscriptionId(), service);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudApp.java
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudApp.java
@@ -53,6 +53,12 @@ public class SpringCloudApp extends AbstractAzResource<SpringCloudApp, SpringClo
         this.setRemote(remote);
     }
 
+    @Override
+    protected void copyFrom(SpringCloudApp origin) {
+        super.copyFrom(origin);
+        this.activeDeploymentName = origin.activeDeploymentName;
+    }
+
     @Nonnull
     @Override
     public List<AbstractAzResourceModule<?, SpringCloudApp, ?>> getSubModules() {
@@ -67,7 +73,7 @@ public class SpringCloudApp extends AbstractAzResource<SpringCloudApp, SpringClo
             return Status.INACTIVE;
         }
         activeDeployment.refresh();
-        return activeDeployment.getStatusSync();
+        return activeDeployment.getStatus();
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudApp.java
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudApp.java
@@ -49,13 +49,6 @@ public class SpringCloudApp extends AbstractAzResource<SpringCloudApp, SpringClo
     protected SpringCloudApp(@Nonnull SpringApp remote, @Nonnull SpringCloudAppModule module) {
         super(remote.name(), module);
         this.deploymentModule = new SpringCloudDeploymentModule(this);
-        this.setRemote(remote);
-    }
-
-    @Override
-    protected void copyFrom(SpringCloudApp origin) {
-        super.copyFrom(origin);
-        this.activeDeployment = origin.activeDeployment;
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudCluster.java
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudCluster.java
@@ -42,7 +42,6 @@ public class SpringCloudCluster extends AbstractAzResource<SpringCloudCluster, S
     protected SpringCloudCluster(@Nonnull SpringService remote, @Nonnull SpringCloudClusterModule module) {
         super(remote.name(), remote.resourceGroupName(), module);
         this.appModule = new SpringCloudAppModule(this);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudDeployment.java
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudDeployment.java
@@ -50,7 +50,6 @@ public class SpringCloudDeployment extends AbstractAzResource<SpringCloudDeploym
 
     protected SpringCloudDeployment(@Nonnull SpringAppDeployment remote, @Nonnull SpringCloudDeploymentModule module) {
         super(remote.name(), module);
-        this.setRemote(remote);
     }
 
     // MODIFY

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudDeployment.java
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudDeployment.java
@@ -124,7 +124,7 @@ public class SpringCloudDeployment extends AbstractAzResource<SpringCloudDeploym
     public boolean waitUntilReady(int timeoutInSeconds) {
         AzureMessager.getMessager().info("Getting deployment status...");
         final SpringCloudDeployment deployment = Utils.pollUntil(() -> {
-            this.refresh();
+            this.invalidateCache();
             return this;
         }, Utils::isDeploymentDone, timeoutInSeconds);
         return Utils.isDeploymentDone(deployment);

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudServiceSubscription.java
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudServiceSubscription.java
@@ -32,7 +32,6 @@ public class SpringCloudServiceSubscription extends AbstractAzServiceSubscriptio
 
     SpringCloudServiceSubscription(@Nonnull AppPlatformManager remote, @Nonnull AzureSpringCloud service) {
         this(remote.subscriptionId(), service);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-sqlserver-lib/src/main/java/com/microsoft/azure/toolkit/lib/sqlserver/MicrosoftSqlDatabase.java
+++ b/azure-toolkit-libs/azure-toolkit-sqlserver-lib/src/main/java/com/microsoft/azure/toolkit/lib/sqlserver/MicrosoftSqlDatabase.java
@@ -25,7 +25,6 @@ public class MicrosoftSqlDatabase extends AbstractAzResource<MicrosoftSqlDatabas
 
     protected MicrosoftSqlDatabase(@Nonnull SqlDatabase remote, @Nonnull MicrosoftSqlDatabaseModule module) {
         super(remote.name(), module);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-sqlserver-lib/src/main/java/com/microsoft/azure/toolkit/lib/sqlserver/MicrosoftSqlFirewallRule.java
+++ b/azure-toolkit-libs/azure-toolkit-sqlserver-lib/src/main/java/com/microsoft/azure/toolkit/lib/sqlserver/MicrosoftSqlFirewallRule.java
@@ -30,7 +30,6 @@ public class MicrosoftSqlFirewallRule extends AbstractAzResource<MicrosoftSqlFir
 
     protected MicrosoftSqlFirewallRule(@Nonnull SqlFirewallRule remote, @Nonnull MicrosoftSqlFirewallRuleModule module) {
         super(remote.name(), module);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-sqlserver-lib/src/main/java/com/microsoft/azure/toolkit/lib/sqlserver/MicrosoftSqlServer.java
+++ b/azure-toolkit-libs/azure-toolkit-sqlserver-lib/src/main/java/com/microsoft/azure/toolkit/lib/sqlserver/MicrosoftSqlServer.java
@@ -51,7 +51,6 @@ public class MicrosoftSqlServer extends AbstractAzResource<MicrosoftSqlServer, M
         super(remote.name(), remote.resourceGroupName(), module);
         this.databaseModule = new MicrosoftSqlDatabaseModule(this);
         this.firewallRuleModule = new MicrosoftSqlFirewallRuleModule(this);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-sqlserver-lib/src/main/java/com/microsoft/azure/toolkit/lib/sqlserver/MicrosoftSqlServiceSubscription.java
+++ b/azure-toolkit-libs/azure-toolkit-sqlserver-lib/src/main/java/com/microsoft/azure/toolkit/lib/sqlserver/MicrosoftSqlServiceSubscription.java
@@ -35,7 +35,6 @@ public class MicrosoftSqlServiceSubscription extends AbstractAzServiceSubscripti
 
     MicrosoftSqlServiceSubscription(@Nonnull SqlServerManager manager, @Nonnull AzureSqlServer service) {
         this(manager.serviceClient().getSubscriptionId(), service);
-        this.setRemote(manager);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageAccount.java
@@ -42,7 +42,6 @@ public class StorageAccount extends AbstractAzResource<StorageAccount, StorageSe
 
     protected StorageAccount(@Nonnull com.azure.resourcemanager.storage.models.StorageAccount remote, @Nonnull StorageAccountModule module) {
         super(remote.name(), remote.resourceGroupName(), module);
-        this.setRemote(remote);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageServiceSubscription.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageServiceSubscription.java
@@ -37,7 +37,6 @@ public class StorageServiceSubscription extends AbstractAzServiceSubscription<St
 
     StorageServiceSubscription(@Nonnull StorageManager remote, @Nonnull AzureStorageAccount service) {
         this(remote.subscriptionId(), service);
-        this.setRemote(remote);
     }
 
     @Nonnull


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
add `invalidateCache` to prevent cascade events when refreshing


Does this close any currently open issues?
------------------------------------------
[AB#1974371](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1974371): add refresh action on combobox component, so that users can always refresh options from remote server in case of inconsistence.


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
