### PR TITLE
fix miscellaneous bugs related to resource framework

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -118,7 +118,7 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
     public void invalidateCache() {
         log.debug("[{}]:invalidateCache()", this.name);
         synchronized (this.syncTimeRef) {
-            this.remoteRef.set(null);
+            // this.remoteRef.set(null); will make a newly created resource behave as a "draft for creating"(since isDraftForCreating() will return true)
             this.syncTimeRef.set(-1);
         }
         log.debug("[{}:{}]:invalidateCache->subModules.invalidateCache()", this.module.getName(), this.getName());

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -134,7 +134,7 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
             return null;
         }
         synchronized (this.syncTimeRef) {
-            if (this.syncTimeRef.get() == -1 || System.currentTimeMillis() - this.syncTimeRef.get() > AzResource.CACHE_LIFETIME) { // double check
+            if (this.syncTimeRef.get() != 0 && (this.syncTimeRef.get() == -1 || System.currentTimeMillis() - this.syncTimeRef.get() > AzResource.CACHE_LIFETIME)) {
                 this.syncTimeRef.set(0);
                 log.debug("[{}:{}]:getRemote->reloadRemote()", this.module.getName(), this.getName());
                 try {

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -295,9 +295,6 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
     protected void doModify(@Nonnull Runnable body, @Nullable String status) {
         synchronized (this.syncTimeRef) {
             try {
-                if (this.syncTimeRef.get() == 0) { // cancel if updating.
-                    return;
-                }
                 this.syncTimeRef.set(0);
                 this.setStatus(Optional.ofNullable(status).orElse(Status.PENDING));
                 log.debug("[{}:{}]:doModify->body.run()", this.module.getName(), this.getName());

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
@@ -105,7 +105,7 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
         }
         synchronized (this.syncTimeRef) {
             try {
-                if (this.syncTimeRef.get() == -1 || System.currentTimeMillis() - this.syncTimeRef.get() > AzResource.CACHE_LIFETIME) { // double check
+                if (this.syncTimeRef.get() != 0 && (this.syncTimeRef.get() == -1 || System.currentTimeMillis() - this.syncTimeRef.get() > AzResource.CACHE_LIFETIME)) {
                     this.syncTimeRef.set(0);
                     log.debug("[{}]:list->this.reload()", this.name);
                     this.reloadResources();


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
see commits.


Does this close any currently open issues?
------------------------------------------
[AB#1979186](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1979186): [Test]Unreasonable behavior when deleting cosmosDB
[AB#1978814](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1978814): Icon in Azure explorer will not update (change to refreshing) when delete resource group
[AB#1978430](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1978430): [Test]Status in Azure Explorer does not change when some basic operations are performed on the VM

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
