### PR TITLE
Resolve issues for cosmos documents

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.26.0</version>
+        <version>0.26.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.26.0</version>
+        <version>0.26.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.26.0</version>
+        <version>0.26.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-common-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.26.0</version>
+        <version>0.26.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.26.0</version>
+        <version>0.26.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-containerregistry-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-containerregistry-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.26.0</version>
+        <version>0.26.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-containerservice-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-containerservice-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.26.0</version>
+        <version>0.26.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.26.0</version>
+        <version>0.26.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCollection.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoCollection.java
@@ -7,6 +7,8 @@ package com.microsoft.azure.toolkit.lib.cosmos.mongo;
 
 import com.azure.resourcemanager.cosmos.fluent.models.MongoDBCollectionGetResultsInner;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
+import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
@@ -70,7 +72,12 @@ public class MongoCollection extends AbstractAzResource<MongoCollection, MongoDa
         final String id = document.get(MONGO_ID_KEY).toString();
         final MongoDocumentDraft documentDraft = this.documentModule.create(id, getResourceGroupName());
         documentDraft.setDraftDocument(document);
-        return documentDraft.commit();
+        final boolean existing = this.getDocumentModule().exists(documentDraft.getName(), documentDraft.getResourceGroupName());
+        final MongoDocument result = documentDraft.commit();
+        final AzureString importMessage = AzureString.format("Import document to Mongo collection %s successfully.", this.getName());
+        final AzureString updateMessage = AzureString.format("Update document %s in Mongo collection %s successfully.", id, this.getName());
+        AzureMessager.getMessager().info(existing ? updateMessage : importMessage);
+        return result;
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDocumentDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/mongo/MongoDocumentDraft.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeExcep
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
+import com.microsoft.azure.toolkit.lib.common.utils.JsonUtils;
 import com.mongodb.BasicDBObject;
 import com.mongodb.client.result.UpdateResult;
 import lombok.Getter;
@@ -50,6 +51,15 @@ public class MongoDocumentDraft extends MongoDocument implements
         return Optional.ofNullable(draftDocument)
                 .map(draftDocument -> draftDocument.get(MONGO_ID_KEY))
                 .orElseGet(super::getDocumentId);
