### PR TITLE
[Task #2036787, #2036786] Add validation/default value based on project compile version

### DIFF
--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
@@ -117,7 +117,7 @@ public class DeployMojo extends AbstractFunctionMojo {
         validateParameters();
         validateFunctionCompatibility();
         final String javaVersion = Optional.ofNullable(functionAppConfig.runtime()).map(RuntimeConfig::javaVersion).map(JavaVersion::getValue).orElse(StringUtils.EMPTY);
-        validateArtifactCompileVersion(javaVersion, getArtifactToDeploy(), getFailsOnRuntimeValidation());
+        validateArtifactCompileVersion(javaVersion, getArtifactToDeploy(), getFailsOnRuntimeValidationError());
         validateApplicationInsightsConfiguration();
     }
 

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
@@ -93,11 +93,11 @@ public class DeployMojo extends AbstractFunctionMojo {
     @AzureOperation("user/functionapp.deploy_app")
     protected void doExecute() throws Throwable {
         this.mergeCommandLineConfig();
-        final FunctionAppConfig functionAppConfig = getParser().parseConfig();
-        doValidate(functionAppConfig);
+        final ConfigParser parser = getParser();
+        doValidate(parser.getRuntimeConfig());
         initAzureAppServiceClient();
 
-        final FunctionAppBase<?, ?, ?> target = createOrUpdateResource(functionAppConfig);
+        final FunctionAppBase<?, ?, ?> target = createOrUpdateResource(parser.parseConfig());
         deployArtifact(target);
         updateTelemetryProperties();
     }
@@ -113,10 +113,10 @@ public class DeployMojo extends AbstractFunctionMojo {
         }
     }
 
-    protected void doValidate(FunctionAppConfig functionAppConfig) throws AzureExecutionException {
+    protected void doValidate(final RuntimeConfig runtimeConfig) throws AzureExecutionException {
         validateParameters();
         validateFunctionCompatibility();
-        final String javaVersion = Optional.ofNullable(functionAppConfig.runtime()).map(RuntimeConfig::javaVersion).map(JavaVersion::getValue).orElse(StringUtils.EMPTY);
+        final String javaVersion = Optional.ofNullable(runtimeConfig).map(RuntimeConfig::javaVersion).map(JavaVersion::getValue).orElse(StringUtils.EMPTY);
         validateArtifactCompileVersion(javaVersion, getArtifactToDeploy(), getFailsOnRuntimeValidationError());
         validateApplicationInsightsConfiguration();
     }

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
@@ -22,7 +22,6 @@ import com.microsoft.azure.toolkit.lib.appservice.model.PricingTier;
 import com.microsoft.azure.toolkit.lib.appservice.task.CreateOrUpdateFunctionAppTask;
 import com.microsoft.azure.toolkit.lib.appservice.task.DeployFunctionAppTask;
 import com.microsoft.azure.toolkit.lib.appservice.utils.AppServiceConfigUtils;
-import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureExecutionException;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
@@ -30,9 +29,7 @@ import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import com.microsoft.azure.toolkit.lib.common.utils.Utils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -96,10 +93,11 @@ public class DeployMojo extends AbstractFunctionMojo {
     @AzureOperation("user/functionapp.deploy_app")
     protected void doExecute() throws Throwable {
         this.mergeCommandLineConfig();
-        doValidate();
+        final FunctionAppConfig functionAppConfig = getParser().parseConfig();
+        doValidate(functionAppConfig);
         initAzureAppServiceClient();
 
-        final FunctionAppBase<?, ?, ?> target = createOrUpdateResource(getParser().parseConfig());
+        final FunctionAppBase<?, ?, ?> target = createOrUpdateResource(functionAppConfig);
         deployArtifact(target);
         updateTelemetryProperties();
     }
@@ -115,10 +113,11 @@ public class DeployMojo extends AbstractFunctionMojo {
         }
     }
 
-    protected void doValidate() throws AzureExecutionException {
+    protected void doValidate(FunctionAppConfig functionAppConfig) throws AzureExecutionException {
         validateParameters();
         validateFunctionCompatibility();
-        validateArtifactCompileVersion();
+        final String javaVersion = Optional.ofNullable(functionAppConfig.runtime()).map(RuntimeConfig::javaVersion).map(JavaVersion::getValue).orElse(StringUtils.EMPTY);
+        validateArtifactCompileVersion(javaVersion, getArtifactToDeploy(), failOnRuntimeValidationError);
         validateApplicationInsightsConfiguration();
     }
 
@@ -177,9 +176,9 @@ public class DeployMojo extends AbstractFunctionMojo {
     }
 
     protected FunctionAppBase<?, ?, ?> createOrUpdateResource(final FunctionAppConfig config) throws Throwable {
-        FunctionApp app = Azure.az(AzureFunctions.class).functionApps(config.subscriptionId()).updateOrCreate(config.appName(), config.resourceGroup());
+        final FunctionApp app = Azure.az(AzureFunctions.class).functionApps(config.subscriptionId()).updateOrCreate(config.appName(), config.resourceGroup());
         final boolean newFunctionApp = !app.exists();
-        AppServiceConfig defaultConfig = !newFunctionApp ? fromAppService(app, app.getAppServicePlan()) : buildDefaultConfig(config.subscriptionId(),
+        final AppServiceConfig defaultConfig = !newFunctionApp ? fromAppService(app, app.getAppServicePlan()) : buildDefaultConfig(config.subscriptionId(),
             config.resourceGroup(), config.appName());
         mergeAppServiceConfig(config, defaultConfig);
         if (!newFunctionApp && !config.disableAppInsights() && StringUtils.isEmpty(config.appInsightsKey())) {
@@ -190,46 +189,13 @@ public class DeployMojo extends AbstractFunctionMojo {
     }
 
     private AppServiceConfig buildDefaultConfig(String subscriptionId, String resourceGroup, String appName) {
-        ComparableVersion javaVersionForProject = null;
-        final String outputFileName = project.getBuild().getFinalName() + "." + project.getPackaging();
-        File outputFile = new File(project.getBuild().getDirectory(), outputFileName);
-        if (outputFile.exists() && StringUtils.equalsIgnoreCase("jar", FilenameUtils.getExtension(outputFile.getName()))) {
-            try {
-                javaVersionForProject = new ComparableVersion(Utils.getArtifactCompileVersion(outputFile));
-            } catch (Exception e) {
-                // it is acceptable that java version from jar file cannot be retrieved
-            }
-        }
-
-        javaVersionForProject = ObjectUtils.firstNonNull(javaVersionForProject, new ComparableVersion(System.getProperty("java.version")));
-        // get java version according to project java version
-        JavaVersion javaVersion = javaVersionForProject.compareTo(new ComparableVersion("9")) < 0 ? JavaVersion.JAVA_8 : JavaVersion.JAVA_11;
-        return AppServiceConfigUtils.buildDefaultFunctionConfig(subscriptionId, resourceGroup, appName, javaVersion);
+        return AppServiceConfigUtils.buildDefaultFunctionConfig(subscriptionId, resourceGroup, appName, JavaVersion.JAVA_8);
     }
 
     private void deployArtifact(final FunctionAppBase<?, ?, ?> target) {
         final File file = new File(getDeploymentStagingDirectoryPath());
         final FunctionDeployType type = StringUtils.isEmpty(deploymentType) ? null : FunctionDeployType.fromString(deploymentType);
         new DeployFunctionAppTask(target, file, type).doExecute();
-    }
-
-    protected void validateArtifactCompileVersion() throws AzureExecutionException {
-        final RuntimeConfig runtimeConfig = getParser().getRuntimeConfig();
-        if (runtimeConfig.os() == OperatingSystem.DOCKER) {
-            return;
-        }
-        final JavaVersion javaVersion = Optional.ofNullable(runtimeConfig.javaVersion()).orElse(CreateOrUpdateFunctionAppTask.DEFAULT_FUNCTION_JAVA_VERSION);
-        final ComparableVersion runtimeVersion = new ComparableVersion(javaVersion.getValue());
-        final ComparableVersion artifactVersion = new ComparableVersion(Utils.getArtifactCompileVersion(getArtifactToDeploy()));
-        if (runtimeVersion.compareTo(artifactVersion) >= 0) {
-            return;
-        }
-        if (javaVersion.isExpandedValue()) {
-            AzureMessager.getMessager().warning(AzureString.format(ARTIFACT_INCOMPATIBLE_WARNING, artifactVersion.toString(), runtimeVersion.toString()));
-        } else {
-            final String errorMessage = AzureString.format(ARTIFACT_INCOMPATIBLE_ERROR, artifactVersion.toString(), runtimeVersion.toString()).toString();
-            throw new AzureExecutionException(errorMessage);
-        }
     }
 
     private File getArtifactToDeploy() throws AzureExecutionException {

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
@@ -93,10 +93,10 @@ public class DeployMojo extends AbstractFunctionMojo {
     @AzureOperation("user/functionapp.deploy_app")
     protected void doExecute() throws Throwable {
         this.mergeCommandLineConfig();
-        final ConfigParser parser = getParser();
-        doValidate(parser.getRuntimeConfig());
+        doValidate();
         initAzureAppServiceClient();
 
+        final ConfigParser parser = getParser();
         final FunctionAppBase<?, ?, ?> target = createOrUpdateResource(parser.parseConfig());
         deployArtifact(target);
         updateTelemetryProperties();
@@ -113,12 +113,17 @@ public class DeployMojo extends AbstractFunctionMojo {
         }
     }
 
-    protected void doValidate(final RuntimeConfig runtimeConfig) throws AzureExecutionException {
+    protected void doValidate() throws AzureExecutionException {
         validateParameters();
         validateFunctionCompatibility();
+        validateArtifactCompileVersion();
+        validateApplicationInsightsConfiguration();
+    }
+
+    private void validateArtifactCompileVersion() throws AzureExecutionException {
+        final RuntimeConfig runtimeConfig = getParser().getRuntimeConfig();
         final String javaVersion = Optional.ofNullable(runtimeConfig).map(RuntimeConfig::javaVersion).map(JavaVersion::getValue).orElse(StringUtils.EMPTY);
         validateArtifactCompileVersion(javaVersion, getArtifactToDeploy(), getFailsOnRuntimeValidationError());
-        validateApplicationInsightsConfiguration();
     }
 
     // todo: Extract validator for all maven toolkits

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
@@ -117,7 +117,7 @@ public class DeployMojo extends AbstractFunctionMojo {
         validateParameters();
         validateFunctionCompatibility();
         final String javaVersion = Optional.ofNullable(functionAppConfig.runtime()).map(RuntimeConfig::javaVersion).map(JavaVersion::getValue).orElse(StringUtils.EMPTY);
-        validateArtifactCompileVersion(javaVersion, getArtifactToDeploy(), failOnRuntimeValidationError);
+        validateArtifactCompileVersion(javaVersion, getArtifactToDeploy(), getFailsOnRuntimeValidation());
         validateApplicationInsightsConfiguration();
     }
 

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -629,8 +629,10 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
     @Nullable
     protected String getCompileLevel() {
         // order compile, target
+        // refers https://github.com/apache/maven-compiler-plugin/blob/maven-compiler-plugin-3.11.0/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java#L1286-L1291
         final String rawLevel = Stream.of("compile", "target").map(this::getCompilerPluginConfigurationByName)
                 .filter(StringUtils::isNotEmpty).findFirst().orElse(null);
+        // refers https://github.com/apache/maven-compiler-plugin/blob/maven-compiler-plugin-3.11.0/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java#L1293-L1295
         return StringUtils.startsWithIgnoreCase(rawLevel, "1.") ? StringUtils.substring(rawLevel, 2) : rawLevel;
     }
 

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -114,14 +114,15 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
     protected static final String SUBSCRIPTION_TEMPLATE = "Subscription: %s(%s)";
     protected static final String USING_AZURE_ENVIRONMENT = "Using Azure environment: %s.";
     protected static final String SUBSCRIPTION_NOT_FOUND = "Subscription %s was not found in current account.";
-    protected static final String COMPILE_LEVEL_NOT_SUPPORTED = "Your project compile level (%s) is higher than the supported values in Azure, " +
-            "please lower the compile level in case any compatibility issues and errors. Here are the supported runtimes: %s";
+    protected static final String COMPILE_LEVEL_NOT_SUPPORTED = "Your project's compile level (%s) is not compatible with any of the supported runtime versions of Azure. " +
+            "The supported runtime versions include %s. Please reset the compile level to a compatible version in case any compatibility issues and errors.";
     protected static final String FAILED_TO_GET_VALID_RUNTIMES = "Failed to get valid runtime based on project compile level, fall back to all values";
 
     private static final String AZURE_ENVIRONMENT = "azureEnvironment";
     private static final String PROXY = "proxy";
-    public static final String INVALID_ARTIFACT = "The compile level of the artifact '%s' is '%s', which is higher than the runtime compile level '%s'. " +
-            "Please recompile the artifact with a lower compile level or switch to higher Java runtime.";
+    private static final String INVALID_ARTIFACT = "The artifact's compile level (%s) is incompatible with runtime '%s'. " +
+            "Please recompile the artifact with a lower level or switch to a higher Java runtime.";
+    private static final String SKIP_VALIDATION_MESSAGE = "To skip this validation, set failsOnRuntimeValidation to false in the command line or pom.xml";
 
     //region Properties
 
@@ -183,7 +184,7 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
     @Getter
     @JsonProperty
     @Parameter(property = "failsOnError", defaultValue = "true")
-    protected Boolean failsOnError;
+    protected boolean failsOnError;
 
     /**
      * Deprecated, please set the authentication type in `auth`
@@ -269,8 +270,9 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
      * Boolean flag to control whether throwing exception when runtime validation failed
      */
     @JsonProperty
-    @Parameter(property = "skipRuntimeValidation", defaultValue = "true")
-    protected boolean failOnRuntimeValidationError;
+    @Getter
+    @Parameter(property = "failsOnRuntimeValidation", defaultValue = "true")
+    protected Boolean failsOnRuntimeValidation;
 
     @Component
     @JsonIgnore
@@ -644,7 +646,7 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
         }
         final AzureString errorMessage = AzureString.format(INVALID_ARTIFACT, artifact.getAbsolutePath(), artifactCompileVersion, runtimeVersion);
         if (failOnValidation) {
-            throw new AzureToolkitRuntimeException(errorMessage.getString());
+            throw new AzureToolkitRuntimeException(errorMessage.getString() + StringUtils.LF + SKIP_VALIDATION_MESSAGE);
         } else {
             AzureMessager.getMessager().warning(errorMessage);
         }

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -638,10 +638,17 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
         }
     }
 
-    public static void validateArtifactCompileVersion(final String runtimeJavaVersion, final File artifact, final boolean failOnValidation) {
-        final int runtimeVersion = Utils.getJavaMajorVersion(runtimeJavaVersion);
-        final int artifactCompileVersion = Utils.getArtifactCompileVersion(artifact);
-        if (runtimeVersion < 0 || artifactCompileVersion < 0 || artifactCompileVersion <= runtimeVersion) {
+    public static void validateArtifactCompileVersion(final String runtimeJavaVersion, final File artifact, final boolean failOnValidation) throws AzureToolkitRuntimeException {
+        final int runtimeVersion;
+        final int artifactCompileVersion;
+        try {
+            runtimeVersion = Utils.getJavaMajorVersion(runtimeJavaVersion);
+            artifactCompileVersion = Utils.getArtifactCompileVersion(artifact);
+        } catch (RuntimeException e) {
+            AzureMessager.getMessager().warning("Failed to get version of your artifact, skip artifact compatibility test");
+            return;
+        }
+        if (artifactCompileVersion <= runtimeVersion) {
             return;
         }
         final AzureString errorMessage = AzureString.format(INVALID_ARTIFACT, artifactCompileVersion, runtimeVersion);

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -184,7 +184,7 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
     @Getter
     @JsonProperty
     @Parameter(property = "failsOnError", defaultValue = "true")
-    protected boolean failsOnError;
+    protected Boolean failsOnError;
 
     /**
      * Deprecated, please set the authentication type in `auth`
@@ -646,7 +646,7 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
         }
         final AzureString errorMessage = AzureString.format(INVALID_ARTIFACT, artifactCompileVersion, runtimeVersion);
         if (failOnValidation) {
-            throw new AzureToolkitRuntimeException(errorMessage.getString() + StringUtils.LF + SKIP_VALIDATION_MESSAGE);
+            throw new AzureToolkitRuntimeException(errorMessage.getString() + System.lineSeparator() + SKIP_VALIDATION_MESSAGE);
         } else {
             AzureMessager.getMessager().warning(errorMessage);
         }

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -656,7 +656,7 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
     protected String getCompileLevel() {
         // order compile, target
         // refers https://github.com/apache/maven-compiler-plugin/blob/maven-compiler-plugin-3.11.0/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java#L1286-L1291
-        final String rawLevel = Stream.of("compile", "target").map(this::getCompilerPluginConfigurationByName)
+        final String rawLevel = Stream.of("release", "target").map(this::getCompilerPluginConfigurationByName)
                 .filter(StringUtils::isNotEmpty).findFirst().orElse(null);
         // refers https://github.com/apache/maven-compiler-plugin/blob/maven-compiler-plugin-3.11.0/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java#L1293-L1295
         return StringUtils.startsWithIgnoreCase(rawLevel, "1.") ? StringUtils.substring(rawLevel, 2) : rawLevel;

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -116,13 +116,13 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
     protected static final String SUBSCRIPTION_NOT_FOUND = "Subscription %s was not found in current account.";
     protected static final String COMPILE_LEVEL_NOT_SUPPORTED = "Your project's compile level (%s) is not compatible with any of the supported runtimes of Azure. " +
             "The supported runtimes include %s. Please reset the compile level to a compatible version in case any compatibility issues.";
-    protected static final String FAILED_TO_GET_VALID_RUNTIMES = "Failed to get valid runtime based on project compile level, fall back to all values";
+    protected static final String FAILED_TO_GET_VALID_RUNTIMES = "Failed to get valid runtime based on project's compile level, fall back to all values";
 
     private static final String AZURE_ENVIRONMENT = "azureEnvironment";
     private static final String PROXY = "proxy";
-    private static final String INVALID_ARTIFACT = "The artifact's compile level (%s) is incompatible with runtime '%s'. " +
+    private static final String INVALID_ARTIFACT = "The artifact's compile level (%s) is not compatible with runtime '%s'. " +
             "Please rebuild the artifact with a lower level or switch to a higher Java runtime.";
-    private static final String SKIP_VALIDATION_MESSAGE = "To skip this validation, set failsOnRuntimeValidationError to false in the command line or pom.xml";
+    private static final String SKIP_VALIDATION_MESSAGE = "To skip this validation, set 'failsOnRuntimeValidationError' to 'false' in the command line or pom.xml";
 
     //region Properties
 

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/AbstractAzureMojo.java
@@ -114,15 +114,15 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
     protected static final String SUBSCRIPTION_TEMPLATE = "Subscription: %s(%s)";
     protected static final String USING_AZURE_ENVIRONMENT = "Using Azure environment: %s.";
     protected static final String SUBSCRIPTION_NOT_FOUND = "Subscription %s was not found in current account.";
-    protected static final String COMPILE_LEVEL_NOT_SUPPORTED = "Your project's compile level (%s) is not compatible with any of the supported runtime versions of Azure. " +
-            "The supported runtime versions include %s. Please reset the compile level to a compatible version in case any compatibility issues and errors.";
+    protected static final String COMPILE_LEVEL_NOT_SUPPORTED = "Your project's compile level (%s) is not compatible with any of the supported runtimes of Azure. " +
+            "The supported runtimes include %s. Please reset the compile level to a compatible version in case any compatibility issues.";
     protected static final String FAILED_TO_GET_VALID_RUNTIMES = "Failed to get valid runtime based on project compile level, fall back to all values";
 
     private static final String AZURE_ENVIRONMENT = "azureEnvironment";
     private static final String PROXY = "proxy";
     private static final String INVALID_ARTIFACT = "The artifact's compile level (%s) is incompatible with runtime '%s'. " +
-            "Please recompile the artifact with a lower level or switch to a higher Java runtime.";
-    private static final String SKIP_VALIDATION_MESSAGE = "To skip this validation, set failsOnRuntimeValidation to false in the command line or pom.xml";
+            "Please rebuild the artifact with a lower level or switch to a higher Java runtime.";
+    private static final String SKIP_VALIDATION_MESSAGE = "To skip this validation, set failsOnRuntimeValidationError to false in the command line or pom.xml";
 
     //region Properties
 
@@ -271,8 +271,8 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
      */
     @JsonProperty
     @Getter
-    @Parameter(property = "failsOnRuntimeValidation", defaultValue = "true")
-    protected Boolean failsOnRuntimeValidation;
+    @Parameter(property = "failsOnRuntimeValidationError", defaultValue = "true")
+    protected Boolean failsOnRuntimeValidationError;
 
     @Component
     @JsonIgnore
@@ -644,7 +644,7 @@ public abstract class AbstractAzureMojo extends AbstractMojo {
         if (runtimeVersion < 0 || artifactCompileVersion < 0 || artifactCompileVersion <= runtimeVersion) {
             return;
         }
-        final AzureString errorMessage = AzureString.format(INVALID_ARTIFACT, artifact.getAbsolutePath(), artifactCompileVersion, runtimeVersion);
+        final AzureString errorMessage = AzureString.format(INVALID_ARTIFACT, artifactCompileVersion, runtimeVersion);
         if (failOnValidation) {
             throw new AzureToolkitRuntimeException(errorMessage.getString() + StringUtils.LF + SKIP_VALIDATION_MESSAGE);
         } else {

--- a/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/utils/MavenArtifactUtils.java
+++ b/azure-maven-plugin-lib/src/main/java/com/microsoft/azure/maven/utils/MavenArtifactUtils.java
@@ -84,7 +84,7 @@ public class MavenArtifactUtils {
         }
         final List<File> executableJars = files.stream().filter(MavenArtifactUtils::isExecutableJar).collect(Collectors.toList());
         if (executableJars.isEmpty()) {
-            throw new MojoExecutionException(ARTIFACT_NOT_SUPPORTED);
+            return null;
         }
         // Throw exception when there are multi runnable artifacts
         if (executableJars.size() > 1) {

--- a/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/DeployMojo.java
+++ b/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/DeployMojo.java
@@ -85,7 +85,7 @@ public class DeployMojo extends AbstractMojoBase {
                 .orElseThrow(() -> new AzureToolkitRuntimeException("No artifact is specified to deploy."));
         final String javaVersion = Optional.ofNullable(deploymentConfig).map(SpringCloudDeploymentConfig::getJavaVersion)
                 .map(version -> StringUtils.removeStart(version, "Java_")).orElse(StringUtils.EMPTY);
-        validateArtifactCompileVersion(javaVersion, file, getFailsOnRuntimeValidation());
+        validateArtifactCompileVersion(javaVersion, file, getFailsOnRuntimeValidationError());
         final DeploySpringCloudAppTask task = new DeploySpringCloudAppTask(appConfig, true);
 
         final List<AzureTask<?>> tasks = task.getSubTasks();

--- a/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/DeployMojo.java
+++ b/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/DeployMojo.java
@@ -85,7 +85,7 @@ public class DeployMojo extends AbstractMojoBase {
                 .orElseThrow(() -> new AzureToolkitRuntimeException("No artifact is specified to deploy."));
         final String javaVersion = Optional.ofNullable(deploymentConfig).map(SpringCloudDeploymentConfig::getJavaVersion)
                 .map(version -> StringUtils.removeStart(version, "Java_")).orElse(StringUtils.EMPTY);
-        validateArtifactCompileVersion(javaVersion, file, failOnRuntimeValidationError);
+        validateArtifactCompileVersion(javaVersion, file, getFailsOnRuntimeValidation());
         final DeploySpringCloudAppTask task = new DeploySpringCloudAppTask(appConfig, true);
 
         final List<AzureTask<?>> tasks = task.getSubTasks();

--- a/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/DeployMojo.java
+++ b/azure-spring-apps-maven-plugin/src/main/java/com/microsoft/azure/maven/springcloud/DeployMojo.java
@@ -32,6 +32,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
@@ -80,8 +81,11 @@ public class DeployMojo extends AbstractMojoBase {
         // Init spring clients, and prompt users to confirm
         final SpringCloudAppConfig appConfig = this.getConfiguration();
         final SpringCloudDeploymentConfig deploymentConfig = appConfig.getDeployment();
-        Optional.ofNullable(deploymentConfig).map(SpringCloudDeploymentConfig::getArtifact).map(IArtifact::getFile)
+        final File file = Optional.ofNullable(deploymentConfig).map(SpringCloudDeploymentConfig::getArtifact).map(IArtifact::getFile)
                 .orElseThrow(() -> new AzureToolkitRuntimeException("No artifact is specified to deploy."));
+        final String javaVersion = Optional.ofNullable(deploymentConfig).map(SpringCloudDeploymentConfig::getJavaVersion)
+                .map(version -> StringUtils.removeStart(version, "Java_")).orElse(StringUtils.EMPTY);
+        validateArtifactCompileVersion(javaVersion, file, failOnRuntimeValidationError);
         final DeploySpringCloudAppTask task = new DeploySpringCloudAppTask(appConfig, true);
 
         final List<AzureTask<?>> tasks = task.getSubTasks();

--- a/azure-spring-apps-maven-plugin/src/main/resources/MessageTemplates.yaml
+++ b/azure-spring-apps-maven-plugin/src/main/resources/MessageTemplates.yaml
@@ -87,7 +87,15 @@ property:         jvmOptions
 
 ---
 id:               configure-java-version
-promote:          "Input runtime Java version{{(schema.default) ? '(***' ~ schema.default ~ '***)' : ''}}:"
+promote:
+    header: "Runtimes:"
+    many: "Select runtime for deployment:"
+message:
+  auto_select:    "There is only one valid runtime (***{{ runtimes[0] }}***) for your project, will use it automatically."
+  select_none:    "You have not selected any runtime, 'config' will terminate."
+required:         true
+auto_select:      true
+default_index:    0
 resource:         Deployment
 property:         runtimeVersion
 

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/DeployMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/DeployMojo.java
@@ -102,7 +102,7 @@ public class DeployMojo extends AbstractWebAppMojo {
         }
         final String javaVersion = Optional.ofNullable(runtime.getJavaVersion()).map(JavaVersion::getValue).orElse(StringUtils.EMPTY);
         artifacts.stream().map(WebAppArtifact::getFile).filter(Objects::nonNull)
-                .forEach(artifact -> validateArtifactCompileVersion(javaVersion, artifact, failOnRuntimeValidationError));
+                .forEach(artifact -> validateArtifactCompileVersion(javaVersion, artifact, getFailsOnRuntimeValidation()));
     }
 
     private void mergeCommandLineConfig() {

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/DeployMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/DeployMojo.java
@@ -102,7 +102,7 @@ public class DeployMojo extends AbstractWebAppMojo {
         }
         final String javaVersion = Optional.ofNullable(runtime.getJavaVersion()).map(JavaVersion::getValue).orElse(StringUtils.EMPTY);
         artifacts.stream().map(WebAppArtifact::getFile).filter(Objects::nonNull)
-                .forEach(artifact -> validateArtifactCompileVersion(javaVersion, artifact, getFailsOnRuntimeValidation()));
+                .forEach(artifact -> validateArtifactCompileVersion(javaVersion, artifact, getFailsOnRuntimeValidationError()));
     }
 
     private void mergeCommandLineConfig() {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Validate artifact compile version during deploy
- Get default runtime based on project compile level for spring/webapp maven plugin
- Change to select runtime in spring maven plugin config goal


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
