### PR TITLE
Support creates mongo databases in cosmos library

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/CosmosDBAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/CosmosDBAccount.java
@@ -9,6 +9,8 @@ import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
+import com.microsoft.azure.toolkit.lib.common.model.Region;
+import com.microsoft.azure.toolkit.lib.cosmos.model.CosmosDBAccountConnectionString;
 import com.microsoft.azure.toolkit.lib.cosmos.model.DatabaseAccountConnectionStrings;
 import com.microsoft.azure.toolkit.lib.cosmos.model.DatabaseAccountKeys;
 import com.microsoft.azure.toolkit.lib.cosmos.model.DatabaseAccountKind;
@@ -65,6 +67,16 @@ public class CosmosDBAccount extends AbstractAzResource<CosmosDBAccount, CosmosS
     @Nullable
     public String getDocumentEndpoint() {
         return Optional.ofNullable(getRemote()).map(remote -> remote.documentEndpoint()).orElse(null);
+    }
+
+    @Nullable
+    public Region getRegion() {
+        return remoteOptional().map(remote -> Region.fromName(remote.regionName())).orElse(null);
+    }
+
+    @Nullable
+    public CosmosDBAccountConnectionString getCosmosDBAccountPrimaryConnectionString() {
+        return null;
     }
 
     @NotNull

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraCosmosDBAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraCosmosDBAccount.java
@@ -9,6 +9,7 @@ import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccount;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccountModule;
 import com.microsoft.azure.toolkit.lib.cosmos.model.CassandraDatabaseAccountConnectionString;
