### PR TITLE
Skip copy resource when source file has already located in target

### DIFF
--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/PackageMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/PackageMojo.java
@@ -39,6 +39,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -54,6 +55,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.Set;
@@ -344,10 +346,10 @@ public class PackageMojo extends AbstractFunctionMojo {
                 .map(Artifact::getArtifactId).findFirst().orElse(AZURE_FUNCTIONS_JAVA_LIBRARY);
         for (final Artifact artifact : artifacts) {
             if (!StringUtils.equalsIgnoreCase(artifact.getArtifactId(), libraryToExclude)) {
-                FileUtils.copyFileToDirectory(artifact.getFile(), libFolder);
+                copyFileToDirectory(artifact.getFile(), libFolder);
             }
         }
-        FileUtils.copyFileToDirectory(getArtifactFile(), new File(stagingDirectory));
+        copyFileToDirectory(getArtifactFile(), new File(stagingDirectory));
         Log.info(COPY_SUCCESS);
     }
 
@@ -450,5 +452,11 @@ public class PackageMojo extends AbstractFunctionMojo {
                 .distinct()
                 .collect(Collectors.toList());
         getTelemetryProxy().addDefaultProperty(TRIGGER_TYPE, StringUtils.join(bindingTypeSet, ","));
+    }
+
+    private static void copyFileToDirectory(@Nonnull final File srcFile, @Nonnull final File destFile) throws IOException {
+        if (!Objects.equals(srcFile.getParentFile(), destFile)) {
+            FileUtils.copyFileToDirectory(srcFile, destFile);
+        }
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/core/AzureFunctionPackager.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/core/AzureFunctionPackager.java
@@ -25,6 +25,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -36,11 +37,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+// todo: investigate whether we need to migrate to unified function packager in java tooling
 public class AzureFunctionPackager extends AzureFunctionPackagerBase {
     private static final String TRIGGER_TYPE = "triggerType";
     protected static final String LINE_FEED = "\r\n";
@@ -136,7 +139,6 @@ public class AzureFunctionPackager extends AzureFunctionPackagerBase {
             final List<FunctionMethod> functions = project.findAnnotatedMethods();
             AzureMessager.getMessager().info(functions.size() + FOUND_FUNCTIONS);
             return functions;
-
         } catch (Exception ex) {
             // Log and warn
             AzureMessager.getMessager().error(ex, "Encounter error when parsing Azure Function annotations.");
@@ -240,9 +242,9 @@ public class AzureFunctionPackager extends AzureFunctionPackagerBase {
             FileUtils.cleanDirectory(libFolder);
         }
         for (final File file : project.getDependencies()) {
-            FileUtils.copyFileToDirectory(file, libFolder);
+            copyFileToDirectory(file, libFolder);
         }
-        FileUtils.copyFileToDirectory(project.getArtifactFile(), new File(stagingDirectory));
+        copyFileToDirectory(project.getArtifactFile(), new File(stagingDirectory));
         AzureMessager.getMessager().info(COPY_SUCCESS);
     }
 
@@ -296,6 +298,12 @@ public class AzureFunctionPackager extends AzureFunctionPackagerBase {
             return JsonUtils.fromJson(jsonRaw, new TypeReference<HashMap<String, Object>>(){});
         } catch (IOException e) {
             return null;
+        }
+    }
+
+    private static void copyFileToDirectory(@Nonnull final File srcFile, @Nonnull final File destFile) throws IOException {
+        if (!Objects.equals(srcFile.getParentFile(), destFile)) {
+            FileUtils.copyFileToDirectory(srcFile, destFile);
         }
     }
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Skip copy resource when source file has already located in target, fixes #2097


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
