### PR TITLE
Upgrade jackson-databind to 2.13.4.2 to resolve cve-2022-42003/cve-2022-42004

### DIFF
--- a/azure-toolkit-libs/pom.xml
+++ b/azure-toolkit-libs/pom.xml
@@ -97,7 +97,8 @@
         <dom4j.version>2.1.3</dom4j.version>
         <guava.version>31.1-jre</guava.version>
         <httpclient.version>4.5.13</httpclient.version>
-        <jackson.version>2.13.3</jackson.version>
+        <jackson.version>2.13.4</jackson.version>
+        <jackson-databind.version>2.13.4.2</jackson-databind.version>
         <jansi.version>2.4.0</jansi.version>
         <annotations.version>23.0.0</annotations.version>
         <json-schema-validator.version>2.2.14</json-schema-validator.version>
@@ -357,7 +358,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson-databind.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
Upgrade jackson-databind to 2.13.4.2 to resolve cve-2022-42003/cve-2022-42004

What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
