### PR TITLE
Add Context with error handling when create app service slot 

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/FunctionAppDeploymentSlotDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/FunctionAppDeploymentSlotDraft.java
@@ -6,6 +6,7 @@
 package com.microsoft.azure.toolkit.lib.appservice.function;
 
 import com.azure.core.management.exception.ManagementException;
+import com.azure.core.util.Context;
 import com.azure.resourcemanager.appservice.models.DeploymentSlotBase;
 import com.azure.resourcemanager.appservice.models.FunctionApp;
 import com.azure.resourcemanager.appservice.models.FunctionDeploymentSlot;
@@ -39,6 +40,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static com.microsoft.azure.toolkit.lib.appservice.function.FunctionAppDraft.CAN_NOT_UPDATE_EXISTING_APP_SERVICE_OS;
@@ -117,9 +119,13 @@ public class FunctionAppDeploymentSlotDraft extends FunctionAppDeploymentSlot
         }
         final IAzureMessager messager = AzureMessager.getMessager();
         messager.info(AzureString.format("Start creating Function App deployment slot ({0})...", name));
-        // As we can not update runtime for deployment slot during creation, so call update resource here
-        FunctionDeploymentSlot slot = (FunctionDeploymentSlot) Objects.requireNonNull(this.doModify(() -> withCreate.create(), Status.CREATING));
+        // workaround to resolve slot creation exception could not be caught by azure operation
+        // todo: add unified error handling for reactor
+        final Consumer<Throwable> throwableConsumer = error -> messager.error(error);
+        final Context context = new Context("reactor.onErrorDropped.local", throwableConsumer);
+        FunctionDeploymentSlot slot = (FunctionDeploymentSlot) Objects.requireNonNull(this.doModify(() -> withCreate.create(context), Status.CREATING));
         final Runtime runtime = this.getRuntime();
+        // As we can not update runtime for deployment slot during creation, so call update resource here
         final boolean isRuntimeModified = (Objects.nonNull(runtime) && !Objects.equals(runtime, getParent().getRuntime())) || Objects.nonNull(this.getDockerConfiguration());
         this.ensureConfig().setAppSettings(null); // reset app settings
         this.ensureConfig().setDiagnosticConfig(null); // reset diagnostic config


### PR DESCRIPTION
Add Context with error handling when create app service slot in case reactor exception is not handled, [AB#2019324](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/2019324)

What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
