### PR TITLE
Upgrade snakeyaml to 1.31 to fix cve-2022-25857

### DIFF
--- a/azure-toolkit-libs/pom.xml
+++ b/azure-toolkit-libs/pom.xml
@@ -103,7 +103,7 @@
         <lombok.version>1.18.24</lombok.version>
         <mockito.version>3.10.0</mockito.version>
         <rx.version>1.3.8</rx.version>
-        <snakeyaml.version>1.30</snakeyaml.version>
+        <snakeyaml.version>1.31</snakeyaml.version>
         <slf4j-api.version>1.7.36</slf4j-api.version>
         <spring-test.version>5.3.20</spring-test.version>
         <google.jsr305.version>3.0.2</google.jsr305.version>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Upgrade snakeyaml to 1.31 to fix cve-2022-25857


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