+    }
+
+    @Nullable
+    @Override
+    public ObjectNode getDocument() {
+        return Optional.ofNullable(draftDocument)
+                .map(Document::toJson)
+                .map(json -> JsonUtils.fromJson(json, ObjectNode.class))
+                .orElseGet(() -> super.getDocument());
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlContainer.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlContainer.java
@@ -10,6 +10,8 @@ import com.azure.cosmos.models.CosmosContainerResponse;
 import com.azure.resourcemanager.cosmos.fluent.models.SqlContainerGetResultsInner;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
+import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
@@ -66,7 +68,12 @@ public class SqlContainer extends AbstractAzResource<SqlContainer, SqlDatabase, 
                 .map(JsonNode::asText).orElse(StringUtils.EMPTY);
         final SqlDocumentDraft documentDraft = this.documentModule.create(String.format("%s#%s", id, partitionKey), getResourceGroupName());
         documentDraft.setDraftDocument(node);
-        return documentDraft.commit();
+        final boolean existing = this.getDocumentModule().exists(documentDraft.getName(), documentDraft.getResourceGroupName());
+        final SqlDocument result = documentDraft.commit();
+        final AzureString importMessage = AzureString.format("Import document to Cosmos container %s successfully.", this.getName());
+        final AzureString updateMessage = AzureString.format("Update document %s in Cosmos container %s successfully.", id, this.getName());
+        AzureMessager.getMessager().info(existing ? updateMessage : importMessage);
+        return result;
     }
 
     public String getPartitionKey() {

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocument.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocument.java
@@ -40,7 +40,9 @@ public class SqlDocument extends AbstractAzResource<SqlDocument, SqlContainer, O
     public String getDocumentPartitionKey() {
         final String partitionKey = getParent().getPartitionKey();
         return Optional.ofNullable(this.getRemote())
-                .map(remote -> remote.at(partitionKey)).map(JsonNode::asText).orElse(null);
+                .map(remote -> remote.at(partitionKey))
+                .filter(node -> !node.isMissingNode())
+                .map(JsonNode::asText).orElse(null);
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocument.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocument.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
 import com.microsoft.azure.toolkit.lib.cosmos.ICosmosDocument;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
@@ -19,6 +20,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+
+import static com.microsoft.azure.toolkit.lib.cosmos.sql.SqlDocumentModule.ID;
 
 public class SqlDocument extends AbstractAzResource<SqlDocument, SqlContainer, ObjectNode> implements Deletable, ICosmosDocument {
     protected static final String[] HIDE_FIELDS = {"_rid", "_self", "_etag", "_attachments", "_ts"};
@@ -33,16 +36,15 @@ public class SqlDocument extends AbstractAzResource<SqlDocument, SqlContainer, O
 
     @Nullable
     public String getDocumentId() {
-        return Optional.ofNullable(this.getRemote()).map(remote -> remote.get("id")).map(JsonNode::asText).orElse(null);
+        return Optional.ofNullable(this.getRemote()).map(remote -> remote.get(ID)).map(JsonNode::asText).orElse(null);
     }
 
     @Nullable
     public String getDocumentPartitionKey() {
         final String partitionKey = getParent().getPartitionKey();
         return Optional.ofNullable(this.getRemote())
-                .map(remote -> remote.at(partitionKey))
-                .filter(node -> !node.isMissingNode())
-                .map(JsonNode::asText).orElse(null);
+                .map(remote -> SqlDocumentModule.getSqlDocumentPartitionValue(remote, partitionKey))
+                .orElse(null);
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocumentDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocumentDraft.java
@@ -8,18 +8,18 @@ package com.microsoft.azure.toolkit.lib.cosmos.sql;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.models.CosmosPatchItemRequestOptions;
 import com.azure.cosmos.models.PartitionKey;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Optional;
+
+import static com.microsoft.azure.toolkit.lib.cosmos.sql.SqlDocumentModule.ID;
 
 public class SqlDocumentDraft extends SqlDocument implements
     AzResource.Draft<SqlDocument, ObjectNode> {
@@ -49,7 +49,7 @@ public class SqlDocumentDraft extends SqlDocument implements
     @Override
     public String getDocumentId() {
         return Optional.ofNullable(draftDocument)
-                .map(draftDocument -> draftDocument.get("id").asText())
+                .map(draftDocument -> draftDocument.get(ID).asText())
                 .orElseGet(super::getDocumentId);
     }
 
@@ -57,7 +57,8 @@ public class SqlDocumentDraft extends SqlDocument implements
     @Override
     public String getDocumentPartitionKey() {
         final String partitionKey = getParent().getPartitionKey();
-        return Optional.ofNullable(draftDocument).map(doc -> doc.at(partitionKey)).filter(node -> !node.isMissingNode()).map(JsonNode::asText)
+        return Optional.ofNullable(draftDocument)
+                .map(doc -> SqlDocumentModule.getSqlDocumentPartitionValue(doc, partitionKey))
                 .orElseGet(super::getDocumentPartitionKey);
     }
 
@@ -71,9 +72,10 @@ public class SqlDocumentDraft extends SqlDocument implements
     @AzureOperation(name = "cosmos.create_sql_document_in_azure.document", params = {"this.getName()"}, type = AzureOperation.Type.REQUEST)
     public ObjectNode createResourceInAzure() {
         final String documentPartitionKey = getParent().getPartitionKey();
-        final PartitionKey partitionKey = draftDocument.at(documentPartitionKey).isMissingNode() ? PartitionKey.NONE :
-                new PartitionKey(draftDocument.at(documentPartitionKey).asText());
-        final String documentId = draftDocument.get("id").asText();
+        final String documentPartitionValue = SqlDocumentModule.getSqlDocumentPartitionValue(draftDocument, documentPartitionKey);
+        final PartitionKey partitionKey = Objects.isNull(documentPartitionValue) ?
+                PartitionKey.NONE : new PartitionKey(documentPartitionValue);
+        final String documentId = draftDocument.get(ID).asText();
         final CosmosContainer client = ((SqlDocumentModule) getModule()).getClient();
         Objects.requireNonNull(client).createItem(draftDocument).getItem();
         return Objects.requireNonNull(client).readItem(documentId, partitionKey, ObjectNode.class).getItem();
@@ -85,13 +87,13 @@ public class SqlDocumentDraft extends SqlDocument implements
     public ObjectNode updateResourceInAzure(@Nonnull ObjectNode origin) {
         final CosmosContainer client = ((SqlDocumentModule) getModule()).getClient();
         final String documentPartitionKey = getDocumentPartitionKey();
-        final PartitionKey partitionKey = StringUtils.isEmpty(getDocumentPartitionKey()) ? PartitionKey.NONE : new PartitionKey(documentPartitionKey);
+        final PartitionKey partitionKey = Objects.isNull(getDocumentPartitionKey()) ? PartitionKey.NONE : new PartitionKey(documentPartitionKey);
         final ObjectNode node = draftDocument.deepCopy();
         for (String field : HIDE_FIELDS) {
             node.set(field, origin.get(field));
         }
         Objects.requireNonNull(client).replaceItem(node, getDocumentId(), partitionKey, new CosmosPatchItemRequestOptions()).getItem();
-        return Objects.requireNonNull(client).readItem(node.get("id").asText(), partitionKey, ObjectNode.class).getItem();
+        return Objects.requireNonNull(client).readItem(node.get(ID).asText(), partitionKey, ObjectNode.class).getItem();
     }
 
     @Override

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocumentModule.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocumentModule.java
@@ -100,7 +100,7 @@ public class SqlDocumentModule extends AbstractAzResourceModule<SqlDocument, Sql
         final SqlContainer container = getParent();
         final String id = Objects.requireNonNull(objectNode.get("id")).asText();
         final String partitionKey = container.getPartitionKey();
-        final String partitionValue = Optional.ofNullable(objectNode.get(partitionKey))
+        final String partitionValue = Optional.ofNullable(objectNode.at(partitionKey)).filter(node -> !node.isMissingNode())
             .map(JsonNode::asText).orElse(StringUtils.EMPTY);
         final SqlDocument sqlDocument = newResource(String.format("%s#%s", id, partitionValue), container.getResourceGroupName());
         sqlDocument.setRemote(objectNode);

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocumentModule.java
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/src/main/java/com/microsoft/azure/toolkit/lib/cosmos/sql/SqlDocumentModule.java
@@ -30,6 +30,8 @@ import java.util.stream.Stream;
 public class SqlDocumentModule extends AbstractAzResourceModule<SqlDocument, SqlContainer, ObjectNode> implements ICosmosDocumentModule<SqlDocument> {
 
     public static final String DELIMITER = "#";
+    public static final String ID = "id";
+    public static final String NONE = "$$$none$$$";
     @Nullable
     private Iterator<FeedResponse<ObjectNode>> iterator;
 
@@ -73,11 +75,11 @@ public class SqlDocumentModule extends AbstractAzResourceModule<SqlDocument, Sql
             return null;
         }
         final String id = split[0];
-        final String partitionKey = split.length > 1 ? split[1] : StringUtils.EMPTY;
+        final String partitionKeyValue = split.length > 1 ? split[1] : StringUtils.EMPTY;
+        final PartitionKey partitionKey = StringUtils.equals(partitionKeyValue, NONE) ? PartitionKey.NONE : new PartitionKey(partitionKeyValue);
         return Optional.ofNullable(getClient())
-            .map(client -> Optional.ofNullable(doLoadDocument(client, new PartitionKey(partitionKey), id))
-                .orElseGet(() -> doLoadDocument(client, PartitionKey.NONE, id)))
-            .orElse(null);
+                .map(client -> doLoadDocument(client, partitionKey, id))
+                .orElse(null);
     }
 
     @Nullable
@@ -91,18 +93,17 @@ public class SqlDocumentModule extends AbstractAzResourceModule<SqlDocument, Sql
 
     @Nullable
     public SqlDocument get(@Nonnull String id, @Nonnull String partitionKey, @Nullable String resourceGroup) {
-        return super.get(String.format("%s#%s", id, partitionKey), resourceGroup);
+        return super.get(getSqlDocumentResourceName(id, partitionKey), resourceGroup);
     }
 
     @Nonnull
     @Override
     protected SqlDocument newResource(@Nonnull ObjectNode objectNode) {
         final SqlContainer container = getParent();
-        final String id = Objects.requireNonNull(objectNode.get("id")).asText();
+        final String id = Objects.requireNonNull(objectNode.get(ID)).asText();
         final String partitionKey = container.getPartitionKey();
-        final String partitionValue = Optional.ofNullable(objectNode.at(partitionKey)).filter(node -> !node.isMissingNode())
-            .map(JsonNode::asText).orElse(StringUtils.EMPTY);
-        final SqlDocument sqlDocument = newResource(String.format("%s#%s", id, partitionValue), container.getResourceGroupName());
+        final String partitionValue = getSqlDocumentPartitionValue(objectNode, partitionKey);
+        final SqlDocument sqlDocument = newResource(getSqlDocumentResourceName(id, partitionValue), container.getResourceGroupName());
         sqlDocument.setRemote(objectNode);
         return sqlDocument;
     }
@@ -137,5 +138,18 @@ public class SqlDocumentModule extends AbstractAzResourceModule<SqlDocument, Sql
     @Nullable
     protected synchronized CosmosContainer getClient() {
         return getParent().getClient();
+    }
+
+    @Nonnull
+    public static String getSqlDocumentResourceName(@Nonnull final String id, @Nullable final String partitionKey) {
+        return String.format("%s#%s", id, Objects.isNull(partitionKey) ? NONE : partitionKey);
+    }
+
+    @Nullable
+    public static String getSqlDocumentPartitionValue(@Nonnull final ObjectNode node, @Nullable final String partitionKey) {
+        return Optional.ofNullable(partitionKey)
+                .map(node::at)
+                .filter(n -> !n.isMissingNode())
+                .map(JsonNode::asText).orElse(null);
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-database-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-database-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.26.0</version>
+        <version>0.26.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-mysql-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-mysql-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.26.0</version>
+        <version>0.26.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-postgre-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-postgre-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.26.0</version>
+        <version>0.26.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-redis-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-redis-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.26.0</version>
+        <version>0.26.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.26.0</version>
+        <version>0.26.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-sqlserver-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-sqlserver-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.26.0</version>
+        <version>0.26.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.26.0</version>
+        <version>0.26.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-toolkit-libs/pom.xml
+++ b/azure-toolkit-libs/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-libs</artifactId>
-    <version>0.26.0</version>
+    <version>0.26.1</version>
     <packaging>pom</packaging>
     <name>Libs for Azure Toolkits</name>
     <description>Wrapped libs for Microsoft Azure Toolkits</description>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-toolkit-libs</artifactId>
-                <version>0.26.0</version>
+                <version>0.26.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Override `getDocument` in draft, fix `getDocumentDisplayName` will always return null for draft
- Use JsonObject.at to get sql partition key
- Catch exception when read metadata from cosmos sql container 
- Show different message for create/update document in document container during import


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
