### PR TITLE
Fix logic to get shared key in mongo document draft

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDocumentDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDocumentDraft.java
@@ -15,6 +15,7 @@ import lombok.Setter;
 import org.bson.Document;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -48,6 +49,16 @@ public class MongoDocumentDraft extends MongoDocument implements
         return Optional.ofNullable(draftDocument)
                 .map(draftDocument -> draftDocument.get(MONGO_ID_KEY))
                 .orElseGet(super::getDocumentId);
+    }
+
+    @Nullable
+    @Override
+    public String getSharedKey() {
+        final String sharedKey = getParent().getSharedKey();
+        return Optional.ofNullable(draftDocument)
+                .map(node -> node.get(sharedKey))
+                .map(Object::toString)
+                .orElseGet(super::getSharedKey);
     }
 
     @Override


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix logic to get shared key in mongo document draft


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
