### PR TITLE
Add model for cosmos db connection string

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/CosmosDBAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/CosmosDBAccount.java
@@ -24,29 +24,31 @@ import java.util.Optional;
 public class CosmosDBAccount extends AbstractAzResource<CosmosDBAccount, CosmosServiceSubscription,
         com.azure.resourcemanager.cosmos.models.CosmosDBAccount> implements Deletable {
 
+    private DatabaseAccountKeys databaseAccountKeys;
+    private DatabaseAccountConnectionStrings databaseAccountConnectionStrings;
+
     protected CosmosDBAccount(@Nonnull String name, @Nonnull String resourceGroupName, @Nonnull CosmosDBAccountModule module) {
         super(name, resourceGroupName, module);
     }
 
     protected CosmosDBAccount(@Nonnull CosmosDBAccount account) {
         super(account);
+        this.databaseAccountKeys = account.databaseAccountKeys;
+        this.databaseAccountConnectionStrings = account.databaseAccountConnectionStrings;
     }
 
     protected CosmosDBAccount(@Nonnull com.azure.resourcemanager.cosmos.models.CosmosDBAccount remote, @Nonnull CosmosDBAccountModule module) {
         super(remote.name(), ResourceId.fromString(remote.id()).resourceGroupName(), module);
     }
 
-    @Nullable
+    @Nonnull
     public DatabaseAccountKeys listKeys() {
-        return Optional.ofNullable(getRemote())
-                .map(remote -> DatabaseAccountKeys.fromDatabaseAccountListKeysResult(remote.listKeys())).orElse(null);
+        return remoteOptional().map(ignore -> this.databaseAccountKeys).orElseGet(DatabaseAccountKeys::new);
     }
 
-    @Nullable
+    @Nonnull
     public DatabaseAccountConnectionStrings listConnectionStrings() {
-        return Optional.ofNullable(getRemote())
-                .map(remote -> DatabaseAccountConnectionStrings.fromDatabaseAccountListConnectionStringsResult(remote.listConnectionStrings(), Objects.requireNonNull(getKind())))
-                .orElse(null);
+        return remoteOptional().map(ignore -> this.databaseAccountConnectionStrings).orElseGet(DatabaseAccountConnectionStrings::new);
     }
 
     @Nullable
@@ -60,8 +62,9 @@ public class CosmosDBAccount extends AbstractAzResource<CosmosDBAccount, CosmosS
         return Collections.emptyList();
     }
 
+    @Nullable
     public String getDocumentEndpoint() {
-        return getRemote().documentEndpoint();
+        return Optional.ofNullable(getRemote()).map(remote -> remote.documentEndpoint()).orElse(null);
     }
 
     @NotNull
