### PR TITLE
Add security suppress message for fake credentials in telemetry test case

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/test/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemetryClientTest.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/test/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemetryClientTest.java
@@ -15,10 +15,10 @@ public class AzureTelemetryClientTest extends AzureTelemetryClient {
     @Test
     public void anonymizePersonallyIdentifiableInformation() {
         final Map<String, String> map = new HashMap<String, String>() {{
-            put("fake-password", "pwd=FAKE");
+            put("fake-password", "pwd=FAKE"); // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="fake credential for test case")]
             put("fake-email", "no-reply@example.com");
             put("fake-token", "token=FAKE");
-            put("fake-slack-token", "xoxp-FAKE");
+            put("fake-slack-token", "xoxp-FAKE"); // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="fake credential for test case")]
             put("fake-path", "/Users/username/.AzureToolkitforIntelliJ/extensions");
         }};
         AzureTelemetryClientTest.anonymizePersonallyIdentifiableInformation(map);


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Add security suppress message for fake credentials in telemetry test case



Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
