### PR TITLE
[Task #1998146] Support remote debugging for Azure Functions

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/AppServiceAppBase.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/AppServiceAppBase.java
@@ -7,6 +7,8 @@ package com.microsoft.azure.toolkit.lib.appservice;
 
 import com.azure.resourcemanager.appservice.models.CsmPublishingProfileOptions;
 import com.azure.resourcemanager.appservice.models.DeployOptions;
+import com.azure.resourcemanager.appservice.models.HostType;
+import com.azure.resourcemanager.appservice.models.HostnameSslState;
 import com.azure.resourcemanager.appservice.models.PublishingProfileFormat;
 import com.azure.resourcemanager.appservice.models.SupportsOneDeploy;
 import com.azure.resourcemanager.appservice.models.WebAppBase;
@@ -28,6 +30,9 @@ import com.microsoft.azure.toolkit.lib.appservice.plan.AppServicePlan;
 import com.microsoft.azure.toolkit.lib.appservice.plan.AppServicePlanModule;
 import com.microsoft.azure.toolkit.lib.appservice.utils.AppServiceUtils;
 import com.microsoft.azure.toolkit.lib.appservice.utils.Utils;
+import com.microsoft.azure.toolkit.lib.appservice.webapp.AzureWebApp;
+import com.microsoft.azure.toolkit.lib.auth.AuthType;
+import com.microsoft.azure.toolkit.lib.auth.AzureAccount;
 import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
@@ -124,6 +129,16 @@ public abstract class AppServiceAppBase<
     @Nullable
     public String getHostName() {
         return this.remoteOptional().map(WebSiteBase::defaultHostname).orElse(null);
+    }
+
+    @Nullable
+    public String getKuduHostName() {
+        return this.remoteOptional()
+                .map(siteBase -> siteBase.hostnameSslStates().values().stream()
+                        .filter(sslState -> sslState.hostType() == HostType.REPOSITORY)
+                        .map(HostnameSslState::name)
+                        .findFirst().orElse(null))
+                .orElse(null);
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/FunctionAppDeploymentSlot.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/FunctionAppDeploymentSlot.java
@@ -8,11 +8,14 @@ package com.microsoft.azure.toolkit.lib.appservice.function;
 import com.azure.resourcemanager.appservice.fluent.models.HostKeysInner;
 import com.azure.resourcemanager.appservice.models.FunctionDeploymentSlot;
 import com.azure.resourcemanager.appservice.models.FunctionDeploymentSlotBasic;
+import com.azure.resourcemanager.appservice.models.PlatformArchitecture;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class FunctionAppDeploymentSlot extends FunctionAppBase<FunctionAppDeploymentSlot, FunctionApp, FunctionDeploymentSlot> {
 
@@ -41,5 +44,26 @@ public class FunctionAppDeploymentSlot extends FunctionAppBase<FunctionAppDeploy
     public String getMasterKey() {
         final String name = String.format("%s/slots/%s", getParent().getName(), this.getName());
         return getFullRemote().manager().serviceClient().getWebApps().listHostKeysAsync(this.getResourceGroupName(), name).map(HostKeysInner::masterKey).block();
+    }
+
+    @Override
+    public void enableRemoteDebug() {
+        final Map<String, String> appSettings = this.getAppSettings();
+        getFullRemote().update()
+                .withWebSocketsEnabled(true)
+                .withPlatformArchitecture(PlatformArchitecture.X64)
+                .withAppSetting(HTTP_PLATFORM_DEBUG_PORT, appSettings.getOrDefault(HTTP_PLATFORM_DEBUG_PORT, DEFAULT_REMOTE_DEBUG_PORT))
+                .withAppSetting(JAVA_OPTS, getJavaOptsWithRemoteDebugEnabled(appSettings)).apply();
+    }
+
+    @Override
+    public void disableRemoteDebug() {
+        final Map<String, String> appSettings = this.getAppSettings();
+        final String javaOpts = this.getJavaOptsWithRemoteDebugDisabled(appSettings);
+        if (StringUtils.isEmpty(javaOpts)) {
+            getFullRemote().update().withoutAppSetting(HTTP_PLATFORM_DEBUG_PORT).withoutAppSetting(JAVA_OPTS).apply();
+        } else {
+            getFullRemote().update().withoutAppSetting(HTTP_PLATFORM_DEBUG_PORT).withAppSetting(JAVA_OPTS, javaOpts).apply();
+        }
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudAppInstance.java
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudAppInstance.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Objects;
 
 public class SpringCloudAppInstance extends AbstractAzResource<SpringCloudAppInstance, SpringCloudDeployment, DeploymentInstance> {
-    private static final String REMOTE_URL_TEMPLATE = "https://%s/api/remoteDebugging/apps/%s/deployments/%s/instances/%s";
+    private static final String REMOTE_URL_TEMPLATE = "https://%s/api/remoteDebugging/apps/%s/deployments/%s/instances/%s?port=%s";
 
     protected SpringCloudAppInstance(@NotNull String name, @NotNull SpringCloudAppInstanceModule module) {
         super(name, module);
@@ -41,9 +41,9 @@ public class SpringCloudAppInstance extends AbstractAzResource<SpringCloudAppIns
         return Status.UNKNOWN;
     }
 
-    public String getRemoteDebuggingUrl () {
+    public String getRemoteDebuggingUrl() {
         SpringCloudApp app = this.getParent().getParent();
-        return String.format(REMOTE_URL_TEMPLATE, app.getParent().getFqdn(), app.getName(), this.getParent().getName(), this.getName());
+        return String.format(REMOTE_URL_TEMPLATE, app.getParent().getFqdn(), app.getName(), this.getParent().getName(), this.getName(), this.getParent().getRemoteDebuggingPort());
     }
 
 }

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudDeployment.java
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/src/main/java/com/microsoft/azure/toolkit/lib/springcloud/SpringCloudDeployment.java
@@ -234,4 +234,11 @@ public class SpringCloudDeployment extends AbstractAzResource<SpringCloudDeploym
     public boolean isRemoteDebuggingEnabled() {
         return this.remoteDebuggingEnabled;
     }
+
+    public int getRemoteDebuggingPort() {
+        AppPlatformManager manager = this.getParent().getParent().getRemote().manager();
+        final String clusterName = this.getParent().getParent().getName();
+        final String appName = this.getParent().getName();
+        return manager.serviceClient().getDeployments().getRemoteDebuggingConfig(this.getResourceGroupName(), clusterName, appName, getName()).port();
+    }
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Support remote debugging for Azure Functions
    * Enable remote debug
         - Set `use32BitWorkerProcess` to false
         - Set `webSocketsEnabled` to true
         - Update related application settings
             * Set `JAVA_OPTS` to `-Djava.net.preferIPv4Stack=true -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=127.0.0.1:8898`
             * Set `HTTP_PLATFORM_DEBUG_PORT` to 8898
    * Disable remote debug
        - Update related application settings
            * Remove `HTTP_PLATFORM_DEBUG_PORT`
            * Remove java debug args from `JAVA_OPTS`

For disable remote debug, I just removed the debug related app settings as we did not know `use32BitWorkerProcess` and `webSocketsEnabled` is enabled by us or users

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