@@ -69,5 +72,11 @@ public class CosmosDBAccount extends AbstractAzResource<CosmosDBAccount, CosmosS
     public String loadStatus(@NotNull com.azure.resourcemanager.cosmos.models.CosmosDBAccount remote) {
         // todo: investigate how to get status instead of provisioning state
         return remote.innerModel().provisioningState();
+    }
+
+    @Override
+    protected void updateAdditionalProperties(com.azure.resourcemanager.cosmos.models.CosmosDBAccount newRemote, com.azure.resourcemanager.cosmos.models.CosmosDBAccount oldRemote) {
+        this.databaseAccountKeys = DatabaseAccountKeys.fromDatabaseAccountListKeysResult(newRemote.listKeys());
+        this.databaseAccountConnectionStrings = DatabaseAccountConnectionStrings.fromDatabaseAccountListConnectionStringsResult(newRemote.listConnectionStrings(), Objects.requireNonNull(this.getKind()));
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraCosmosDBAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraCosmosDBAccount.java
@@ -8,12 +8,11 @@ package com.microsoft.azure.toolkit.lib.cosmos.cassandra;
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccount;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccountModule;
-import com.microsoft.azure.toolkit.lib.cosmos.model.DatabaseAccountConnectionStrings;
-import org.apache.commons.lang3.StringUtils;
+import com.microsoft.azure.toolkit.lib.cosmos.model.CassandraDatabaseAccountConnectionString;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 public class CassandraCosmosDBAccount extends CosmosDBAccount {
@@ -38,29 +37,30 @@ public class CassandraCosmosDBAccount extends CosmosDBAccount {
         return this.keyspaceModule;
     }
 
+    @Nullable
     public String getPrimaryConnectionString() {
-        return Optional.ofNullable(listConnectionStrings()).map(DatabaseAccountConnectionStrings::getPrimaryConnectionString).orElse(null);
+        return listConnectionStrings().getPrimaryConnectionString();
     }
 
+    @Nonnull
+    public CassandraDatabaseAccountConnectionString getCassandraConnectionString() {
+        return Optional.ofNullable(getPrimaryConnectionString())
+                .map(CassandraDatabaseAccountConnectionString::fromConnectionString)
+                .orElseGet(CassandraDatabaseAccountConnectionString::new);
+    }
+
+    @Nullable
     public Integer getPort() {
-        return Optional.ofNullable(getPrimaryConnectionString())
-                .map(connectionString -> getParameterFromConnectionString(connectionString, "Port"))
-                .map(Integer::valueOf).orElse(null);
+        return getCassandraConnectionString().getPort();
     }
 
+    @Nullable
     public String getUserName() {
-        return Optional.ofNullable(getPrimaryConnectionString())
-                .map(connectionString -> getParameterFromConnectionString(connectionString, "Username")).orElse(null);
+        return getCassandraConnectionString().getUsername();
     }
 
+    @Nullable
     public String getContactPoint() {
-        return Optional.ofNullable(getPrimaryConnectionString())
-                .map(connectionString -> getParameterFromConnectionString(connectionString, "HostName")).orElse(null);
-    }
-
-    public String getParameterFromConnectionString(@Nonnull final String connectionString, final String key) {
-        final String[] parameters = connectionString.split(";");
-        final String parameter = Arrays.stream(parameters).filter(value -> StringUtils.containsIgnoreCase(value, key)).findFirst().orElse(null);
-        return StringUtils.isEmpty(parameter) ? null : StringUtils.substringAfterLast(parameter, "=");
+        return getCassandraConnectionString().getContactPoint();
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/CassandraDatabaseAccountConnectionString.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/CassandraDatabaseAccountConnectionString.java
@@ -35,6 +35,6 @@ public class CassandraDatabaseAccountConnectionString {
     @Nullable
     private static String extractValueFromParameters(@Nonnull final String[] parameters, final String key) {
         final String parameter = Arrays.stream(parameters).filter(value -> StringUtils.containsIgnoreCase(value, key)).findFirst().orElse(null);
-        return StringUtils.isEmpty(parameter) ? null : StringUtils.substringAfterLast(parameter, "=");
+        return StringUtils.isEmpty(parameter) ? null : StringUtils.substringAfter(parameter, "=");
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/CassandraDatabaseAccountConnectionString.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/CassandraDatabaseAccountConnectionString.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.cosmos.model;
+
+import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Optional;
+
+@Data
+public class CassandraDatabaseAccountConnectionString {
+    private String contactPoint;
+    private Integer port;
+    private String username;
+    private String password;
+    private String connectionString;
+
+    public static CassandraDatabaseAccountConnectionString fromConnectionString(@Nonnull final String connectionString) {
+        final String[] parameters = connectionString.split(";");
+        final CassandraDatabaseAccountConnectionString result = new CassandraDatabaseAccountConnectionString();
+        result.setContactPoint(extractValueFromParameters(parameters, "HostName"));
+        result.setPort(Optional.ofNullable(extractValueFromParameters(parameters, "Port")).map(Integer::valueOf).orElse(null));
+        result.setUsername(extractValueFromParameters(parameters, "Username"));
+        result.setPassword(extractValueFromParameters(parameters, "Password"));
+        result.setConnectionString(connectionString);
+        return result;
+    }
+
+    @Nullable
+    private static String extractValueFromParameters(@Nonnull final String[] parameters, final String key) {
+        final String parameter = Arrays.stream(parameters).filter(value -> StringUtils.containsIgnoreCase(value, key)).findFirst().orElse(null);
+        return StringUtils.isEmpty(parameter) ? null : StringUtils.substringAfterLast(parameter, "=");
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/DatabaseAccountConnectionStrings.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/DatabaseAccountConnectionStrings.java
@@ -7,15 +7,19 @@ package com.microsoft.azure.toolkit.lib.cosmos.model;
 
 import com.azure.resourcemanager.cosmos.models.DatabaseAccountConnectionString;
 import com.azure.resourcemanager.cosmos.models.DatabaseAccountListConnectionStringsResult;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @EqualsAndHashCode
 public class DatabaseAccountConnectionStrings {
     private String primaryConnectionString;

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/DatabaseAccountKeys.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/DatabaseAccountKeys.java
@@ -6,14 +6,18 @@
 package com.microsoft.azure.toolkit.lib.cosmos.model;
 
 import com.azure.resourcemanager.cosmos.models.DatabaseAccountListKeysResult;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 import javax.annotation.Nonnull;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @EqualsAndHashCode
 public class DatabaseAccountKeys {
     private String primaryMasterKey;

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/DatabaseAccountKind.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/DatabaseAccountKind.java
@@ -34,7 +34,7 @@ public class DatabaseAccountKind {
     public static DatabaseAccountKind fromString(String input) {
         return values().stream()
                 .filter(logLevel -> StringUtils.equalsIgnoreCase(input, logLevel.getValue()))
-                .findFirst().orElse(null);
+                .findFirst().orElseGet(() -> new DatabaseAccountKind(input));
     }
 
     public static DatabaseAccountKind fromAccount(@Nonnull CosmosDBAccount account) {

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/MongoDatabaseAccountConnectionString.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/MongoDatabaseAccountConnectionString.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.cosmos.model;
+
+import com.mongodb.ConnectionString;
+import lombok.Data;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+@Data
+public class MongoDatabaseAccountConnectionString {
+    private String host;
+    private Integer port;
+    private List<String> hosts;
+    private String username;
+    private char[] password;
+    private String connection;
+    private Boolean sslEnabled;
+
+    public static MongoDatabaseAccountConnectionString fromConnectionString(@Nonnull final String connectionString) {
+        final ConnectionString mongo = new ConnectionString(connectionString);
+        final MongoDatabaseAccountConnectionString result = new MongoDatabaseAccountConnectionString();
+        result.setHosts(mongo.getHosts());
+        result.setHost(CollectionUtils.isEmpty(mongo.getHosts()) ? null : StringUtils.substringBefore(mongo.getHosts().get(0), ":"));
+        result.setPort(CollectionUtils.isEmpty(mongo.getHosts()) ? null : Integer.valueOf(StringUtils.substringAfter(mongo.getHosts().get(0), ":")));
+        result.setUsername(mongo.getUsername());
+        result.setPassword(mongo.getPassword());
+        result.setSslEnabled(mongo.getSslEnabled());
+        result.setConnection(connectionString);
+        return result;
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/SqlDatabaseAccountConnectionString.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/SqlDatabaseAccountConnectionString.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.cosmos.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SqlDatabaseAccountConnectionString {
+    private String uri;
+    private String key;
+    private String connectionString;
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCosmosDBAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCosmosDBAccount.java
@@ -10,12 +10,12 @@ import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccount;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccountModule;
 import com.microsoft.azure.toolkit.lib.cosmos.model.DatabaseAccountConnectionStrings;
+import com.microsoft.azure.toolkit.lib.cosmos.model.MongoDatabaseAccountConnectionString;
 import com.mongodb.ConnectionString;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -39,37 +39,41 @@ public class MongoCosmosDBAccount extends CosmosDBAccount {
         this.mongoDatabaseModule = new MongoDatabaseModule(this);
     }
 
+    @Nullable
     public ConnectionString getPrimaryConnectionString() {
-        return Optional.ofNullable(listConnectionStrings())
-                .map(DatabaseAccountConnectionStrings::getPrimaryConnectionString).map(ConnectionString::new).orElse(null);
+        return Optional.ofNullable(listConnectionStrings().getPrimaryConnectionString()).map(ConnectionString::new).orElse(null);
     }
 
+    @Nonnull
+    public MongoDatabaseAccountConnectionString getMongoConnectionString() {
+        return Optional.ofNullable(listConnectionStrings().getPrimaryConnectionString())
+                .map(MongoDatabaseAccountConnectionString::fromConnectionString)
+                .orElseGet(MongoDatabaseAccountConnectionString::new);
+    }
+
+    @Nullable
     public List<String> getHosts() {
-        return Optional.ofNullable(getPrimaryConnectionString()).map(ConnectionString::getHosts).orElse(null);
+        return getMongoConnectionString().getHosts();
     }
 
+    @Nullable
     public String getContactPoint() {
-        final List<String> hosts = getHosts();
-        if (CollectionUtils.isEmpty(hosts)) {
-            return null;
-        }
-        return StringUtils.substringAfterLast(hosts.get(0), ":");
+        return getMongoConnectionString().getHost();
     }
 
+    @Nullable
     public Integer getPort() {
-        final List<String> hosts = getHosts();
-        if (CollectionUtils.isEmpty(hosts)) {
-            return null;
-        }
-        return Integer.valueOf(StringUtils.substringAfterLast(hosts.get(0), ":"));
+        return getMongoConnectionString().getPort();
     }
 
+    @Nullable
     public String getUserName() {
-        return getPrimaryConnectionString().getUsername();
+        return getMongoConnectionString().getUsername();
     }
 
-    public boolean isSslEnabled() {
-        return getPrimaryConnectionString().getSslEnabled();
+    @Nullable
+    public Boolean isSslEnabled() {
+        return getMongoConnectionString().getSslEnabled();
     }
 
     public MongoDatabaseModule mongoDatabases() {

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlCosmosDBAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlCosmosDBAccount.java
@@ -9,8 +9,10 @@ import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccount;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccountModule;
+import com.microsoft.azure.toolkit.lib.cosmos.model.SqlDatabaseAccountConnectionString;
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
@@ -40,5 +42,14 @@ public class SqlCosmosDBAccount extends CosmosDBAccount {
 
     public SqlDatabaseModule sqlDatabases() {
         return this.sqlDatabaseModule;
+    }
+
+    @Nonnull
+    public SqlDatabaseAccountConnectionString getSqlAccountConnectionString() {
+        return SqlDatabaseAccountConnectionString.builder()
+                .connectionString(listConnectionStrings().getPrimaryConnectionString())
+                .key(listKeys().getPrimaryMasterKey())
+                .uri(getDocumentEndpoint())
+                .build();
     }
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Add model for cosmos db connection string
- Use `updateAdditionalProperties` to list connection string

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
