### PR TITLE
fix typo so that admin user name of VM creation dialog would be set to machine user name in default

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourceGroupModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/ResourceGroupModule.java
@@ -7,14 +7,19 @@ package com.microsoft.azure.toolkit.lib.resource;
 
 import com.azure.resourcemanager.resources.ResourceManager;
 import com.azure.resourcemanager.resources.models.ResourceGroups;
+import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.account.IAccount;
+import com.microsoft.azure.toolkit.lib.account.IAzureAccount;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class ResourceGroupModule extends AbstractAzResourceModule<ResourceGroup, ResourcesServiceSubscription, com.azure.resourcemanager.resources.models.ResourceGroup> {
 
@@ -22,6 +27,14 @@ public class ResourceGroupModule extends AbstractAzResourceModule<ResourceGroup,
 
     public ResourceGroupModule(@Nonnull ResourcesServiceSubscription parent) {
         super(NAME, parent);
+    }
+
+    @Nonnull
+    @Override
+    public List<ResourceGroup> list() {
+        final IAccount account = Azure.az(IAzureAccount.class).account();
+        // FIXME: @wamgmi, improve this hotfix of #1980254
+        return super.list().stream().filter(rg -> account.getSelectedSubscriptions().contains(rg.getSubscription())).collect(Collectors.toList());
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/virtualmachine/VirtualMachineDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/src/main/java/com/microsoft/azure/toolkit/lib/compute/virtualmachine/VirtualMachineDraft.java
@@ -137,7 +137,7 @@ public class VirtualMachineDraft extends VirtualMachine implements AzResource.Dr
         networkDraft.withDefaultConfig();
         securityGroupDraft.setSecurityRules(Collections.singletonList(SecurityRule.SSH_RULE));
 
-        this.setAdminUserName(System.getProperty(System.getProperty("user.name")));
+        this.setAdminUserName(System.getProperty("user.name"));
         this.setNetwork(networkDraft);
         this.setIpAddress(ipAddressDraft);
         this.setSecurityGroup(securityGroupDraft);


### PR DESCRIPTION
#1983031: [Test] Expect to get machine user name in VM creation dialog

What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
[AB#1983031](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1983031): [Test] Expect to get machine user name in VM creation dialog


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
