### PR TITLE
open streaming log when create failed

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/DeployFunctionAppTask.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/DeployFunctionAppTask.java
@@ -77,7 +77,7 @@ public class DeployFunctionAppTask extends AzureTask<FunctionAppBase<?, ?, ?>> {
             } catch (final Exception e) {
                 // show warning instead of exception for list triggers
                 messager.warning(FAILED_TO_LIST_TRIGGERS);
-                startStreamingLog();
+                new StreamingLogTask(target).doExecute();
             }
         }
         return target;
@@ -111,27 +111,4 @@ public class DeployFunctionAppTask extends AzureTask<FunctionAppBase<?, ?, ?>> {
         }
     }
 
-
-
-    private void startStreamingLog() {
-        if (!target.isStreamingLogSupported() || !openStreamingLogOnFailure) {
-            return;
-        }
-        messager.debug("###############STREAMING LOG BEGIN##################");
-        subscription = target.streamAllLogsAsync()
-                .doFinally((type) -> messager.debug("###############STREAMING LOG END##################"))
-                .subscribe(messager::debug);
-        try {
-            TimeUnit.MINUTES.sleep(1);
-        } catch (final Exception ignored) {
-        } finally {
-            stopStreamingLog();
-        }
-    }
-
-    private synchronized void stopStreamingLog() {
-        if (subscription != null && !subscription.isDisposed()) {
-            subscription.dispose();
-        }
-    }
 }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/StreamingLogTask.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/StreamingLogTask.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *  * Copyright (c) Microsoft Corporation. All rights reserved.
+ *  *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *
+ */
+
+package com.microsoft.azure.toolkit.lib.appservice.task;
+
+import com.microsoft.azure.toolkit.lib.appservice.AppServiceAppBase;
+import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
+import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
+import com.microsoft.azure.toolkit.lib.common.messager.IAzureMessager;
+import com.microsoft.azure.toolkit.lib.common.task.AzureTask;
+import reactor.core.Disposable;
+
+import java.util.concurrent.TimeUnit;
+
+public class StreamingLogTask extends AzureTask<AppServiceAppBase<?, ?, ?>> {
+    private final AppServiceAppBase<?, ?, ?> webApp;
+    private Disposable subscription;
+
+    public StreamingLogTask(AppServiceAppBase<?, ?, ?> webApp) {
+        this.webApp = webApp;
+    }
+
+    @Override
+    protected AppServiceAppBase<?, ?, ?> doExecute() {
+        startStreamingLog();
+        return this.webApp;
+    }
+
+    private void startStreamingLog() {
+        if (!webApp.isStreamingLogSupported()) {
+            return;
+        }
+        final IAzureMessager messager = AzureMessager.getMessager();
+        messager.info(AzureString.format("Opening streaming log of app({0})...", webApp.getName()));
+        messager.debug("###############STREAMING LOG BEGIN##################");
+        this.subscription = this.webApp.streamAllLogsAsync()
+                .doFinally((type) -> messager.debug("###############STREAMING LOG END##################"))
+                .subscribe(messager::debug);
+        try {
+            TimeUnit.MINUTES.sleep(1);
+        } catch (final Exception ignored) {
+        } finally {
+            stopStreamingLog();
+        }
+    }
+
+    private synchronized void stopStreamingLog() {
+        if (subscription != null && !subscription.isDisposed()) {
+            subscription.dispose();
+        }
+    }
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
for web app & function app, try to open streaming log when create failed.


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
