### PR TITLE
resources are wrapped as GenericResource, whose `isDraftForCreating` returns false always, making the creating resource deleted from cache when refreshing children.

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/GenericResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/resource/GenericResource.java
@@ -82,6 +82,23 @@ public class GenericResource extends AbstractAzResource<GenericResource, Resourc
 
     @Nonnull
     @Override
+    public String getStatus() {
+        final AbstractAzResource<?, ?, ?> concrete = this.toConcreteResource();
+        return concrete instanceof GenericResource ? Status.UNKNOWN : concrete.getStatus();
+    }
+
+    @Override
+    public boolean isDraftForCreating() {
+        // don't use `toConcreteResource` because it will cause recursive calls.
+        // toConcreteResource -> Azure.getOrInitById -> AzureAppService.getOrInitById -> GenericResource.getKind -> AbstractAzResource.getRemote -> isDraftForCreating
+        if (Objects.nonNull(this.concrete) && !(this.concrete instanceof GenericResource)) {
+            return this.concrete.isDraftForCreating();
+        }
+        return super.isDraftForCreating();
+    }
+
+    @Nonnull
+    @Override
     public String getFullResourceType() {
         return this.resourceId.fullResourceType();
     }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
[AB#1919451](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1919451): [Test] After creating services successfully, Resource Groups won't auto refresh to show it


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
