### PR TITLE
fallback to `loadResourcesFromAzure` if `SupportsListing` is not supported and `loadResourcePagesFromAzure` is not overridden.

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
@@ -525,11 +525,10 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
         } else if (client instanceof SupportsListing) {
             log.debug("[{}]:loadPagedResourcesFromAzure->client.list()", this.name);
             return this.<SupportsListing<R>>cast(client).list().iterableByPage(getPageSize()).iterator();
-        } else if (client != null) {
+        } else {
             log.debug("[{}]:loadPagedResourcesFromAzure->NOT Supported", this.name);
             return Collections.singletonList(new ItemPage<>(this.loadResourcesFromAzure())).iterator();
         }
-        return Collections.emptyIterator();
     }
 
     @Nullable

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
@@ -527,7 +527,7 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
             return this.<SupportsListing<R>>cast(client).list().iterableByPage(getPageSize()).iterator();
         } else if (client != null) {
             log.debug("[{}]:loadPagedResourcesFromAzure->NOT Supported", this.name);
-            throw new AzureToolkitRuntimeException("not supported");
+            return Collections.singletonList(new ItemPage<>(this.loadResourcesFromAzure())).iterator();
         }
         return Collections.emptyIterator();
     }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
