### PR TITLE
Support azurite emulator in storage toolkit lib

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/AzureConfiguration.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/AzureConfiguration.java
@@ -46,6 +46,10 @@ public class AzureConfiguration {
     private boolean authPersistenceEnabled = true;
     private String eventHubsConsumerGroup = "$Default";
 
+    private String azuritePath;
+    private String azuriteWorkspace;
+    private Boolean enableLeaseMode = false;
+
     public void setProxyInfo(ProxyInfo proxy) {
         this.setProxySource(proxy.getSource());
         this.setHttpProxyHost(proxy.getHost());

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -103,7 +103,9 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
 
     public boolean exists() {
         final P parent = this.getParent();
-        if (StringUtils.equals(this.statusRef.get(), Status.DELETED)) {
+        if (this.isEmulatorResource()) {
+            return true;
+        } else if (StringUtils.equals(this.statusRef.get(), Status.DELETED)) {
             return false;
         } else if (parent == AzResource.NONE || this instanceof AbstractAzServiceSubscription || this instanceof ResourceGroup) {
             return this.remoteOptional().isPresent();
@@ -137,7 +139,9 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
     @Nullable
     public final R getRemote(boolean... sync) {
         log.debug("[{}:{}]:getRemote()", this.module.getName(), this.getName());
-        Azure.az(IAzureAccount.class).account();
+        if (!isEmulatorResource()) {
+            Azure.az(IAzureAccount.class).account();
+        }
         if (this.isDraftForCreating()) {
             log.debug("[{}:{}]:getRemote->this.isDraftForCreating()=true", this.module.getName(), this.getName());
             return null;

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -483,4 +483,8 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
     public boolean isEmulatorResource() {
         return this.getParent() instanceof AbstractAzResource && ((AbstractAzResource<?, ?, ?>) this.getParent()).isEmulatorResource();
     }
+
+    public boolean isAuthRequired() {
+        return !isEmulatorResource();
+    }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -475,4 +475,8 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
     public boolean isDraftForUpdating() {
         return this instanceof Draft && Objects.nonNull(((Draft<?, ?>) this).getOrigin());
     }
+
+    public boolean isEmulatorResource() {
+        return this.getParent() instanceof AbstractAzResource && ((AbstractAzResource<?, ?, ?>) this.getParent()).isEmulatorResource();
+    }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
@@ -115,7 +115,9 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
     @Override
     public List<T> list() { // getResources
         log.debug("[{}]:list()", this.name);
-        Azure.az(IAzureAccount.class).account();
+        if (requireAuthentication()) {
+            Azure.az(IAzureAccount.class).account();
+        }
         if (this.parent instanceof AbstractAzResource && ((AbstractAzResource<?, ?, ?>) this.parent).isDraftForCreating()) {
             log.debug("[{}]:list->parent.isDraftForCreating()=true", this.name);
             return Collections.emptyList();
@@ -133,6 +135,10 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
         }
         log.debug("[{}]:list->this.resources.values()", this.name);
         return this.resources.values().stream().filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
+    }
+
+    protected boolean requireAuthentication() {
+        return !(this.getParent() instanceof AbstractAzResource) || !((AbstractAzResource<?, ?, ?>) this.getParent()).isEmulatorResource();
     }
 
     private void reloadResources() {
@@ -175,8 +181,6 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
                 this.addResources(loadedResources);
                 fireEvents.debounce();
             }
-        } catch (Exception e) {
-            throw e;
         } finally {
             this.lock.unlock();
         }
@@ -254,7 +258,9 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
             log.debug("[{}]:get->parent.isDraftForCreating()=true||isBlank(name)=true", this.name);
             return null;
         }
-        Azure.az(IAzureAccount.class).account();
+        if (requireAuthentication()) {
+            Azure.az(IAzureAccount.class).account();
+        }
         final String id = this.toResourceId(name, resourceGroup).toLowerCase();
         if (!this.resources.containsKey(id)) {
             R remote = null;

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
@@ -115,7 +115,7 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
     @Override
     public List<T> list() { // getResources
         log.debug("[{}]:list()", this.name);
-        if (requireAuthentication()) {
+        if (isAuthRequired()) {
             Azure.az(IAzureAccount.class).account();
         }
         if (this.parent instanceof AbstractAzResource && ((AbstractAzResource<?, ?, ?>) this.parent).isDraftForCreating()) {
@@ -137,8 +137,8 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
         return this.resources.values().stream().filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
     }
 
-    protected boolean requireAuthentication() {
-        return !(this.getParent() instanceof AbstractAzResource) || !((AbstractAzResource<?, ?, ?>) this.getParent()).isEmulatorResource();
+    public boolean isEmulatorResource() {
+        return this.getParent() instanceof AbstractAzResource && ((AbstractAzResource<?, ?, ?>) this.getParent()).isEmulatorResource();
     }
 
     private void reloadResources() {
@@ -258,7 +258,7 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
             log.debug("[{}]:get->parent.isDraftForCreating()=true||isBlank(name)=true", this.name);
             return null;
         }
-        if (requireAuthentication()) {
+        if (isAuthRequired()) {
             Azure.az(IAzureAccount.class).account();
         }
         final String id = this.toResourceId(name, resourceGroup).toLowerCase();
@@ -616,5 +616,9 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
 
     public static int getPageSize() {
         return Azure.az().config().getPageSize();
+    }
+
+    public boolean isAuthRequired() {
+        return !isEmulatorResource();
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AzResource.java
@@ -262,6 +262,11 @@ public interface AzResource extends Refreshable {
         public int hashCode() {
             return this.getClass().hashCode();
         }
+
+        @Override
+        public boolean isEmulatorResource() {
+            return false;
+        }
     }
 
     @SuppressWarnings("unused")

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/Subscription.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/Subscription.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.toolkit.lib.common.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,9 +19,12 @@ import javax.annotation.Nonnull;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Subscription {
+    public static final Subscription NONE = Subscription.builder().name(AzResource.NONE.getName())
+        .id("00000000-0000-0000-0000-000000000000").tenantId("00000000-0000-0000-0000-000000000000").selected(true).build();
     @Nonnull
     @JsonProperty
     @EqualsAndHashCode.Include

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/utils/Utils.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/utils/Utils.java
@@ -25,6 +25,8 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.math.BigInteger;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
@@ -58,6 +60,7 @@ public class Utils {
     private static final String SPRING_BOOT_CLASSES = "Spring-Boot-Classes";
     private static final String START_CLASS = "Start-Class";
     private static final String DEFAULT_SPRING_BOOT_CLASSES = "BOOT-INF/classes/";
+    public static final int DEFAULT_TIMEOUT = 10000;
 
     public static String generateRandomResourceName(@Nonnull final String prefix, final int maxLength) {
         final String name = String.format("%s-%s", prefix, Utils.getTimestamp());
@@ -262,5 +265,20 @@ public class Utils {
             return null;
         }
         return t;
+    }
+
+    public static boolean isUrlAccessible(@Nonnull final String url, @Nonnull final Integer... validResponseCodes)  {
+        HttpURLConnection.setFollowRedirects(false);
+        HttpURLConnection con = null;
+        try {
+            con = (HttpURLConnection) new URL(url).openConnection();
+            con.setRequestMethod("HEAD");
+            con.setReadTimeout(DEFAULT_TIMEOUT);
+            return ArrayUtils.contains(validResponseCodes, con.getResponseCode());
+        } catch (IOException ex) {
+            return false;
+        } finally {
+            Optional.ofNullable(con).ifPresent(HttpURLConnection::disconnect);
+        }
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/AzureStorageAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/AzureStorageAccount.java
@@ -13,8 +13,8 @@ import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.AzureConfiguration;
 import com.microsoft.azure.toolkit.lib.auth.Account;
 import com.microsoft.azure.toolkit.lib.auth.AzureAccount;
-import com.microsoft.azure.toolkit.lib.common.model.AbstractAzServiceSubscription;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzService;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractAzServiceSubscription;
 import com.microsoft.azure.toolkit.lib.storage.model.Kind;
 import com.microsoft.azure.toolkit.lib.storage.model.Performance;
 import com.microsoft.azure.toolkit.lib.storage.model.Redundancy;
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -51,7 +52,13 @@ public class AzureStorageAccount extends AbstractAzService<StorageServiceSubscri
 
     @Nonnull
     public List<StorageAccount> accounts() {
-        return this.list().stream().flatMap(m -> m.storageAccounts().list().stream()).collect(Collectors.toList());
+        final List<StorageAccount> result = new ArrayList<>();
+        result.add(AzuriteStorageAccount.AZURITE_STORAGE_ACCOUNT);
+        if (Azure.az(AzureAccount.class).isLoggedIn()) {
+            final List<StorageAccount> collect = this.list().stream().flatMap(m -> m.storageAccounts().list().stream()).collect(Collectors.toList());
+            result.addAll(collect);
+        }
+        return result;
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/AzureStorageAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/AzureStorageAccount.java
@@ -52,11 +52,17 @@ public class AzureStorageAccount extends AbstractAzService<StorageServiceSubscri
 
     @Nonnull
     public List<StorageAccount> accounts() {
+        return accounts(false);
+    }
+
+    @Nonnull
+    public List<StorageAccount> accounts(boolean includeLocalEmulator) {
         final List<StorageAccount> result = new ArrayList<>();
-        result.add(AzuriteStorageAccount.AZURITE_STORAGE_ACCOUNT);
+        if (includeLocalEmulator) {
+            result.add(AzuriteStorageAccount.AZURITE_STORAGE_ACCOUNT);
+        }
         if (Azure.az(AzureAccount.class).isLoggedIn()) {
-            final List<StorageAccount> collect = this.list().stream().flatMap(m -> m.storageAccounts().list().stream()).collect(Collectors.toList());
-            result.addAll(collect);
+            this.list().stream().flatMap(m -> m.storageAccounts().list().stream()).forEachOrdered(result::add);
         }
         return result;
     }

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/AzureStorageAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/AzureStorageAccount.java
@@ -111,4 +111,9 @@ public class AzureStorageAccount extends AbstractAzService<StorageServiceSubscri
     public String getResourceTypeName() {
         return "Storage accounts";
     }
+
+    @Override
+    public boolean isAuthRequired() {
+        return false; // As storage supports emulator resource, we don't need to login to list storage accounts
+    }
 }

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/AzuriteStorageAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/AzuriteStorageAccount.java
@@ -26,6 +26,7 @@ import com.microsoft.azure.toolkit.lib.storage.model.AccessTier;
 import com.microsoft.azure.toolkit.lib.storage.model.Kind;
 import com.microsoft.azure.toolkit.lib.storage.model.Performance;
 import com.microsoft.azure.toolkit.lib.storage.model.Redundancy;
+import org.apache.commons.collections4.CollectionUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
@@ -35,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class AzuriteStorageAccount extends StorageAccount {
@@ -57,10 +59,30 @@ public class AzuriteStorageAccount extends StorageAccount {
         super(NAME, AZURITE, module);
     }
 
+    @Override
+    protected void updateAdditionalProperties(@Nullable com.azure.resourcemanager.storage.models.StorageAccount newRemote, @Nullable com.azure.resourcemanager.storage.models.StorageAccount oldRemote) {
+        this.subModules.clear();
+        if (Objects.nonNull(newRemote)) {
+            if (this.canHaveBlobs()) {
+                this.subModules.add(this.blobContainerModule);
+            }
+            if (this.canHaveShares()) {
+                this.subModules.add(this.shareModule);
+            }
+            if (this.canHaveQueues()) {
+                this.subModules.add(this.queueModule);
+            }
+            if (this.canHaveTables()) {
+                this.subModules.add(this.tableModule);
+            }
+        }
+        super.updateAdditionalProperties(newRemote, oldRemote);
+    }
+
     @Nonnull
     @Override
     public String getStatus(boolean immediately) {
-        final boolean isAzuriteAccessible = canHaveBlobs() || canHaveQueues() || canHaveTables();
+        final boolean isAzuriteAccessible = CollectionUtils.isNotEmpty(this.subModules);
         return isAzuriteAccessible ? "Running" : "Stopped";
     }
 

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/AzuriteStorageAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/AzuriteStorageAccount.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.storage;
+
+import com.azure.core.util.paging.ContinuablePage;
+import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
+import com.microsoft.azure.toolkit.lib.common.model.Region;
+import com.microsoft.azure.toolkit.lib.common.utils.Utils;
+import com.microsoft.azure.toolkit.lib.storage.model.AccessTier;
+import com.microsoft.azure.toolkit.lib.storage.model.Kind;
+import com.microsoft.azure.toolkit.lib.storage.model.Performance;
+import com.microsoft.azure.toolkit.lib.storage.model.Redundancy;
+import org.apache.http.HttpStatus;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+public class AzuriteStorageAccount extends StorageAccount {
+
+    public static final String AZURITE_RESOURCE_ID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurite/providers/Microsoft.Storage/storageAccounts/azurite";
+    public static final String AZURITE = "Azurite";
+    public static final String NAME = "Storage Emulator (Azurite)";
+    public static final AzuriteStorageAccount AZURITE_STORAGE_ACCOUNT = new AzuriteStorageAccount(AzuriteStorageAccountModule.AZURITE_STORAGE_ACCOUNT_MODULE);
+    // Refers https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite
+    public static final String AZURITE_CONNECTION_STRING = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="public credential for azurite, refers https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite")]
+    public static final String AZURITE_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="public credential for azurite, refers https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite")]
+    private static final String CONNECTION_NAME = "devstoreaccount1";
+    // todo: @hanli support customized port for azurite
+    private static final String BLOBS_URI = "http://127.0.0.1:10000/devstoreaccount1";
+    private static final String QUEUES_URI = "http://127.0.0.1:10001/devstoreaccount1";
+    private static final String TABLES_URI = "http://127.0.0.1:10002/devstoreaccount1";
+
+    protected AzuriteStorageAccount(@Nonnull StorageAccountModule module) {
+        super(NAME, AZURITE, module);
+    }
+
+    @Nonnull
+    @Override
+    public String getStatus(boolean immediately) {
+        final boolean isAzuriteAccessible = canHaveBlobs() || canHaveQueues() || canHaveTables();
+        return isAzuriteAccessible ? "Running" : "Stopped";
+    }
+
+    @Nonnull
+    @Override
+    public String loadStatus(@Nullable com.azure.resourcemanager.storage.models.StorageAccount remote) {
+        return getStatus(false);
+    }
+
+    @Override
+    public boolean exists() {
+        return true;
+    }
+
+    @Nonnull
+    @Override
+    public String getId() {
+        return AZURITE_RESOURCE_ID;
+    }
+
+    @Nonnull
+    @Override
+    public String getConnectionString() {
+        return AZURITE_CONNECTION_STRING;
+    }
+
+    @Nonnull
+    @Override
+    public String getKey() {
+        return AZURITE_KEY;
+    }
+
+    @Nullable
+    @Override
+    public Region getRegion() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Performance getPerformance() {
+        return null;
+    }
+
+    public boolean canHaveQueues() {
+        return isAzuriteEndpointAccessible(QUEUES_URI);
+    }
+
+    public boolean canHaveTables() {
+        return isAzuriteEndpointAccessible(TABLES_URI);
+    }
+
+    public boolean canHaveBlobs() {
+        return isAzuriteEndpointAccessible(BLOBS_URI);
+    }
+
+    public boolean canHaveShares() {
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public Redundancy getRedundancy() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Kind getKind() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public AccessTier getAccessTier() {
+        return null;
+    }
+
+    @Override
+    public boolean isEmulatorResource() {
+        return true;
+    }
+
+    private static boolean isAzuriteEndpointAccessible(@Nonnull final String endpoint) {
+        return Utils.isUrlAccessible(endpoint, HttpStatus.SC_OK, HttpStatus.SC_ACCEPTED, HttpStatus.SC_BAD_REQUEST);
+    }
+
+    static class AzuriteStorageAccountModule extends StorageAccountModule {
+        private static final AzuriteStorageAccountModule AZURITE_STORAGE_ACCOUNT_MODULE = new AzuriteStorageAccountModule(new StorageServiceSubscription("", Azure.az(AzureStorageAccount.class)));
+
+        public AzuriteStorageAccountModule(@Nonnull StorageServiceSubscription parent) {
+            super(parent);
+        }
+
+        @Nonnull
+        @Override
+        public List<StorageAccount> list() {
+            return Arrays.asList(AZURITE_STORAGE_ACCOUNT);
+        }
+
+        @Nonnull
+        @Override
+        protected Iterator<? extends ContinuablePage<String, com.azure.resourcemanager.storage.models.StorageAccount>> loadResourcePagesFromAzure() {
+            return Collections.emptyIterator();
+        }
+
+        @Nullable
+        @Override
+        protected com.azure.resourcemanager.storage.models.StorageAccount loadResourceFromAzure(@Nonnull String name, @org.jetbrains.annotations.Nullable String resourceGroup) {
+            return null;
+        }
+
+        @Nonnull
+        @Override
+        protected StorageAccount newResource(@Nonnull com.azure.resourcemanager.storage.models.StorageAccount storageAccount) {
+            throw new AzureToolkitRuntimeException("not supported");
+        }
+
+        @Nonnull
+        @Override
+        protected StorageAccount newResource(@Nonnull String name, @Nullable String resourceGroupName) {
+            throw new AzureToolkitRuntimeException("not supported");
+        }
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/AzuriteStorageAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/AzuriteStorageAccount.java
@@ -21,10 +21,12 @@ import com.azure.storage.queue.QueueServiceClientBuilder;
 import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
+import com.microsoft.azure.toolkit.lib.common.model.Subscription;
 import com.microsoft.azure.toolkit.lib.storage.model.AccessTier;
 import com.microsoft.azure.toolkit.lib.storage.model.Kind;
 import com.microsoft.azure.toolkit.lib.storage.model.Performance;
 import com.microsoft.azure.toolkit.lib.storage.model.Redundancy;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -160,6 +162,12 @@ public class AzuriteStorageAccount extends StorageAccount {
     @Override
     public boolean isEmulatorResource() {
         return true;
+    }
+
+    @NotNull
+    @Override
+    public Subscription getSubscription() {
+        return Subscription.NONE;
     }
 
     static class AzuriteStorageAccountModule extends StorageAccountModule {

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/AzuriteStorageAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/AzuriteStorageAccount.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 public class AzuriteStorageAccount extends StorageAccount {
 
@@ -63,15 +64,16 @@ public class AzuriteStorageAccount extends StorageAccount {
         return isAzuriteAccessible ? "Running" : "Stopped";
     }
 
+    @Override
+    public void refresh() {
+        Optional.ofNullable(this.subModules).ifPresent(List::clear); // clear cache for sub modules
+        super.refresh();
+    }
+
     @Nonnull
     @Override
     public String loadStatus(@Nullable com.azure.resourcemanager.storage.models.StorageAccount remote) {
         return getStatus(false);
-    }
-
-    @Override
-    public boolean exists() {
-        return true;
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageAccount.java
@@ -35,10 +35,10 @@ import java.util.Objects;
 public class StorageAccount extends AbstractAzResource<StorageAccount, StorageServiceSubscription, com.azure.resourcemanager.storage.models.StorageAccount>
     implements Deletable {
 
-    private final BlobContainerModule blobContainerModule;
-    private final ShareModule shareModule;
-    private final QueueModule queueModule;
-    private final TableModule tableModule;
+    protected final BlobContainerModule blobContainerModule;
+    protected final ShareModule shareModule;
+    protected final QueueModule queueModule;
+    protected final TableModule tableModule;
     protected final List<AbstractAzResourceModule<?, ?, ?>> subModules = new ArrayList<>();
 
     protected StorageAccount(@Nonnull String name, @Nonnull String resourceGroupName, @Nonnull StorageAccountModule module) {

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageAccount.java
@@ -94,12 +94,12 @@ public class StorageAccount extends AbstractAzResource<StorageAccount, StorageSe
     public String loadStatus(@Nonnull com.azure.resourcemanager.storage.models.StorageAccount remote) {
         return remote.innerModel().provisioningState().toString();
     }
-
+    
     @Nonnull
     public String getConnectionString() {
         // see https://github.com/Azure/azure-cli/blob/ac3b190d4d/src/azure-cli/azure/cli/command_modules/storage/operations/account.py#L232
         final AzureEnvironment environment = Azure.az(AzureCloud.class).get();
-        return ResourceManagerUtils.getStorageConnectionString(this.name(), getKey(), environment);
+        return ResourceManagerUtils.getStorageConnectionString(this.getName(), getKey(), environment);
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageAccount.java
@@ -39,7 +39,7 @@ public class StorageAccount extends AbstractAzResource<StorageAccount, StorageSe
     private final ShareModule shareModule;
     private final QueueModule queueModule;
     private final TableModule tableModule;
-    private final List<AbstractAzResourceModule<?, ?, ?>> subModules = new ArrayList<>();
+    protected final List<AbstractAzResourceModule<?, ?, ?>> subModules = new ArrayList<>();
 
     protected StorageAccount(@Nonnull String name, @Nonnull String resourceGroupName, @Nonnull StorageAccountModule module) {
         super(name, resourceGroupName, module);

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/queue/QueueModule.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/queue/QueueModule.java
@@ -5,11 +5,13 @@
 
 package com.microsoft.azure.toolkit.lib.storage.queue;
 
+import com.azure.core.util.Context;
 import com.azure.core.util.paging.ContinuablePage;
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import com.azure.storage.queue.QueueClient;
 import com.azure.storage.queue.QueueServiceClient;
 import com.azure.storage.queue.QueueServiceClientBuilder;
+import com.azure.storage.queue.models.QueuesSegmentOptions;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.page.ItemPage;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
@@ -53,7 +55,7 @@ public class QueueModule extends AbstractAzResourceModule<Queue, StorageAccount,
             return Collections.emptyIterator();
         }
         final QueueServiceClient client = this.getQueueServiceClient();
-        return Objects.requireNonNull(client).listQueues().streamByPage(getPageSize())
+        return Objects.requireNonNull(client).listQueues(new QueuesSegmentOptions().setIncludeMetadata(true),null, Context.NONE).streamByPage(getPageSize())
             .map(p -> new ItemPage<>(p.getValue().stream().map(s -> client.getQueueClient(s.getName()))))
             .iterator();
     }
@@ -65,7 +67,7 @@ public class QueueModule extends AbstractAzResourceModule<Queue, StorageAccount,
             return null;
         }
         final QueueServiceClient client = this.getQueueServiceClient();
-        Stream<QueueClient> resources = Objects.requireNonNull(client).listQueues().stream().map(s -> client.getQueueClient(s.getName()));
+        Stream<QueueClient> resources = Objects.requireNonNull(client).listQueues(new QueuesSegmentOptions().setIncludeMetadata(true),null, Context.NONE).stream().map(s -> client.getQueueClient(s.getName()));
         return resources.filter(c -> c.getQueueName().equals(name)).findAny().orElse(null);
     }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Add `AzuriteStorageAccount` to support local storage emulator Azurite


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
