### PR TITLE
[Task #2000951, #2000953] Add support for data management for cosmos db

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/AzureConfiguration.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/AzureConfiguration.java
@@ -9,6 +9,9 @@ import com.microsoft.azure.toolkit.lib.common.proxy.ProxyInfo;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @Setter
 public class AzureConfiguration {
@@ -27,6 +30,8 @@ public class AzureConfiguration {
     private int httpProxyPort;
     private String proxyUsername;
     private String proxyPassword;
+    private int cosmosBatchSize = 50;
+    private List<String> documentsLabelFields = new ArrayList<>();
 
     public void setProxyInfo(ProxyInfo proxy) {
         this.setProxySource(proxy.getSource());

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/AzureConfiguration.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/AzureConfiguration.java
@@ -10,11 +10,14 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Getter
 @Setter
 public class AzureConfiguration {
+    public static final List<String> DEFAULT_DOCUMENT_LABEL_FIELDS = Arrays.asList("name", "Name", "NAME", "ID", "UUID", "Id", "id", "uuid");
+
     private String logLevel;
     private String userAgent;
     private String cloud;
@@ -31,7 +34,7 @@ public class AzureConfiguration {
     private String proxyUsername;
     private String proxyPassword;
     private int cosmosBatchSize = 50;
-    private List<String> documentsLabelFields = new ArrayList<>();
+    private List<String> documentsLabelFields = new ArrayList<>(DEFAULT_DOCUMENT_LABEL_FIELDS);
 
     public void setProxyInfo(ProxyInfo proxy) {
         this.setProxySource(proxy.getSource());

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/pom.xml
@@ -35,6 +35,14 @@
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-cosmos</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.datastax.oss</groupId>
+            <artifactId>java-driver-core</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/ICosmosDocument.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/ICosmosDocument.java
@@ -22,9 +22,9 @@ public interface ICosmosDocument extends AzResource {
     void updateDocument(ObjectNode document);
 
     default String getDocumentDisplayName() {
-        final List<String> documentsLabelFields = Azure.az().config().getDocumentsLabelFields();
+        final List<String> labels = Azure.az().config().getDocumentsLabelFields();
         final ObjectNode document = getDocument();
-        for (final String label : documentsLabelFields) {
+        for (final String label : labels) {
             if (document != null && document.has(label)) {
                 return document.get(label).asText();
             }

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/ICosmosDocument.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/ICosmosDocument.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+package com.microsoft.azure.toolkit.lib.cosmos;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
+
+public interface ICosmosDocument extends AzResource {
+    @Nullable
+    ObjectNode getDocument();
+
+    @Nullable
+    Object getDocumentId();
+
+    void updateDocument(ObjectNode document);
+
+    default String getDocumentDisplayName() {
+        final List<String> documentsLabelFields = Azure.az().config().getDocumentsLabelFields();
+        final ObjectNode document = getDocument();
+        for (final String label : documentsLabelFields) {
+            if (document != null && document.has(label)) {
+                return document.get(label).asText();
+            }
+        }
+        return Optional.ofNullable(getDocumentId()).map(Object::toString).orElse("Unknown");
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/ICosmosDocumentModule.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/ICosmosDocumentModule.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+package com.microsoft.azure.toolkit.lib.cosmos;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+public interface ICosmosDocumentModule<T extends ICosmosDocument> extends AzResource {
+    T importDocument(@Nonnull final ObjectNode node);
+
+    List<T> listDocuments();
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/ICosmosDocumentModule.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/ICosmosDocumentModule.java
@@ -14,4 +14,6 @@ public interface ICosmosDocumentModule<T extends ICosmosDocument> extends AzReso
     T importDocument(@Nonnull final ObjectNode node);
 
     List<T> listDocuments();
+
+    long getDocumentCount();
 }

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraKeyspace.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraKeyspace.java
@@ -9,6 +9,7 @@ import com.azure.resourcemanager.cosmos.fluent.models.CassandraKeyspaceGetResult
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
+import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccount;
 import com.microsoft.azure.toolkit.lib.cosmos.ICosmosCollection;
 import com.microsoft.azure.toolkit.lib.cosmos.ICosmosDatabase;
@@ -41,6 +42,10 @@ public class CassandraKeyspace extends AbstractAzResource<CassandraKeyspace, Cos
     @Override
     public List<AbstractAzResourceModule<?, ?, ?>> getSubModules() {
         return Collections.singletonList(containerModule);
+    }
+
+    public Region getRegion() {
+        return getParent().getRegion();
     }
 
     public CassandraTableModule tables() {

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraKeyspaceDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraKeyspaceDraft.java
@@ -8,10 +8,8 @@ package com.microsoft.azure.toolkit.lib.cosmos.cassandra;
 import com.azure.core.util.Context;
 import com.azure.resourcemanager.cosmos.fluent.CosmosDBManagementClient;
 import com.azure.resourcemanager.cosmos.fluent.models.CassandraKeyspaceGetResultsInner;
-import com.azure.resourcemanager.cosmos.models.AutoscaleSettings;
 import com.azure.resourcemanager.cosmos.models.CassandraKeyspaceCreateUpdateParameters;
 import com.azure.resourcemanager.cosmos.models.CassandraKeyspaceResource;
-import com.azure.resourcemanager.cosmos.models.CreateUpdateOptions;
 import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.cosmos.ICosmosDatabaseDraft;
@@ -48,18 +46,7 @@ public class CassandraKeyspaceDraft extends CassandraKeyspace implements
         final CassandraKeyspaceCreateUpdateParameters parameters = new CassandraKeyspaceCreateUpdateParameters()
                 .withLocation(Objects.requireNonNull(this.getParent().getRegion()).getName())
                 .withResource(new CassandraKeyspaceResource().withId(this.getName()));
-        final Integer throughput = ensureConfig().getThroughput();
-        final Integer maxThroughput = ensureConfig().getMaxThroughput();
-        assert ObjectUtils.anyNull(throughput, maxThroughput);
-        if (ObjectUtils.anyNotNull(throughput, maxThroughput)) {
-            final CreateUpdateOptions options = new CreateUpdateOptions();
-            if (Objects.nonNull(ensureConfig().getThroughput())) {
-                options.withThroughput(throughput);
-            } else {
-                options.withAutoscaleSettings(new AutoscaleSettings().withMaxThroughput(maxThroughput));
-            }
-            parameters.withOptions(options);
-        }
+        parameters.withOptions(ensureConfig().toCreateUpdateOptions());
         AzureMessager.getMessager().info(AzureString.format("Start creating Cassandra keyspace({0})...", this.getName()));
         final CassandraKeyspaceGetResultsInner result = cosmosDBManagementClient.getCassandraResources().createUpdateCassandraKeyspace(this.getResourceGroupName(), this.getParent().getName(),
                 this.getName(), parameters, Context.NONE);

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraTableDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraTableDraft.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import com.microsoft.azure.toolkit.lib.common.utils.Utils;
 import com.microsoft.azure.toolkit.lib.cosmos.model.CassandraDatabaseAccountConnectionString;
 import com.microsoft.azure.toolkit.lib.cosmos.model.ThroughputConfig;
 import lombok.Data;
@@ -65,7 +66,7 @@ public class CassandraTableDraft extends CassandraTable implements
 
     private CqlSession createSession(final CassandraCosmosDBAccount account) throws NoSuchAlgorithmException, KeyManagementException {
         final SSLContext sc = SSLContext.getInstance("TLSv1.2");
-        sc.init(null,null, new java.security.SecureRandom());
+        sc.init(null, null, new java.security.SecureRandom());
         final DriverConfigLoader configLoader =
                 DriverConfigLoader.programmaticBuilder().withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(10)).build();
         final CassandraDatabaseAccountConnectionString connectionString = Objects.requireNonNull(account.getCassandraConnectionString());
@@ -102,7 +103,15 @@ public class CassandraTableDraft extends CassandraTable implements
     @Data
     @EqualsAndHashCode(callSuper = true)
     public static class CassandraTableConfig extends ThroughputConfig {
+        public static final String DEFAULT_SCHEMA = "(userid int, name text, email text, PRIMARY KEY (userid))";
         private String tableId;
         private String schema;
+
+        public static CassandraTableConfig getDefaultConfig() {
+            final CassandraTableConfig result = new CassandraTableConfig();
+            result.setTableId(String.format("table%s", Utils.getTimestamp()));
+            result.setSchema(DEFAULT_SCHEMA);
+            return result;
+        }
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraTableDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraTableDraft.java
@@ -5,28 +5,36 @@
 
 package com.microsoft.azure.toolkit.lib.cosmos.cassandra;
 
-import com.azure.core.util.Context;
 import com.azure.resourcemanager.cosmos.fluent.CassandraResourcesClient;
 import com.azure.resourcemanager.cosmos.fluent.models.CassandraTableGetResultsInner;
-import com.azure.resourcemanager.cosmos.models.CassandraSchema;
-import com.azure.resourcemanager.cosmos.models.CassandraTableCreateUpdateParameters;
-import com.azure.resourcemanager.cosmos.models.CassandraTableResource;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
+import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import com.microsoft.azure.toolkit.lib.cosmos.model.CassandraDatabaseAccountConnectionString;
 import com.microsoft.azure.toolkit.lib.cosmos.model.ThroughputConfig;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Setter;
 import org.apache.commons.lang3.ObjectUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.net.ssl.SSLContext;
+import java.net.InetSocketAddress;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 
 public class CassandraTableDraft extends CassandraTable implements
         AzResource.Draft<CassandraTable, CassandraTableGetResultsInner> {
 
+    @Setter
     private CassandraTableConfig config;
 
     protected CassandraTableDraft(@NotNull String name, @NotNull String resourceGroupName, @NotNull CassandraTableModule module) {
@@ -41,20 +49,32 @@ public class CassandraTableDraft extends CassandraTable implements
     @NotNull
     @Override
     public CassandraTableGetResultsInner createResourceInAzure() {
-        final CassandraResourcesClient cassandraResourcesClient = Objects.requireNonNull(((CassandraTableModule) Objects.requireNonNull(getModule())).getClient());
+        final CassandraKeyspace keyspace = getParent();
+        final CassandraCosmosDBAccount account = (CassandraCosmosDBAccount) keyspace.getParent();
 
-        final CassandraTableResource sqlContainerResource = new CassandraTableResource()
-                .withId(ensureConfig().getTableId())
-                .withSchema(new CassandraSchema());
-        final CassandraTableCreateUpdateParameters parameters = new CassandraTableCreateUpdateParameters()
-                .withLocation(Objects.requireNonNull(this.getParent().getRegion()).getName())
-                .withResource(sqlContainerResource);
-        parameters.withOptions(ensureConfig().toCreateUpdateOptions());
-        AzureMessager.getMessager().info(AzureString.format("Start creating Cassandra table({0})...", this.getName()));
-        final CassandraTableGetResultsInner result = cassandraResourcesClient.createUpdateCassandraTable(this.getResourceGroupName(), this.getParent().getParent().getName(),
-                this.getParent().getName(), this.getName(), parameters, Context.NONE);
+        try (final CqlSession session = createSession(account)) {
+            AzureMessager.getMessager().info(AzureString.format("Start creating Cassandra table({0})...", this.getName()));
+            session.execute(String.format("CREATE TABLE %s.%s %s", keyspace.getName(), getName(), ensureConfig().getSchema()));
+        } catch (final NoSuchAlgorithmException | KeyManagementException e) {
+            throw new AzureToolkitRuntimeException("Failed to create Cassandra table.", e);
+        }
+        final CassandraResourcesClient cassandraResourcesClient = Objects.requireNonNull(((CassandraTableModule) Objects.requireNonNull(getModule())).getClient());
         AzureMessager.getMessager().success(AzureString.format("Cassandra table({0}) is successfully created.", this.getName()));
-        return result;
+        return cassandraResourcesClient.getCassandraTable(this.getResourceGroupName(), account.getName(), keyspace.getName(), this.getName());
+    }
+
+    private CqlSession createSession(final CassandraCosmosDBAccount account) throws NoSuchAlgorithmException, KeyManagementException {
+        final SSLContext sc = SSLContext.getInstance("TLSv1.2");
+        sc.init(null,null, new java.security.SecureRandom());
+        final DriverConfigLoader configLoader =
+                DriverConfigLoader.programmaticBuilder().withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(10)).build();
+        final CassandraDatabaseAccountConnectionString connectionString = Objects.requireNonNull(account.getCassandraConnectionString());
+        return CqlSession.builder()
+                .withLocalDatacenter(Objects.requireNonNull(account.getRegion()).getLabel())
+                .withConfigLoader(configLoader)
+                .withSslContext(sc)
+                .addContactPoint(new InetSocketAddress(connectionString.getHost(), connectionString.getPort()))
+                .withAuthCredentials(connectionString.getUsername(), connectionString.getPassword()).build();
     }
 
     @NotNull

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraTableDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraTableDraft.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.cosmos.cassandra;
+
+import com.azure.core.util.Context;
+import com.azure.resourcemanager.cosmos.fluent.CassandraResourcesClient;
+import com.azure.resourcemanager.cosmos.fluent.models.CassandraTableGetResultsInner;
+import com.azure.resourcemanager.cosmos.models.CassandraSchema;
+import com.azure.resourcemanager.cosmos.models.CassandraTableCreateUpdateParameters;
+import com.azure.resourcemanager.cosmos.models.CassandraTableResource;
+import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
+import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import com.microsoft.azure.toolkit.lib.cosmos.model.ThroughputConfig;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.ObjectUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class CassandraTableDraft extends CassandraTable implements
+        AzResource.Draft<CassandraTable, CassandraTableGetResultsInner> {
+
+    private CassandraTableConfig config;
+
+    protected CassandraTableDraft(@NotNull String name, @NotNull String resourceGroupName, @NotNull CassandraTableModule module) {
+        super(name, resourceGroupName, module);
+    }
+
+    @Override
+    public void reset() {
+        this.config = null;
+    }
+
+    @NotNull
+    @Override
+    public CassandraTableGetResultsInner createResourceInAzure() {
+        final CassandraResourcesClient cassandraResourcesClient = Objects.requireNonNull(((CassandraTableModule) Objects.requireNonNull(getModule())).getClient());
+
+        final CassandraTableResource sqlContainerResource = new CassandraTableResource()
+                .withId(ensureConfig().getTableId())
+                .withSchema(new CassandraSchema());
+        final CassandraTableCreateUpdateParameters parameters = new CassandraTableCreateUpdateParameters()
+                .withLocation(Objects.requireNonNull(this.getParent().getRegion()).getName())
+                .withResource(sqlContainerResource);
+        parameters.withOptions(ensureConfig().toCreateUpdateOptions());
+        AzureMessager.getMessager().info(AzureString.format("Start creating Cassandra table({0})...", this.getName()));
+        final CassandraTableGetResultsInner result = cassandraResourcesClient.createUpdateCassandraTable(this.getResourceGroupName(), this.getParent().getParent().getName(),
+                this.getParent().getName(), this.getName(), parameters, Context.NONE);
+        AzureMessager.getMessager().success(AzureString.format("Cassandra table({0}) is successfully created.", this.getName()));
+        return result;
+    }
+
+    @NotNull
+    @Override
+    public CassandraTableGetResultsInner updateResourceInAzure(@NotNull CassandraTableGetResultsInner origin) {
+        throw new UnsupportedOperationException("not support");
+    }
+
+    @Override
+    public boolean isModified() {
+        return config != null && ObjectUtils.anyNotNull(config.getTableId(), config.getSchema());
+    }
+
+    @Nullable
+    @Override
+    public CassandraTable getOrigin() {
+        return null;
+    }
+
+    private CassandraTableConfig ensureConfig() {
+        this.config = Optional.ofNullable(config).orElseGet(CassandraTableConfig::new);
+        return this.config;
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    public static class CassandraTableConfig extends ThroughputConfig {
+        private String tableId;
+        private String schema;
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraTableModule.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/cassandra/CassandraTableModule.java
@@ -7,7 +7,9 @@ package com.microsoft.azure.toolkit.lib.cosmos.cassandra;
 import com.azure.resourcemanager.cosmos.fluent.CassandraResourcesClient;
 import com.azure.resourcemanager.cosmos.fluent.models.CassandraTableGetResultsInner;
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
+import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -51,6 +53,18 @@ public class CassandraTableModule extends AbstractAzResourceModule<CassandraTabl
     protected void deleteResourceFromAzure(@NotNull String resourceId) {
         final ResourceId id = ResourceId.fromString(resourceId);
         Optional.ofNullable(getClient()).ifPresent(client -> client.deleteCassandraTable(id.resourceGroupName(), id.parent().parent().name(), id.parent().name(), id.name()));
+    }
+
+    @NotNull
+    @Override
+    protected AzResource.Draft<CassandraTable, CassandraTableGetResultsInner> newDraftForCreate(@NotNull String name, @Nullable String rgName) {
+        return new CassandraTableDraft(name, Objects.requireNonNull(rgName), this);
+    }
+
+    @NotNull
+    @Override
+    protected AzResource.Draft<CassandraTable, CassandraTableGetResultsInner> newDraftForUpdate(@NotNull CassandraTable cassandraTable) {
+        throw new AzureToolkitRuntimeException("not supported");
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/DatabaseConfig.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/DatabaseConfig.java
@@ -7,12 +7,12 @@ package com.microsoft.azure.toolkit.lib.cosmos.model;
 
 import com.microsoft.azure.toolkit.lib.common.utils.Utils;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
-public class DatabaseConfig {
+@EqualsAndHashCode(callSuper = true)
+public class DatabaseConfig extends ThroughputConfig {
     private String name;
-    private Integer throughput;
-    private Integer maxThroughput;
 
     public static DatabaseConfig getDefaultDatabaseConfig() {
         return getDefaultDatabaseConfig("database");

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/ThroughputConfig.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/model/ThroughputConfig.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.cosmos.model;
+
+import com.azure.resourcemanager.cosmos.models.AutoscaleSettings;
+import com.azure.resourcemanager.cosmos.models.CreateUpdateOptions;
+import lombok.Data;
+import org.apache.commons.lang3.ObjectUtils;
+
+import java.util.Objects;
+
+@Data
+public class ThroughputConfig {
+    private Integer throughput;
+    private Integer maxThroughput;
+
+    public CreateUpdateOptions toCreateUpdateOptions() {
+        assert ObjectUtils.anyNull(throughput, maxThroughput);
+        if (ObjectUtils.allNull(throughput, maxThroughput)) {
+            return null;
+        }
+        final CreateUpdateOptions options = new CreateUpdateOptions();
+        return Objects.nonNull(throughput) ? options.withThroughput(throughput) :
+                options.withAutoscaleSettings(new AutoscaleSettings().withMaxThroughput(maxThroughput));
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCollection.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCollection.java
@@ -6,34 +6,103 @@
 package com.microsoft.azure.toolkit.lib.cosmos.mongo;
 
 import com.azure.resourcemanager.cosmos.fluent.models.MongoDBCollectionGetResultsInner;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
 import com.microsoft.azure.toolkit.lib.cosmos.ICosmosCollection;
+import com.microsoft.azure.toolkit.lib.cosmos.ICosmosDocumentModule;
+import com.microsoft.azure.toolkit.lib.cosmos.model.MongoDatabaseAccountConnectionString;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientURI;
+import lombok.Getter;
+import org.bson.Document;
+import org.bson.types.ObjectId;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
-public class MongoCollection extends AbstractAzResource<MongoCollection, MongoDatabase, MongoDBCollectionGetResultsInner> implements Deletable, ICosmosCollection {
+import static com.microsoft.azure.toolkit.lib.cosmos.mongo.MongoDocumentModule.MONGO_ID_KEY;
+
+public class MongoCollection extends AbstractAzResource<MongoCollection, MongoDatabase, MongoDBCollectionGetResultsInner>
+        implements Deletable, ICosmosCollection, ICosmosDocumentModule<MongoDocument> {
+
+    @Getter
+    private com.mongodb.client.MongoCollection<Document> collection;
+    @Getter
+    private final MongoDocumentModule documentModule;
 
     protected MongoCollection(@Nonnull String name, @Nonnull String resourceGroupName, @Nonnull MongoCollectionModule module) {
         super(name, resourceGroupName, module);
+        this.documentModule = new MongoDocumentModule(this);
     }
 
     protected MongoCollection(@Nonnull MongoDBCollectionGetResultsInner remote, @Nonnull MongoCollectionModule module) {
         super(remote.name(), module);
+        this.documentModule = new MongoDocumentModule(this);
     }
 
     protected MongoCollection(@Nonnull MongoCollection collection) {
         super(collection);
+        this.collection = collection.collection;
+        this.documentModule = collection.documentModule;
     }
 
     @NotNull
     @Override
     public List<AbstractAzResourceModule<?, ?, ?>> getSubModules() {
-        return Collections.emptyList();
+        return Collections.singletonList(documentModule);
+    }
+
+    public MongoDocumentModule documents() {
+        return this.documentModule;
+    }
+
+    @Override
+    public MongoDocument importDocument(@Nonnull final ObjectNode node) {
+        final Document document = Document.parse(node.toPrettyString());
+        if (document.get(MONGO_ID_KEY) == null) {
+            document.put(MONGO_ID_KEY, new ObjectId());
+        }
+        final String id = document.get(MONGO_ID_KEY).toString();
+        final MongoDocumentDraft documentDraft = this.documentModule.create(id, getResourceGroupName());
+        documentDraft.setDraftDocument(document);
+        return documentDraft.commit();
+    }
+
+    @Override
+    public List<MongoDocument> listDocuments() {
+        return documents().list();
+    }
+
+    @Override
+    protected void updateAdditionalProperties(@Nullable MongoDBCollectionGetResultsInner newRemote, @Nullable MongoDBCollectionGetResultsInner oldRemote) {
+        super.updateAdditionalProperties(newRemote, oldRemote);
+        this.collection = getDocumentClient();
+    }
+
+    public synchronized com.mongodb.client.MongoCollection<Document> getClient() {
+        if (Objects.isNull(this.collection)) {
+            this.collection = getDocumentClient();
+        }
+        return this.collection;
+    }
+
+    private com.mongodb.client.MongoCollection<Document> getDocumentClient() {
+        try {
+            final MongoDatabase database = this.getParent();
+            final MongoCosmosDBAccount account = (MongoCosmosDBAccount) database.getParent();
+            final MongoDatabaseAccountConnectionString mongoConnectionString = Objects.requireNonNull(account.getMongoConnectionString());
+            final MongoClient mongoClient = new MongoClient(new MongoClientURI(mongoConnectionString.getConnectionString()));
+            return mongoClient.getDatabase(database.getName()).getCollection(this.getName());
+        } catch (Throwable e) {
+            // swallow exception to load data client
+            return null;
+        }
     }
 
     @NotNull

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCollection.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCollection.java
@@ -25,6 +25,7 @@ import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.microsoft.azure.toolkit.lib.cosmos.mongo.MongoDocumentModule.MONGO_ID_KEY;
 
@@ -77,6 +78,11 @@ public class MongoCollection extends AbstractAzResource<MongoCollection, MongoDa
     @Override
     public List<MongoDocument> listDocuments() {
         return documents().list();
+    }
+
+    @Override
+    public long getDocumentCount() {
+        return Optional.ofNullable(getClient()).map(client -> client.countDocuments()).orElse(0L);
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCollectionDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCollectionDraft.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+package com.microsoft.azure.toolkit.lib.cosmos.mongo;
+
+import com.azure.core.util.Context;
+import com.azure.resourcemanager.cosmos.fluent.MongoDBResourcesClient;
+import com.azure.resourcemanager.cosmos.fluent.models.MongoDBCollectionGetResultsInner;
+import com.azure.resourcemanager.cosmos.models.MongoDBCollectionCreateUpdateParameters;
+import com.azure.resourcemanager.cosmos.models.MongoDBCollectionResource;
+import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
+import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import com.microsoft.azure.toolkit.lib.cosmos.model.ThroughputConfig;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class MongoCollectionDraft extends MongoCollection implements
+        AzResource.Draft<MongoCollection, MongoDBCollectionGetResultsInner> {
+
+    private MongoCollectionConfig config;
+
+    protected MongoCollectionDraft(@NotNull String name, @NotNull String resourceGroupName, @NotNull MongoCollectionModule module) {
+        super(name, resourceGroupName, module);
+    }
+
+    @Override
+    public void reset() {
+        this.config = null;
+    }
+
+    @NotNull
+    @Override
+    public MongoDBCollectionGetResultsInner createResourceInAzure() {
+        final MongoDBResourcesClient mongoDBResourcesClient = Objects.requireNonNull(((MongoCollectionModule) Objects.requireNonNull(getModule())).getClient());
+        final Map<String, String> shardKey = StringUtils.isEmpty(ensureConfig().getShardKey()) ? null : Collections.singletonMap(ensureConfig().getShardKey(), "Hash");
+        final MongoDBCollectionResource sqlContainerResource = new MongoDBCollectionResource()
+                .withId(ensureConfig().getCollectionId())
+                .withShardKey(shardKey);
+        final MongoDBCollectionCreateUpdateParameters parameters = new MongoDBCollectionCreateUpdateParameters()
+                .withLocation(Objects.requireNonNull(this.getParent().getRegion()).getName())
+                .withResource(sqlContainerResource);
+        parameters.withOptions(ensureConfig().toCreateUpdateOptions());
+        AzureMessager.getMessager().info(AzureString.format("Start creating MongoDB collection({0})...", this.getName()));
+        final MongoDBCollectionGetResultsInner result = mongoDBResourcesClient.createUpdateMongoDBCollection(this.getResourceGroupName(), this.getParent().getParent().getName(),
+                this.getParent().getName(), this.getName(), parameters, Context.NONE);
+        AzureMessager.getMessager().success(AzureString.format("MongoDB collection({0}) is successfully created.", this.getName()));
+        return result;
+    }
+
+    @NotNull
+    @Override
+    public MongoDBCollectionGetResultsInner updateResourceInAzure(@NotNull MongoDBCollectionGetResultsInner origin) {
+        throw new UnsupportedOperationException("not support");
+    }
+
+    @Override
+    public boolean isModified() {
+        return config != null && ObjectUtils.anyNotNull(config.getCollectionId(), config.getShardKey(), config.getThroughput(), config.getMaxThroughput());
+    }
+
+    @Nullable
+    @Override
+    public MongoCollection getOrigin() {
+        return null;
+    }
+
+    private MongoCollectionConfig ensureConfig() {
+        this.config = Optional.ofNullable(config).orElseGet(MongoCollectionConfig::new);
+        return this.config;
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    public static class MongoCollectionConfig extends ThroughputConfig {
+        private String collectionId;
+        private String shardKey;
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCollectionDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCollectionDraft.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import com.microsoft.azure.toolkit.lib.cosmos.model.ThroughputConfig;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Setter;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -28,6 +29,7 @@ import java.util.Optional;
 public class MongoCollectionDraft extends MongoCollection implements
         AzResource.Draft<MongoCollection, MongoDBCollectionGetResultsInner> {
 
+    @Setter
     private MongoCollectionConfig config;
 
     protected MongoCollectionDraft(@NotNull String name, @NotNull String resourceGroupName, @NotNull MongoCollectionModule module) {

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCollectionDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCollectionDraft.java
@@ -12,6 +12,7 @@ import com.azure.resourcemanager.cosmos.models.MongoDBCollectionResource;
 import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import com.microsoft.azure.toolkit.lib.common.utils.Utils;
 import com.microsoft.azure.toolkit.lib.cosmos.model.ThroughputConfig;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -87,5 +88,11 @@ public class MongoCollectionDraft extends MongoCollection implements
     public static class MongoCollectionConfig extends ThroughputConfig {
         private String collectionId;
         private String shardKey;
+
+        public static MongoCollectionConfig getDefaultConfig() {
+            final MongoCollectionConfig result = new MongoCollectionConfig();
+            result.setCollectionId(String.format("collection-%s", Utils.getTimestamp()));
+            return result;
+        }
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCollectionModule.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCollectionModule.java
@@ -7,10 +7,13 @@ package com.microsoft.azure.toolkit.lib.cosmos.mongo;
 import com.azure.resourcemanager.cosmos.fluent.MongoDBResourcesClient;
 import com.azure.resourcemanager.cosmos.fluent.models.MongoDBCollectionGetResultsInner;
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
+import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -30,7 +33,7 @@ public class MongoCollectionModule extends AbstractAzResourceModule<MongoCollect
     @NotNull
     @Override
     protected MongoCollection newResource(@NotNull String name, @Nullable String resourceGroupName) {
-        return new MongoCollection(name, resourceGroupName, this);
+        return new MongoCollection(name, Objects.requireNonNull(resourceGroupName), this);
     }
 
     @NotNull
@@ -50,6 +53,18 @@ public class MongoCollectionModule extends AbstractAzResourceModule<MongoCollect
     protected void deleteResourceFromAzure(@NotNull String resourceId) {
         final ResourceId id = ResourceId.fromString(resourceId);
         Optional.ofNullable(getClient()).ifPresent(client -> client.deleteMongoDBCollection(id.resourceGroupName(), id.parent().parent().name(), id.parent().name(), id.name()));
+    }
+
+    @NotNull
+    @Override
+    protected AzResource.Draft<MongoCollection, MongoDBCollectionGetResultsInner> newDraftForCreate(@NotNull String name, @Nullable String rgName) {
+        return new MongoCollectionDraft(name, Objects.requireNonNull(rgName), this);
+    }
+
+    @NotNull
+    @Override
+    protected AzResource.Draft<MongoCollection, MongoDBCollectionGetResultsInner> newDraftForUpdate(@NotNull MongoCollection mongoCollection) {
+        throw new AzureToolkitRuntimeException("not supported");
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDatabase.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDatabase.java
@@ -9,6 +9,7 @@ import com.azure.resourcemanager.cosmos.fluent.models.MongoDBDatabaseGetResultsI
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
+import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccount;
 import com.microsoft.azure.toolkit.lib.cosmos.ICosmosCollection;
 import com.microsoft.azure.toolkit.lib.cosmos.ICosmosDatabase;
@@ -20,7 +21,7 @@ import java.util.List;
 
 public class MongoDatabase extends AbstractAzResource<MongoDatabase, CosmosDBAccount, MongoDBDatabaseGetResultsInner> implements Deletable, ICosmosDatabase {
 
-    private MongoCollectionModule collectionModule;
+    private final MongoCollectionModule collectionModule;
 
     protected MongoDatabase(@NotNull String name, @NotNull String resourceGroupName, @NotNull MongoDatabaseModule module) {
         super(name, resourceGroupName, module);
@@ -35,6 +36,10 @@ public class MongoDatabase extends AbstractAzResource<MongoDatabase, CosmosDBAcc
     protected MongoDatabase(@Nonnull MongoDBDatabaseGetResultsInner remote, @Nonnull MongoDatabaseModule module) {
         super(remote.name(), module);
         this.collectionModule = new MongoCollectionModule(this);
+    }
+
+    public Region getRegion() {
+        return getParent().getRegion();
     }
 
     @NotNull

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDatabaseDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDatabaseDraft.java
@@ -8,8 +8,6 @@ package com.microsoft.azure.toolkit.lib.cosmos.mongo;
 import com.azure.core.util.Context;
 import com.azure.resourcemanager.cosmos.fluent.CosmosDBManagementClient;
 import com.azure.resourcemanager.cosmos.fluent.models.MongoDBDatabaseGetResultsInner;
-import com.azure.resourcemanager.cosmos.models.AutoscaleSettings;
-import com.azure.resourcemanager.cosmos.models.CreateUpdateOptions;
 import com.azure.resourcemanager.cosmos.models.MongoDBDatabaseCreateUpdateParameters;
 import com.azure.resourcemanager.cosmos.models.MongoDBDatabaseResource;
 import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
@@ -48,18 +46,7 @@ public class MongoDatabaseDraft extends MongoDatabase implements
         final MongoDBDatabaseCreateUpdateParameters parameters = new MongoDBDatabaseCreateUpdateParameters()
                 .withLocation(Objects.requireNonNull(this.getParent().getRegion()).getName())
                 .withResource(new MongoDBDatabaseResource().withId(this.getName()));
-        final Integer throughput = ensureConfig().getThroughput();
-        final Integer maxThroughput = ensureConfig().getMaxThroughput();
-        assert ObjectUtils.anyNull(throughput, maxThroughput);
-        if (ObjectUtils.anyNotNull(throughput, maxThroughput)) {
-            final CreateUpdateOptions options = new CreateUpdateOptions();
-            if (Objects.nonNull(ensureConfig().getThroughput())) {
-                options.withThroughput(throughput);
-            } else {
-                options.withAutoscaleSettings(new AutoscaleSettings().withMaxThroughput(maxThroughput));
-            }
-            parameters.withOptions(options);
-        }
+        parameters.withOptions(ensureConfig().toCreateUpdateOptions());
         AzureMessager.getMessager().info(AzureString.format("Start creating MongoDB database({0})...", this.getName()));
         final MongoDBDatabaseGetResultsInner result = cosmosDBManagementClient.getMongoDBResources().createUpdateMongoDBDatabase(this.getResourceGroupName(), this.getParent().getName(),
                 this.getName(), parameters, Context.NONE);

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDocument.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDocument.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.cosmos.mongo;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.Deletable;
+import com.microsoft.azure.toolkit.lib.common.utils.JsonUtils;
+import com.microsoft.azure.toolkit.lib.cosmos.ICosmosDocument;
+import org.bson.Document;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static com.microsoft.azure.toolkit.lib.cosmos.mongo.MongoDocumentModule.MONGO_ID_KEY;
+
+public class MongoDocument extends AbstractAzResource<MongoDocument, MongoCollection, Document> implements Deletable, ICosmosDocument {
+    protected MongoDocument(@NotNull String name, @NotNull String resourceGroupName, @NotNull AbstractAzResourceModule<MongoDocument, MongoCollection, Document> module) {
+        super(name, resourceGroupName, module);
+    }
+
+    protected MongoDocument(@Nonnull MongoDocument origin) {
+        super(origin);
+    }
+
+    @NotNull
+    @Override
+    public List<AbstractAzResourceModule<?, ?, ?>> getSubModules() {
+        return Collections.emptyList();
+    }
+
+    @Nullable
+    @Override
+    public Object getDocumentId() {
+        return Optional.ofNullable(getRemote()).map(doc -> doc.get(MONGO_ID_KEY)).orElse(null);
+    }
+
+    @Nullable
+    @Override
+    public ObjectNode getDocument() {
+        return Optional.ofNullable(getRemote()).map(Document::toJson)
+                .map(json -> JsonUtils.fromJson(json, ObjectNode.class)).orElse(null);
+    }
+
+    @Override
+    public void updateDocument(ObjectNode document) {
+        final MongoDocumentDraft sqlDocumentDraft = (MongoDocumentDraft) this.update();
+        sqlDocumentDraft.setDocument(document);
+        sqlDocumentDraft.commit();
+    }
+
+    @Override
+    public String getDocumentDisplayName() {
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public String loadStatus(@NotNull Document remote) {
+        return Status.RUNNING;
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDocument.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDocument.java
@@ -57,11 +57,6 @@ public class MongoDocument extends AbstractAzResource<MongoDocument, MongoCollec
         sqlDocumentDraft.commit();
     }
 
-    @Override
-    public String getDocumentDisplayName() {
-        return null;
-    }
-
     @NotNull
     @Override
     public String loadStatus(@NotNull Document remote) {

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDocumentDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDocumentDraft.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+package com.microsoft.azure.toolkit.lib.cosmos.mongo;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import com.mongodb.BasicDBObject;
+import com.mongodb.client.result.UpdateResult;
+import lombok.Getter;
+import lombok.Setter;
+import org.bson.Document;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.microsoft.azure.toolkit.lib.cosmos.mongo.MongoDocumentModule.MONGO_ID_KEY;
+
+public class MongoDocumentDraft extends MongoDocument implements
+        AzResource.Draft<MongoDocument, Document> {
+
+    @Getter
+    private MongoDocument origin;
+
+    @Getter
+    @Setter
+    private Document draftDocument;
+
+    protected MongoDocumentDraft(@Nonnull String name, @Nonnull String resourceGroupName, @Nonnull AbstractAzResourceModule<MongoDocument, MongoCollection, Document> module) {
+        super(name, resourceGroupName, module);
+    }
+
+    protected MongoDocumentDraft(@Nonnull MongoDocument origin) {
+        super(origin);
+        this.origin = origin;
+    }
+
+    public void setDocument(ObjectNode document) {
+        this.draftDocument = Document.parse(document.toPrettyString());
+    }
+
+    @Override
+    public Object getDocumentId() {
+        return Optional.ofNullable(draftDocument)
+                .map(draftDocument -> draftDocument.get(MONGO_ID_KEY))
+                .orElseGet(super::getDocumentId);
+    }
+
+    @Override
+    public void reset() {
+        this.draftDocument = null;
+    }
+
+    @Nonnull
+    @Override
+    public Document createResourceInAzure() {
+        final com.mongodb.client.MongoCollection<Document> client = Objects.requireNonNull(((MongoDocumentModule) getModule()).getClient());
+        final Object id = Objects.requireNonNull(draftDocument).get(MONGO_ID_KEY);
+        client.insertOne(draftDocument);
+        return Objects.requireNonNull(client.find(new BasicDBObject(MONGO_ID_KEY, id)).first());
+    }
+
+    @Nonnull
+    @Override
+    public Document updateResourceInAzure(@Nonnull Document origin) {
+        final com.mongodb.client.MongoCollection<Document> client = Objects.requireNonNull(((MongoDocumentModule) getModule()).getClient());
+        final Object id = getDocumentId();
+        final UpdateResult updateResult = client.replaceOne(new Document(MONGO_ID_KEY, id), draftDocument);
+        if (updateResult.getModifiedCount() > 0) {
+            return Objects.requireNonNull(loadRemote());
+        } else {
+            throw new AzureToolkitRuntimeException("Failed to update document.");
+        }
+    }
+
+    @Override
+    public boolean isModified() {
+        return this.draftDocument != null;
+    }
+
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDocumentModule.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDocumentModule.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.cosmos.mongo;
+
+import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import org.apache.commons.lang3.StringUtils;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class MongoDocumentModule extends AbstractAzResourceModule<MongoDocument, MongoCollection, Document> {
+
+    public static final String MONGO_ID_KEY = "_id";
+
+    public MongoDocumentModule(@Nonnull MongoCollection parent) {
+        super("documents", parent);
+    }
+
+    @Nonnull
+    @Override
+    protected MongoDocument newResource(@Nonnull Document document) {
+        final String id = Objects.requireNonNull(document.get(MONGO_ID_KEY)).toString();
+        return new MongoDocument(id, parent.getResourceGroupName(), this);
+    }
+
+    @Nonnull
+    @Override
+    protected MongoDocument newResource(@Nonnull String name, @Nullable String resourceGroupName) {
+        return new MongoDocument(name, Objects.requireNonNull(resourceGroupName), this);
+    }
+
+    @Nonnull
+    @Override
+    protected Stream<Document> loadResourcesFromAzure() {
+        final int cosmosBatchSize = Azure.az().config().getCosmosBatchSize();
+        return Optional.ofNullable(getClient()).map(client -> client.find().limit(cosmosBatchSize))
+                .map(it -> StreamSupport.stream(it.spliterator(), false)).orElse(Stream.empty());
+    }
+
+    @Nullable
+    @Override
+    protected Document loadResourceFromAzure(@Nonnull String name, @Nullable String resourceGroup) {
+        final Object documentId = getDocumentIdFromName(name);
+        return Optional.ofNullable(getClient())
+                .map(client -> client.find(new Document(MONGO_ID_KEY, documentId)).first()).orElse(null);
+    }
+
+    @Nonnull
+    @Override
+    protected AzResource.Draft<MongoDocument, Document> newDraftForCreate(@Nonnull String name, @Nullable String rgName) {
+        return new MongoDocumentDraft(name, Objects.requireNonNull(rgName), this);
+    }
+
+    @Nonnull
+    @Override
+    protected AzResource.Draft<MongoDocument, Document> newDraftForUpdate(@Nonnull MongoDocument mongoDocument) {
+        return new MongoDocumentDraft(mongoDocument);
+    }
+
+    @Override
+    public void delete(@Nonnull String name, @Nullable String rgName) {
+        final Object documentId = getDocumentIdFromName(name);
+        Optional.ofNullable(getClient()).ifPresent(client -> client.deleteOne(new Document(MONGO_ID_KEY, documentId)));
+    }
+
+    private Object getDocumentIdFromName(final String name){
+        return this.list().stream()
+                .filter(document -> document.getDocumentId() != null && StringUtils.equals(name, document.getDocumentId().toString()))
+                .findFirst()
+                .map(MongoDocument::getDocumentId)
+                .orElseGet(() -> new ObjectId(name));
+    }
+
+    @Nullable
+    @Override
+    protected com.mongodb.client.MongoCollection<Document> getClient() {
+        return getParent().getClient();
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlContainer.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlContainer.java
@@ -4,40 +4,120 @@
  */
 package com.microsoft.azure.toolkit.lib.cosmos.sql;
 
+import com.azure.cosmos.ConsistencyLevel;
+import com.azure.cosmos.CosmosClient;
+import com.azure.cosmos.CosmosClientBuilder;
+import com.azure.cosmos.CosmosContainer;
+import com.azure.cosmos.models.CosmosContainerResponse;
 import com.azure.resourcemanager.cosmos.fluent.models.SqlContainerGetResultsInner;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
 import com.microsoft.azure.toolkit.lib.cosmos.ICosmosCollection;
-import org.jetbrains.annotations.NotNull;
+import com.microsoft.azure.toolkit.lib.cosmos.ICosmosDocumentModule;
+import com.microsoft.azure.toolkit.lib.cosmos.model.SqlDatabaseAccountConnectionString;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 
-public class SqlContainer extends AbstractAzResource<SqlContainer, SqlDatabase, SqlContainerGetResultsInner> implements Deletable, ICosmosCollection {
+public class SqlContainer extends AbstractAzResource<SqlContainer, SqlDatabase, SqlContainerGetResultsInner>
+        implements Deletable, ICosmosCollection, ICosmosDocumentModule<SqlDocument> {
+    private CosmosContainer container;
+    private CosmosContainerResponse containerResponse;
+    @Getter
+    private final SqlDocumentModule documentModule;
 
     protected SqlContainer(@Nonnull String name, @Nonnull String resourceGroupName, @Nonnull SqlContainerModule module) {
         super(name, resourceGroupName, module);
+        this.documentModule = new SqlDocumentModule(this);
     }
 
     protected SqlContainer(@Nonnull SqlContainerGetResultsInner remote, @Nonnull SqlContainerModule module) {
         super(remote.name(), module);
+        this.documentModule = new SqlDocumentModule(this);
     }
 
     protected SqlContainer(@Nonnull SqlContainer collection) {
         super(collection);
+        this.container = collection.container;
+        this.containerResponse = collection.containerResponse;
+        this.documentModule = new SqlDocumentModule(this);
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public List<AbstractAzResourceModule<?, ?, ?>> getSubModules() {
-        return Collections.emptyList();
+        return Collections.singletonList(documentModule);
     }
 
-    @NotNull
     @Override
-    public String loadStatus(@NotNull SqlContainerGetResultsInner remote) {
+    protected void updateAdditionalProperties(@Nullable SqlContainerGetResultsInner newRemote, @Nullable SqlContainerGetResultsInner oldRemote) {
+        super.updateAdditionalProperties(newRemote, oldRemote);
+        doGetClient();
+    }
+
+    @Override
+    public SqlDocument importDocument(@Nonnull final ObjectNode node) {
+        if (node.get("id") == null) {
+            node.put("id", UUID.randomUUID().toString());
+        }
+        final String id = node.get("id").asText();
+        final String partitionKey = Optional.ofNullable(node.get(getPartitionKey())).map(JsonNode::asText).orElse(StringUtils.EMPTY);
+        final SqlDocumentDraft documentDraft = this.documentModule.create(String.format("%s#%s", id, partitionKey), getResourceGroupName());
+        documentDraft.setDraftDocument(node);
+        return documentDraft.commit();
+    }
+
+    @Override
+    public List<SqlDocument> listDocuments() {
+        return getDocumentModule().list();
+    }
+
+    public String getPartitionKey() {
+        return Optional.ofNullable(this.containerResponse)
+                .map(CosmosContainerResponse::getProperties)
+                .map(p -> p.getPartitionKeyDefinition().getPaths().get(0))
+                .map(key -> key.startsWith("/") ? key.substring(1) : key)
+                .orElse(null);
+    }
+
+    public synchronized CosmosContainer getClient() {
+        if (Objects.isNull(this.container)) {
+            doGetClient();
+        }
+        return this.container;
+    }
+
+    private void doGetClient() {
+        try {
+            final SqlDatabase sqlDatabase = this.getParent();
+            final SqlCosmosDBAccount account = (SqlCosmosDBAccount) sqlDatabase.getParent();
+            final SqlDatabaseAccountConnectionString connectionString = account.getSqlAccountConnectionString();
+            final CosmosClient cosmosClient = new CosmosClientBuilder()
+                    .endpoint(account.getDocumentEndpoint())
+                    .key(connectionString.getKey())
+                    .preferredRegions(Collections.singletonList(Objects.requireNonNull(account.getRegion()).getName()))
+                    .consistencyLevel(ConsistencyLevel.EVENTUAL)
+                    .buildClient();
+            this.container = cosmosClient.getDatabase(sqlDatabase.getName()).getContainer(this.getName());
+            this.containerResponse = container.read();
+        } catch (Throwable e) {
+            // swallow exception to load data client
+        }
+    }
+
+    @Nonnull
+    @Override
+    public String loadStatus(@Nonnull SqlContainerGetResultsInner remote) {
         return Status.RUNNING;
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlContainer.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlContainer.java
@@ -82,6 +82,11 @@ public class SqlContainer extends AbstractAzResource<SqlContainer, SqlDatabase, 
         return getDocumentModule().list();
     }
 
+    @Override
+    public long getDocumentCount() {
+        return documentModule.getDocumentCount();
+    }
+
     public String getPartitionKey() {
         return Optional.ofNullable(this.containerResponse)
                 .map(CosmosContainerResponse::getProperties)

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlContainerDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlContainerDraft.java
@@ -15,6 +15,7 @@ import com.azure.resourcemanager.cosmos.models.UniqueKeyPolicy;
 import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import com.microsoft.azure.toolkit.lib.common.utils.Utils;
 import com.microsoft.azure.toolkit.lib.cosmos.model.ThroughputConfig;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -105,5 +106,11 @@ public class SqlContainerDraft extends SqlContainer implements
         private String containerId;
         private String partitionKey;
         private List<String> uniqueKeys;
+
+        public static SqlContainerConfig getDefaultConfig() {
+            final SqlContainerConfig result = new SqlContainerConfig();
+            result.setContainerId(String.format("container-%s", Utils.getTimestamp()));
+            return result;
+        }
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlContainerDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlContainerDraft.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+package com.microsoft.azure.toolkit.lib.cosmos.sql;
+
+import com.azure.core.util.Context;
+import com.azure.resourcemanager.cosmos.fluent.SqlResourcesClient;
+import com.azure.resourcemanager.cosmos.fluent.models.SqlContainerGetResultsInner;
+import com.azure.resourcemanager.cosmos.models.ContainerPartitionKey;
+import com.azure.resourcemanager.cosmos.models.SqlContainerCreateUpdateParameters;
+import com.azure.resourcemanager.cosmos.models.SqlContainerResource;
+import com.azure.resourcemanager.cosmos.models.UniqueKey;
+import com.azure.resourcemanager.cosmos.models.UniqueKeyPolicy;
+import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
+import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import com.microsoft.azure.toolkit.lib.cosmos.model.ThroughputConfig;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class SqlContainerDraft extends SqlContainer implements
+        AzResource.Draft<SqlContainer, SqlContainerGetResultsInner> {
+
+    private SqlContainerConfig config;
+
+    protected SqlContainerDraft(@NotNull String name, @NotNull String resourceGroupName, @NotNull SqlContainerModule module) {
+        super(name, resourceGroupName, module);
+    }
+
+    @Override
+    public void reset() {
+        this.config = null;
+    }
+
+    @NotNull
+    @Override
+    public SqlContainerGetResultsInner createResourceInAzure() {
+        final SqlResourcesClient sqlResourcesClient = Objects.requireNonNull(((SqlContainerModule) Objects.requireNonNull(getModule())).getClient());
+        final SqlContainerResource sqlContainerResource = new SqlContainerResource()
+                .withId(ensureConfig().getContainerId())
+                .withPartitionKey(new ContainerPartitionKey().withPaths(Collections.singletonList(ensureConfig().getPartitionKey())))
+                .withUniqueKeyPolicy(getUniqueKeyPolicyFromConfig());
+        final SqlContainerCreateUpdateParameters parameters = new SqlContainerCreateUpdateParameters()
+                .withLocation(Objects.requireNonNull(this.getParent().getRegion()).getName())
+                .withResource(sqlContainerResource);
+        parameters.withOptions(ensureConfig().toCreateUpdateOptions());
+        AzureMessager.getMessager().info(AzureString.format("Start creating SQL container({0})...", this.getName()));
+        final SqlContainerGetResultsInner result = sqlResourcesClient.createUpdateSqlContainer(this.getResourceGroupName(), this.getParent().getParent().getName(),
+                this.getParent().getName(), this.getName(), parameters, Context.NONE);
+        AzureMessager.getMessager().success(AzureString.format("SQL container({0}) is successfully created.", this.getName()));
+        return result;
+    }
+
+    private UniqueKeyPolicy getUniqueKeyPolicyFromConfig() {
+        final List<String> uniqueKeys = ensureConfig().getUniqueKeys();
+        if (CollectionUtils.isEmpty(uniqueKeys)) {
+            return null;
+        }
+        final List<UniqueKey> uniqueKeyList = uniqueKeys.stream().map(path -> Arrays.asList(path.split(",")))
+                .map(paths -> new UniqueKey().withPaths(paths))
+                .collect(Collectors.toList());
+        return new UniqueKeyPolicy().withUniqueKeys(uniqueKeyList);
+    }
+
+    @NotNull
+    @Override
+    public SqlContainerGetResultsInner updateResourceInAzure(@NotNull SqlContainerGetResultsInner origin) {
+        throw new UnsupportedOperationException("not support");
+    }
+
+    @Override
+    public boolean isModified() {
+        return config != null && ObjectUtils.anyNotNull(config.getContainerId(), config.getPartitionKey(), config.getUniqueKeys(),
+                config.getThroughput(), config.getMaxThroughput());
+    }
+
+    @Nullable
+    @Override
+    public SqlContainer getOrigin() {
+        return null;
+    }
+
+    private SqlContainerConfig ensureConfig() {
+        this.config = Optional.ofNullable(config).orElseGet(SqlContainerConfig::new);
+        return this.config;
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    public static class SqlContainerConfig extends ThroughputConfig {
+        private String containerId;
+        private String partitionKey;
+        private List<String> uniqueKeys;
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlContainerDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlContainerDraft.java
@@ -18,6 +18,7 @@ import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import com.microsoft.azure.toolkit.lib.cosmos.model.ThroughputConfig;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Setter;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.jetbrains.annotations.NotNull;
@@ -33,6 +34,7 @@ import java.util.stream.Collectors;
 public class SqlContainerDraft extends SqlContainer implements
         AzResource.Draft<SqlContainer, SqlContainerGetResultsInner> {
 
+    @Setter
     private SqlContainerConfig config;
 
     protected SqlContainerDraft(@NotNull String name, @NotNull String resourceGroupName, @NotNull SqlContainerModule module) {

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlContainerModule.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlContainerModule.java
@@ -7,7 +7,9 @@ package com.microsoft.azure.toolkit.lib.cosmos.sql;
 import com.azure.resourcemanager.cosmos.fluent.SqlResourcesClient;
 import com.azure.resourcemanager.cosmos.fluent.models.SqlContainerGetResultsInner;
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
+import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -51,6 +53,18 @@ public class SqlContainerModule extends AbstractAzResourceModule<SqlContainer, S
     protected void deleteResourceFromAzure(@NotNull String resourceId) {
         final ResourceId id = ResourceId.fromString(resourceId);
         Optional.ofNullable(getClient()).ifPresent(client -> client.deleteSqlContainer(id.resourceGroupName(), id.parent().parent().name(), id.parent().name(), id.name()));
+    }
+
+    @NotNull
+    @Override
+    protected AzResource.Draft<SqlContainer, SqlContainerGetResultsInner> newDraftForCreate(@NotNull String name, @Nullable String rgName) {
+        return new SqlContainerDraft(name, Objects.requireNonNull(rgName), this);
+    }
+
+    @NotNull
+    @Override
+    protected AzResource.Draft<SqlContainer, SqlContainerGetResultsInner> newDraftForUpdate(@NotNull SqlContainer sqlContainer) {
+        throw new AzureToolkitRuntimeException("not supported");
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDatabase.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDatabase.java
@@ -9,6 +9,7 @@ import com.azure.resourcemanager.cosmos.fluent.models.SqlDatabaseGetResultsInner
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
+import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.cosmos.CosmosDBAccount;
 import com.microsoft.azure.toolkit.lib.cosmos.ICosmosCollection;
 import com.microsoft.azure.toolkit.lib.cosmos.ICosmosDatabase;
@@ -20,7 +21,7 @@ import java.util.List;
 
 public class SqlDatabase extends AbstractAzResource<SqlDatabase, CosmosDBAccount, SqlDatabaseGetResultsInner> implements Deletable, ICosmosDatabase {
 
-    private SqlContainerModule containerModule;
+    private final SqlContainerModule containerModule;
 
     protected SqlDatabase(@NotNull String name, @NotNull String resourceGroupName, @NotNull SqlDatabaseModule module) {
         super(name, resourceGroupName, module);
@@ -45,6 +46,10 @@ public class SqlDatabase extends AbstractAzResource<SqlDatabase, CosmosDBAccount
 
     public SqlContainerModule containers() {
         return this.containerModule;
+    }
+
+    public Region getRegion() {
+        return getParent().getRegion();
     }
 
     @NotNull

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDatabaseDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDatabaseDraft.java
@@ -8,8 +8,6 @@ package com.microsoft.azure.toolkit.lib.cosmos.sql;
 import com.azure.core.util.Context;
 import com.azure.resourcemanager.cosmos.fluent.CosmosDBManagementClient;
 import com.azure.resourcemanager.cosmos.fluent.models.SqlDatabaseGetResultsInner;
-import com.azure.resourcemanager.cosmos.models.AutoscaleSettings;
-import com.azure.resourcemanager.cosmos.models.CreateUpdateOptions;
 import com.azure.resourcemanager.cosmos.models.SqlDatabaseCreateUpdateParameters;
 import com.azure.resourcemanager.cosmos.models.SqlDatabaseResource;
 import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
@@ -38,7 +36,7 @@ public class SqlDatabaseDraft extends SqlDatabase implements
 
     @Override
     public void reset() {
-
+        this.config = null;
     }
 
     @NotNull
@@ -48,18 +46,7 @@ public class SqlDatabaseDraft extends SqlDatabase implements
         final SqlDatabaseCreateUpdateParameters parameters = new SqlDatabaseCreateUpdateParameters()
                 .withLocation(Objects.requireNonNull(this.getParent().getRegion()).getName())
                 .withResource(new SqlDatabaseResource().withId(this.getName()));
-        final Integer throughput = ensureConfig().getThroughput();
-        final Integer maxThroughput = ensureConfig().getMaxThroughput();
-        assert ObjectUtils.anyNull(throughput, maxThroughput);
-        if (ObjectUtils.anyNotNull(throughput, maxThroughput)) {
-            final CreateUpdateOptions options = new CreateUpdateOptions();
-            if (Objects.nonNull(ensureConfig().getThroughput())) {
-                options.withThroughput(throughput);
-            } else {
-                options.withAutoscaleSettings(new AutoscaleSettings().withMaxThroughput(maxThroughput));
-            }
-            parameters.withOptions(options);
-        }
+        parameters.withOptions(ensureConfig().toCreateUpdateOptions());
         AzureMessager.getMessager().info(AzureString.format("Start creating SQL database({0})...", this.getName()));
         final SqlDatabaseGetResultsInner result = cosmosDBManagementClient.getSqlResources().createUpdateSqlDatabase(this.getResourceGroupName(), this.getParent().getName(),
                 this.getName(), parameters, Context.NONE);

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocument.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocument.java
@@ -50,11 +50,6 @@ public class SqlDocument extends AbstractAzResource<SqlDocument, SqlContainer, O
     }
 
     @Override
-    public String getDocumentDisplayName() {
-        return null;
-    }
-
-    @Override
     @Nullable
     public ObjectNode getDocument() {
         return Optional.ofNullable(getRemote()).map(remote -> {

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocument.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocument.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.cosmos.sql;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.Deletable;
+import com.microsoft.azure.toolkit.lib.cosmos.ICosmosDocument;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public class SqlDocument extends AbstractAzResource<SqlDocument, SqlContainer, ObjectNode> implements Deletable, ICosmosDocument {
+    protected static final String[] HIDE_FIELDS = {"_rid", "_self", "_etag", "_attachments", "_ts"};
+
+    protected SqlDocument(@Nonnull String name, @Nullable String resourceGroup, @Nonnull SqlDocumentModule module) {
+        super(name, Objects.requireNonNull(resourceGroup), module);
+    }
+
+    public SqlDocument(@NotNull SqlDocument origin) {
+        super(origin);
+    }
+
+    @Nullable
+    public String getDocumentId() {
+        return Optional.ofNullable(this.getRemote()).map(remote -> remote.get("id")).map(JsonNode::asText).orElse(null);
+    }
+
+    @Nullable
+    public String getDocumentPartitionKey() {
+        final String partitionKey = getParent().getPartitionKey();
+        return Optional.ofNullable(this.getRemote()).map(remote -> remote.get(partitionKey)).map(JsonNode::asText).orElse(null);
+    }
+
+    @Override
+    public void updateDocument(ObjectNode document) {
+        final SqlDocumentDraft sqlDocumentDraft = (SqlDocumentDraft) this.update();
+        sqlDocumentDraft.setDraftDocument(document);
+        sqlDocumentDraft.commit();
+    }
+
+    @Override
+    public String getDocumentDisplayName() {
+        return null;
+    }
+
+    @Override
+    @Nullable
+    public ObjectNode getDocument() {
+        return Optional.ofNullable(getRemote()).map(remote -> {
+            final ObjectNode node = remote.deepCopy();
+            for (String field : HIDE_FIELDS) {
+                node.remove(field);
+            }
+            return node;
+        }).orElse(null);
+    }
+
+    @Nonnull
+    @Override
+    public List<AbstractAzResourceModule<?, ?, ?>> getSubModules() {
+        return Collections.emptyList();
+    }
+
+    @Nonnull
+    @Override
+    public String loadStatus(@Nonnull ObjectNode remote) {
+        return Status.RUNNING;
+    }
+
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocumentDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocumentDraft.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.cosmos.sql;
+
+import com.azure.cosmos.CosmosContainer;
+import com.azure.cosmos.models.CosmosPatchItemRequestOptions;
+import com.azure.cosmos.models.PartitionKey;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+import java.util.Optional;
+
+public class SqlDocumentDraft extends SqlDocument implements
+        AzResource.Draft<SqlDocument, ObjectNode> {
+
+    @Getter
+    private SqlDocument origin;
+
+    @Getter
+    @Setter
+    private ObjectNode draftDocument;
+
+    protected SqlDocumentDraft(@Nonnull String name, @Nullable String resourceGroup, @Nonnull SqlDocumentModule module) {
+        super(name, resourceGroup, module);
+    }
+
+    protected SqlDocumentDraft(@Nonnull SqlDocument origin) {
+        super(origin);
+        this.origin = origin;
+    }
+
+    @Override
+    public String getDocumentId() {
+        return Optional.ofNullable(draftDocument)
+                .map(draftDocument -> draftDocument.get("id").asText())
+                .orElseGet(super::getDocumentId);
+    }
+
+    @Nullable
+    @Override
+    public String getDocumentPartitionKey() {
+        final String partitionKey = getParent().getPartitionKey();
+        return Optional.ofNullable(draftDocument).map(doc -> doc.get(partitionKey)).map(JsonNode::asText)
+                .orElseGet(super::getDocumentPartitionKey);
+    }
+
+    @Override
+    public void reset() {
+        this.draftDocument = null;
+    }
+
+    @Nonnull
+    @Override
+    public ObjectNode createResourceInAzure() {
+        final String documentPartitionKey = getParent().getPartitionKey();
+        final PartitionKey partitionKey = draftDocument.get(documentPartitionKey) == null ? PartitionKey.NONE :
+                new PartitionKey(draftDocument.get(documentPartitionKey).asText());
+        final String documentId = draftDocument.get("id").asText();
+        final CosmosContainer client = ((SqlDocumentModule) getModule()).getClient();
+        Objects.requireNonNull(client).createItem(draftDocument).getItem();
+        return Objects.requireNonNull(client).readItem(documentId, partitionKey, ObjectNode.class).getItem();
+    }
+
+    @Nonnull
+    @Override
+    public ObjectNode updateResourceInAzure(@Nonnull ObjectNode origin) {
+        final CosmosContainer client = ((SqlDocumentModule) getModule()).getClient();
+        final String documentPartitionKey = getDocumentPartitionKey();
+        final PartitionKey partitionKey = StringUtils.isEmpty(getDocumentPartitionKey()) ? PartitionKey.NONE : new PartitionKey(documentPartitionKey);
+        final ObjectNode node = draftDocument.deepCopy();
+        for (String field : HIDE_FIELDS) {
+            node.set(field, origin.get(field));
+        }
+        Objects.requireNonNull(client).replaceItem(node, getDocumentId(), partitionKey, new CosmosPatchItemRequestOptions()).getItem();
+        return Objects.requireNonNull(client).readItem(node.get("id").asText(), partitionKey, ObjectNode.class).getItem();
+    }
+
+    @Override
+    public boolean isModified() {
+        return draftDocument != null;
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocumentModule.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocumentModule.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.cosmos.sql;
+
+import com.azure.core.util.paging.ContinuablePagedIterable;
+import com.azure.cosmos.CosmosContainer;
+import com.azure.cosmos.models.CosmosItemRequestOptions;
+import com.azure.cosmos.models.CosmosQueryRequestOptions;
+import com.azure.cosmos.models.PartitionKey;
+import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AzResource;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class SqlDocumentModule extends AbstractAzResourceModule<SqlDocument, SqlContainer, ObjectNode> {
+
+    public static final String DELIMITER = "#";
+
+    public SqlDocumentModule(@Nonnull SqlContainer parent) {
+        super("documents", parent);
+    }
+
+    @Nonnull
+    @Override
+    protected Stream<ObjectNode> loadResourcesFromAzure() {
+        final int cosmosBatchSize = Azure.az().config().getCosmosBatchSize();
+        return Optional.ofNullable(getClient()).map(client -> client.queryItems(String.format("select TOP %d * from c", cosmosBatchSize), new CosmosQueryRequestOptions(), ObjectNode.class))
+                .map(ContinuablePagedIterable::stream)
+                .orElse(Stream.empty());
+    }
+
+    @Nullable
+    @Override
+    protected ObjectNode loadResourceFromAzure(@Nonnull String name, @Nullable String resourceGroup) {
+        final String[] split = name.split(DELIMITER);
+        if (split.length > 2) {
+            return null;
+        }
+        final String id = split[0];
+        final String partitionKey = split.length > 1 ? split[1] : StringUtils.EMPTY;
+        return Optional.ofNullable(getClient())
+                .map(client -> Optional.ofNullable(doLoadDocument(client, new PartitionKey(partitionKey), id))
+                        .orElseGet(() -> doLoadDocument(client, PartitionKey.NONE, id)))
+                .orElse(null);
+    }
+
+    @Nullable
+    private ObjectNode doLoadDocument(@Nonnull CosmosContainer container, @Nonnull PartitionKey partitionKey, @Nonnull String id) {
+        try {
+            return container.readItem(id, partitionKey, ObjectNode.class).getItem();
+        } catch (RuntimeException e2) {
+            return null;
+        }
+    }
+
+    @Nullable
+    public SqlDocument get(@Nonnull String id, @Nonnull String partitionKey, @Nullable String resourceGroup) {
+        return super.get(String.format("%s#%s", id, partitionKey), resourceGroup);
+    }
+
+    @Nonnull
+    @Override
+    protected SqlDocument newResource(@Nonnull ObjectNode ObjectNode) {
+        final SqlContainer container = getParent();
+        final String id = Objects.requireNonNull(ObjectNode.get("id")).asText();
+        final String partitionKey = container.getPartitionKey();
+        final String partitionValue = Optional.ofNullable(ObjectNode.get(partitionKey))
+                .map(JsonNode::asText).orElse(StringUtils.EMPTY);
+        return newResource(String.format("%s#%s", id, partitionValue), container.getResourceGroupName());
+    }
+
+    @Nonnull
+    @Override
+    protected SqlDocument newResource(@Nonnull String name, @Nullable String resourceGroup) {
+        return new SqlDocument(name, resourceGroup, this);
+    }
+
+    @Override
+    protected void deleteResourceFromAzure(@Nonnull String resourceId) {
+        final ResourceId id = ResourceId.fromString(resourceId);
+        final ObjectNode node = loadResourceFromAzure(id.name(), id.resourceGroupName());
+        Optional.ofNullable(getClient()).ifPresent(client -> client.deleteItem(node, new CosmosItemRequestOptions()));
+    }
+
+    @Nonnull
+    @Override
+    protected AzResource.Draft<SqlDocument, ObjectNode> newDraftForCreate(@Nonnull String name, @Nullable String rgName) {
+        return new SqlDocumentDraft(name, rgName, this);
+    }
+
+    @Nonnull
+    @Override
+    protected AzResource.Draft<SqlDocument, ObjectNode> newDraftForUpdate(@Nonnull SqlDocument document) {
+        return new SqlDocumentDraft(document);
+    }
+
+    @Override
+    @Nullable
+    protected synchronized CosmosContainer getClient() {
+        return getParent().getClient();
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocumentModule.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocumentModule.java
@@ -32,6 +32,16 @@ public class SqlDocumentModule extends AbstractAzResourceModule<SqlDocument, Sql
         super("documents", parent);
     }
 
+    public long getDocumentCount() {
+        final CosmosContainer client = getClient();
+        try {
+            return client == null ? 0L : client.queryItems("SELECT VALUE COUNT(1) FROM c", new CosmosQueryRequestOptions(), Long.class)
+                    .iterator().next();
+        } catch (final RuntimeException e) {
+            return 0L;
+        }
+    }
+
     @Nonnull
     @Override
     protected Stream<ObjectNode> loadResourcesFromAzure() {

--- a/azure-toolkit-libs/pom.xml
+++ b/azure-toolkit-libs/pom.xml
@@ -136,6 +136,8 @@
         <jedis.version>3.6.3</jedis.version>
         <asm.version>9.3</asm.version>
         <mongo-java-driver.version>3.12.11</mongo-java-driver.version>
+        <azure-cosmos.version>4.38.0</azure-cosmos.version>
+        <java-driver-core.version>4.15.0</java-driver-core.version>
     </properties>
 
     <repositories>
@@ -719,6 +721,16 @@
                 <groupId>org.mongodb</groupId>
                 <artifactId>mongo-java-driver</artifactId>
                 <version>${mongo-java-driver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-cosmos</artifactId>
+                <version>${azure-cosmos.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.datastax.oss</groupId>
+                <artifactId>java-driver-core</artifactId>
+                <version>${java-driver-core.version}</version>
             </dependency>
             <!-- TEST -->
             <dependency>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Support create table/collection/container for cosmos db
- Migrate to datastax driver to create cassandra table
- Support data management for document for Cosmos DB with SQL/Mongo API
- Add default config and resolve issues for cosmos documents
 
Does this close any currently open issues?
------------------------------------------
[AB#2000951](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/2000951), [AB#2000953](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/2000953)

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
