### PR TITLE
Tiny fixes for 202211 endgame

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/DeployWebAppTask.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/DeployWebAppTask.java
@@ -107,7 +107,7 @@ public class DeployWebAppTask extends AzureTask<WebAppBase<?, ?, ?>> {
             return false;
         }
         if (webApp.getRuntime().isWindows() && BooleanUtils.isTrue(this.waitDeploymentComplete)) {
-            messager.warning("Wait deployment complete is not supported in Windows runtime, skip waiting for deployment status.");
+            messager.warning("`waitDeploymentComplete` is not supported in Windows runtime, skip waiting for deployment status.");
             return false;
         }
         return Optional.ofNullable(this.waitDeploymentComplete).orElseGet(() -> webApp.getRuntime().isLinux());

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AzResourceBase.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AzResourceBase.java
@@ -41,14 +41,15 @@ public interface AzResourceBase {
     }
 
     enum FormalStatus {
-        RUNNING, STOPPED, FAILED, DELETED, UNKNOWN, WRITING, READING, CREATING;
+        RUNNING, STOPPED, FAILED, DELETED, UNKNOWN, WRITING, READING, CREATING, DELETING;
 
         private static final HashSet<String> runningStatus = Sets.newHashSet("running", "success", "succeeded", "ready", "ok");
         private static final HashSet<String> stoppedStatus = Sets.newHashSet("stopped", "deallocated");
         private static final HashSet<String> failedStatus = Sets.newHashSet("failed", "error");
-        private static final HashSet<String> writingStatus = Sets.newHashSet("writing", "pending", "processing", "updating", "deleting",
+        private static final HashSet<String> writingStatus = Sets.newHashSet("writing", "pending", "processing", "updating",
             "starting", "stopping", "restarting", "scaling");
         private static final HashSet<String> readingStatus = Sets.newHashSet("reading", "loading", "refreshing");
+        private static final HashSet<String> deletingStatus = Sets.newHashSet("deleting");
         private static final HashSet<String> deletedStatus = Sets.newHashSet("deleted", "removed", "disconnected");
 
         public static FormalStatus dummyFormalize(String status) {
@@ -65,6 +66,8 @@ public interface AzResourceBase {
                 return FormalStatus.WRITING;
             } else if (readingStatus.contains(status)) {
                 return FormalStatus.READING;
+            } else if (deletingStatus.contains(status)) {
+                return FormalStatus.DELETING;
             } else if (deletedStatus.contains(status)) {
                 return FormalStatus.DELETED;
             } else {
@@ -92,6 +95,10 @@ public interface AzResourceBase {
             return this == CREATING;
         }
 
+        public boolean isDeleting() {
+            return this == DELETING;
+        }
+
         public boolean isWriting() {
             return this == WRITING || this.isCreating();
         }
@@ -113,7 +120,7 @@ public interface AzResourceBase {
         }
 
         public boolean isConnected() {
-            return !(this.isDeleted() || this.isUnknown() || this.isCreating());
+            return !(this.isDeleted() || this.isUnknown() || this.isCreating() || this.isDeleting());
         }
     }
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Update warning message for enable in windows runtime, [AB#2012379](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/2012379)
- Seperate deleting from writing status in FormalStatus, [AB#2007072](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/2007072)


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
