### PR TITLE
when recover operations, exception operation should have higher priority

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/messager/AzureMessage.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/messager/AzureMessage.java
@@ -160,8 +160,16 @@ public class AzureMessage implements IAzureMessage {
             .orElse(new ArrayList<>());
         final Operation current = exceptionOperations.isEmpty() ? OperationThreadContext.current().currentOperation() : exceptionOperations.get(0);
         final List<Operation> contextOperations = getAncestorOperationsUtilAction(current);
+        final List<Operation> contextOperationWithoutException = contextOperations.stream().filter(t -> {
+            for (Operation operation: exceptionOperations) {
+                if (t.getId().equals(operation.getId())) {
+                    return false;
+                }
+            }
+            return true;
+        }).collect(Collectors.toList());
         final Set<Object> seen = ConcurrentHashMap.newKeySet();
-        final List<Operation> operations = Streams.concat(contextOperations.stream(), exceptionOperations.stream())
+        final List<Operation> operations = Streams.concat(contextOperationWithoutException.stream(), exceptionOperations.stream())
             .filter(t -> seen.add(t.getId()))
             .filter(o -> Objects.nonNull(o.getDescription()))
             .collect(Collectors.toList());


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
When two operations are same, may get wrong operation list.
To avoid this, exception operations should have higher priority.


Does this close any currently open issues?
------------------------------------------


Any relevant logs, screenshots, error output, etc.?
-------------------------------------


Any other comments?
-------------------


Has this been tested?
---------------------------
- [ ] Tested