+import com.microsoft.azure.toolkit.lib.cosmos.model.CosmosDBAccountConnectionString;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
@@ -62,5 +63,11 @@ public class CassandraCosmosDBAccount extends CosmosDBAccount {
     @Nullable
     public String getContactPoint() {
         return getCassandraConnectionString().getContactPoint();
+    }
+
+    @Nonnull
+    @Override
+    public CosmosDBAccountConnectionString getCosmosDBAccountPrimaryConnectionString() {
+        return getCassandraConnectionString();
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/CassandraDatabaseAccountConnectionString.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/CassandraDatabaseAccountConnectionString.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 @Data
-public class CassandraDatabaseAccountConnectionString {
+public class CassandraDatabaseAccountConnectionString implements CosmosDBAccountConnectionString {
     private String contactPoint;
     private Integer port;
     private String username;
@@ -36,5 +36,10 @@ public class CassandraDatabaseAccountConnectionString {
     private static String extractValueFromParameters(@Nonnull final String[] parameters, final String key) {
         final String parameter = Arrays.stream(parameters).filter(value -> StringUtils.containsIgnoreCase(value, key)).findFirst().orElse(null);
         return StringUtils.isEmpty(parameter) ? null : StringUtils.substringAfter(parameter, "=");
+    }
+
+    @Override
+    public String getHost() {
+        return this.contactPoint;
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/CosmosDBAccountConnectionString.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/CosmosDBAccountConnectionString.java
@@ -1,0 +1,15 @@
+package com.microsoft.azure.toolkit.lib.cosmos.model;
+
+import org.jetbrains.annotations.Nullable;
+
+public interface CosmosDBAccountConnectionString {
+    @Nullable String getHost();
+
+    @Nullable Integer getPort();
+
+    @Nullable String getUsername();
+
+    @Nullable String getPassword();
+
+    @Nullable String getConnectionString();
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/DatabaseConfig.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/DatabaseConfig.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.cosmos.model;
+
+import lombok.Data;
+
+@Data
+public class DatabaseConfig {
+    private String name;
+    private Integer throughput;
+    private Integer maxThroughput;
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/MongoDatabaseAccountConnectionString.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/MongoDatabaseAccountConnectionString.java
@@ -14,13 +14,13 @@ import javax.annotation.Nonnull;
 import java.util.List;
 
 @Data
-public class MongoDatabaseAccountConnectionString {
+public class MongoDatabaseAccountConnectionString implements CosmosDBAccountConnectionString {
     private String host;
     private Integer port;
     private List<String> hosts;
     private String username;
     private char[] password;
-    private String connection;
+    private String connectionString;
     private Boolean sslEnabled;
 
     public static MongoDatabaseAccountConnectionString fromConnectionString(@Nonnull final String connectionString) {
@@ -32,7 +32,7 @@ public class MongoDatabaseAccountConnectionString {
         result.setUsername(mongo.getUsername());
         result.setPassword(mongo.getPassword());
         result.setSslEnabled(mongo.getSslEnabled());
-        result.setConnection(connectionString);
+        result.setConnectionString(connectionString);
         return result;
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/MongoDatabaseAccountConnectionString.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/MongoDatabaseAccountConnectionString.java
@@ -19,7 +19,7 @@ public class MongoDatabaseAccountConnectionString implements CosmosDBAccountConn
     private Integer port;
     private List<String> hosts;
     private String username;
-    private char[] password;
+    private String password;
     private String connectionString;
     private Boolean sslEnabled;
 
@@ -30,7 +30,7 @@ public class MongoDatabaseAccountConnectionString implements CosmosDBAccountConn
         result.setHost(CollectionUtils.isEmpty(mongo.getHosts()) ? null : StringUtils.substringBefore(mongo.getHosts().get(0), ":"));
         result.setPort(CollectionUtils.isEmpty(mongo.getHosts()) ? null : Integer.valueOf(StringUtils.substringAfter(mongo.getHosts().get(0), ":")));
         result.setUsername(mongo.getUsername());
-        result.setPassword(mongo.getPassword());
+        result.setPassword(String.valueOf(mongo.getPassword()));
         result.setSslEnabled(mongo.getSslEnabled());
         result.setConnectionString(connectionString);
         return result;

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/SqlDatabaseAccountConnectionString.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/SqlDatabaseAccountConnectionString.java
@@ -8,10 +8,41 @@ package com.microsoft.azure.toolkit.lib.cosmos.model;
 import lombok.Builder;
 import lombok.Data;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 @Data
 @Builder
-public class SqlDatabaseAccountConnectionString {
+public class SqlDatabaseAccountConnectionString implements CosmosDBAccountConnectionString {
     private String uri;
     private String key;
     private String connectionString;
+
+    @Override
+    public String getHost() {
+        try {
+            return new URL(uri).getHost();
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public Integer getPort() {
+        try {
+            return new URL(uri).getPort();
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
 }

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCosmosDBAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCosmosDBAccount.java
@@ -9,7 +9,7 @@ import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccount;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccountModule;
-import com.microsoft.azure.toolkit.lib.cosmos.model.DatabaseAccountConnectionStrings;
+import com.microsoft.azure.toolkit.lib.cosmos.model.CosmosDBAccountConnectionString;
 import com.microsoft.azure.toolkit.lib.cosmos.model.MongoDatabaseAccountConnectionString;
 import com.mongodb.ConnectionString;
 import org.jetbrains.annotations.NotNull;
@@ -78,6 +78,12 @@ public class MongoCosmosDBAccount extends CosmosDBAccount {
 
     public MongoDatabaseModule mongoDatabases() {
         return this.mongoDatabaseModule;
+    }
+
+    @Nonnull
+    @Override
+    public CosmosDBAccountConnectionString getCosmosDBAccountPrimaryConnectionString() {
+        return getMongoConnectionString();
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDatabaseDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDatabaseDraft.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.cosmos.mongo;
+
+import com.azure.core.util.Context;
+import com.azure.resourcemanager.cosmos.fluent.CosmosDBManagementClient;
+import com.azure.resourcemanager.cosmos.fluent.models.MongoDBDatabaseGetResultsInner;
+import com.azure.resourcemanager.cosmos.models.AutoscaleSettings;
+import com.azure.resourcemanager.cosmos.models.CreateUpdateOptions;
+import com.azure.resourcemanager.cosmos.models.MongoDBDatabaseCreateUpdateParameters;
+import com.azure.resourcemanager.cosmos.models.MongoDBDatabaseResource;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import com.microsoft.azure.toolkit.lib.cosmos.model.DatabaseConfig;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.ObjectUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class MongoDatabaseDraft extends MongoDatabase implements
+        AzResource.Draft<MongoDatabase, MongoDBDatabaseGetResultsInner> {
+
+    @Setter
+    @Getter
+    private DatabaseConfig config;
+
+    protected MongoDatabaseDraft(@NotNull String name, @NotNull String resourceGroupName, @NotNull MongoDatabaseModule module) {
+        super(name, resourceGroupName, module);
+    }
+
+    @Override
+    public void reset() {
+
+    }
+
+    @NotNull
+    @Override
+    public MongoDBDatabaseGetResultsInner createResourceInAzure() {
+        final CosmosDBManagementClient cosmosDBManagementClient = Objects.requireNonNull(getParent().getRemote()).manager().serviceClient();
+        final MongoDBDatabaseCreateUpdateParameters parameters = new MongoDBDatabaseCreateUpdateParameters()
+                .withLocation(Objects.requireNonNull(this.getParent().getRegion()).getName())
+                .withResource(new MongoDBDatabaseResource().withId(this.getName()));
+        final Integer throughput = ensureConfig().getThroughput();
+        final Integer maxThroughput = ensureConfig().getMaxThroughput();
+        assert ObjectUtils.anyNull(throughput, maxThroughput);
+        if (ObjectUtils.anyNotNull(throughput, maxThroughput)) {
+            final CreateUpdateOptions options = new CreateUpdateOptions();
+            if (Objects.nonNull(ensureConfig().getThroughput())) {
+                options.withThroughput(throughput);
+            } else {
+                options.withAutoscaleSettings(new AutoscaleSettings().withMaxThroughput(maxThroughput));
+            }
+            parameters.withOptions(options);
+        }
+        return cosmosDBManagementClient.getMongoDBResources().createUpdateMongoDBDatabase(this.getResourceGroupName(), this.getParent().getName(),
+                this.getName(), parameters, Context.NONE);
+    }
+
+    @NotNull
+    @Override
+    public MongoDBDatabaseGetResultsInner updateResourceInAzure(@NotNull MongoDBDatabaseGetResultsInner origin) {
+        throw new UnsupportedOperationException("not support");
+    }
+
+    @Override
+    public boolean isModified() {
+        return config != null && ObjectUtils.anyNotNull(config.getThroughput(), config.getMaxThroughput(), config.getName());
+    }
+
+    @Nullable
+    @Override
+    public MongoDatabase getOrigin() {
+        return null;
+    }
+
+    private DatabaseConfig ensureConfig() {
+        this.config = Optional.ofNullable(config).orElseGet(DatabaseConfig::new);
+        return this.config;
+    }
+
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDatabaseModule.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDatabaseModule.java
@@ -9,10 +9,12 @@ import com.azure.resourcemanager.cosmos.fluent.MongoDBResourcesClient;
 import com.azure.resourcemanager.cosmos.fluent.models.MongoDBDatabaseGetResultsInner;
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccount;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -32,7 +34,7 @@ public class MongoDatabaseModule extends AbstractAzResourceModule<MongoDatabase,
     @NotNull
     @Override
     protected MongoDatabase newResource(@NotNull String name, @Nullable String resourceGroupName) {
-        return new MongoDatabase(name, resourceGroupName, this);
+        return new MongoDatabase(name, Objects.requireNonNull(resourceGroupName), this);
     }
 
     @NotNull
@@ -48,6 +50,18 @@ public class MongoDatabaseModule extends AbstractAzResourceModule<MongoDatabase,
         return Optional.ofNullable(getClient()).map(client -> client.getMongoDBDatabase(parent.getResourceGroupName(), parent.getName(), name)).orElse(null);
     }
 
+    @NotNull
+    @Override
+    protected AzResource.Draft<MongoDatabase, MongoDBDatabaseGetResultsInner> newDraftForCreate(@NotNull String name, @Nullable String rgName) {
+        return new MongoDatabaseDraft(name, Objects.requireNonNull(rgName), this);
+    }
+
+    @NotNull
+    @Override
+    protected AzResource.Draft<MongoDatabase, MongoDBDatabaseGetResultsInner> newDraftForUpdate(@NotNull MongoDatabase mongoDatabase) {
+        throw new UnsupportedOperationException("not support");
+    }
+
     @Override
     protected void deleteResourceFromAzure(@NotNull String resourceId) {
         final ResourceId id = ResourceId.fromString(resourceId);
@@ -57,6 +71,6 @@ public class MongoDatabaseModule extends AbstractAzResourceModule<MongoDatabase,
     @Nullable
     @Override
     protected MongoDBResourcesClient getClient() {
-        return this.parent.getRemote().manager().serviceClient().getMongoDBResources();
+        return Objects.requireNonNull(this.parent.getRemote()).manager().serviceClient().getMongoDBResources();
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlCosmosDBAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlCosmosDBAccount.java
@@ -9,6 +9,7 @@ import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccount;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccountModule;
+import com.microsoft.azure.toolkit.lib.cosmos.model.CosmosDBAccountConnectionString;
 import com.microsoft.azure.toolkit.lib.cosmos.model.SqlDatabaseAccountConnectionString;
 import org.jetbrains.annotations.NotNull;
 
@@ -42,6 +43,12 @@ public class SqlCosmosDBAccount extends CosmosDBAccount {
 
     public SqlDatabaseModule sqlDatabases() {
         return this.sqlDatabaseModule;
+    }
+
+    @Nonnull
+    @Override
+    public CosmosDBAccountConnectionString getCosmosDBAccountPrimaryConnectionString() {
+        return getSqlAccountConnectionString();
     }
 
     @Nonnull


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Support create database of mongo cosmos database account
- Add unify interface for cosmos db account connection string

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
