### PR TITLE
Miller/bugfixes 202209

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/cli/AzureCliAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/cli/AzureCliAccount.java
@@ -83,7 +83,11 @@ public class AzureCliAccount extends Account {
 
     @Override
     public boolean checkAvailable() {
-        return this.getManagementToken().isPresent();
+        try {
+            return this.getManagementToken().isPresent();
+        } catch (Throwable e) {
+            return false;
+        }
     }
 
     @AllArgsConstructor

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
@@ -25,6 +25,7 @@ import com.microsoft.azure.toolkit.lib.common.utils.Debouncer;
 import com.microsoft.azure.toolkit.lib.common.utils.TailingDebouncer;
 import com.microsoft.azure.toolkit.lib.resource.GenericResource;
 import com.microsoft.azure.toolkit.lib.resource.GenericResourceModule;
+import com.microsoft.azure.toolkit.lib.resource.ResourceDeployment;
 import com.microsoft.azure.toolkit.lib.resource.ResourceGroup;
 import com.microsoft.azure.toolkit.lib.resource.ResourceGroupModule;
 import lombok.EqualsAndHashCode;
@@ -113,7 +114,7 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
         if (System.currentTimeMillis() - this.syncTimeRef.get() > AzResource.CACHE_LIFETIME) { // 0, -1 or too old.
             try {
                 this.lock.lock();
-                if (this.syncTimeRef.get() != 0 && System.currentTimeMillis() - this.syncTimeRef.get() > AzResource.CACHE_LIFETIME) {// -1 or too old.
+                if (this.syncTimeRef.get() != 0 && System.currentTimeMillis() - this.syncTimeRef.get() > AzResource.CACHE_LIFETIME) { // -1 or too old.
                     log.debug("[{}]:list->this.reload()", this.name);
                     this.reloadResources();
                 }
@@ -327,7 +328,8 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
             this.addResourceToLocal(resource.getId(), resource);
             final ResourceId id = ResourceId.fromString(resource.getId());
             final ResourceGroup resourceGroup = resource.getResourceGroup();
-            if (Objects.isNull(id.parent()) && Objects.nonNull(resourceGroup) && !(resource instanceof ResourceGroup)) {
+            if (Objects.isNull(id.parent()) && Objects.nonNull(resourceGroup) &&
+                !(resource instanceof ResourceGroup) && !(resource instanceof ResourceDeployment)) {
                 final GenericResourceModule genericResourceModule = resourceGroup.genericResources();
                 final GenericResource genericResource = genericResourceModule.newResource(resource);
                 //noinspection unchecked,rawtypes

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
@@ -272,6 +272,14 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
     }
 
     @Nonnull
+    public T getOrTemp(@Nonnull String name, @Nullable String rgName) {
+        final String resourceGroup = normalizeResourceGroupName(name, rgName);
+        log.debug("[{}]:getOrTemp({}, {})", this.name, name, rgName);
+        final String id = this.toResourceId(name, resourceGroup);
+        return this.resources.getOrDefault(id, Optional.empty()).orElseGet(() -> this.newResource(name, resourceGroup));
+    }
+
+    @Nonnull
     public T getOrInit(@Nonnull String name, @Nullable String rgName) {
         final String resourceGroup = normalizeResourceGroupName(name, rgName);
         log.debug("[{}]:getOrDraft({}, {})", this.name, name, rgName);

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzService.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzService.java
@@ -14,7 +14,6 @@ import com.microsoft.azure.toolkit.lib.common.event.AzureEventBus;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import com.microsoft.azure.toolkit.lib.common.operation.OperationContext;
 import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -40,7 +39,7 @@ public abstract class AbstractAzService<T extends AbstractAzServiceSubscription<
         return this.get(id.subscriptionId(), id.resourceGroupName());
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public List<T> list() {
         return super.list().stream().filter(s -> s.getSubscription().isSelected()).collect(Collectors.toList());

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzService.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzService.java
@@ -110,7 +110,7 @@ public abstract class AbstractAzService<T extends AbstractAzServiceSubscription<
         for (Pair<String, String> resourceTypeName : resourceTypeNames) {
             resource = Optional.ofNullable(resource)
                 .map(r -> r.getSubModule(resourceTypeName.getLeft()))
-                .map(m -> m.getOrDraft(resourceTypeName.getRight(), resourceGroup)).orElse(null);
+                .map(m -> m.getOrTemp(resourceTypeName.getRight(), resourceGroup)).orElse(null);
         }
         return (E) resource;
     }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzService.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzService.java
@@ -14,12 +14,15 @@ import com.microsoft.azure.toolkit.lib.common.event.AzureEventBus;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import com.microsoft.azure.toolkit.lib.common.operation.OperationContext;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public abstract class AbstractAzService<T extends AbstractAzServiceSubscription<T, R>, R> extends AbstractAzResourceModule<T, AzResource.None, R>
@@ -35,6 +38,12 @@ public abstract class AbstractAzService<T extends AbstractAzServiceSubscription<
     public T get(@Nonnull String resourceId) {
         final ResourceId id = ResourceId.fromString(resourceId);
         return this.get(id.subscriptionId(), id.resourceGroupName());
+    }
+
+    @NotNull
+    @Override
+    public List<T> list() {
+        return super.list().stream().filter(s -> s.getSubscription().isSelected()).collect(Collectors.toList());
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/utils/CommandUtils.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/utils/CommandUtils.java
@@ -88,10 +88,11 @@ public class CommandUtils {
                 newEnv.putAll(env);
             }
             executor.execute(commandLine, newEnv);
-            if (!mergeErrorStream && err.size() > 0) {
-                log.warn(StringUtils.trim(err.toString()));
+            final String result = StringUtils.trimToEmpty(out.toString());
+            if (!mergeErrorStream && err.size() > 0 && StringUtils.isEmpty(result)) {
+                throw new IOException(StringUtils.trim(err.toString()));
             }
-            return out.toString();
+            return result;
         } finally {
             out.close();
             err.close();

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/CosmosDBAccountModule.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/CosmosDBAccountModule.java
@@ -46,7 +46,8 @@ public class CosmosDBAccountModule extends AbstractAzResourceModule<CosmosDBAcco
     @Nonnull
     @Override
     protected CosmosDBAccount newResource(@Nonnull String name, @Nullable String resourceGroupName) {
-        final com.azure.resourcemanager.cosmos.models.CosmosDBAccount account = Objects.requireNonNull(getClient()).getByResourceGroup(resourceGroupName, name);
+        final com.azure.resourcemanager.cosmos.models.CosmosDBAccount account = Optional.ofNullable(getClient())
+            .map(c -> c.getByResourceGroup(resourceGroupName, name)).orElse(null);
         return account == null ? new CosmosDBAccount(name, Objects.requireNonNull(resourceGroupName), this) : newResource(account);
     }
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/ConfigMojo.java
@@ -220,7 +220,7 @@ public class ConfigMojo extends AbstractWebAppMojo {
         final String defaultName = getProject().getArtifactId() + "-" + System.currentTimeMillis();
         final String resourceGroup = defaultName + "-rg";
         final String defaultSchemaVersion = "v2";
-        final Region defaultRegion = WebAppConfiguration.DEFAULT_REGION;
+        final Region defaultRegion = WebAppConfiguration.getDefaultRegion();
 
         return builder.appName(defaultName)
                 .subscriptionId(subscriptionId)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
[AB#1942813](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1942813): [Test] New deployments are created duplicated under Group and Deployment nodes
[AB#1954362](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1954362): [Test] Show a warning about 'az login' when config a spring app without defining auth type

[AB#1927420](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1927420): [Test] The default region isn't in Azure China Cloud while running config command with Azure China account
[AB#1940560](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1940560): [Test] After expand the group in Favorite/Resource Groups, it auto expand nodes under Azure
[AB#1980254](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1980254): [Test]When any other sub is selected, the resource group of "Java Tooling Tests with TTL = 7 Days" is preserved after loading
[AB#1982636](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1982636): [Test] Fail to load Favorites node with a deleted cosmosDB database

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
