### PR TITLE
Extract emulator interface from AbstractAzResource/Module

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResource.java
@@ -103,9 +103,7 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
 
     public boolean exists() {
         final P parent = this.getParent();
-        if (this.isEmulatorResource()) {
-            return true;
-        } else if (StringUtils.equals(this.statusRef.get(), Status.DELETED)) {
+        if (StringUtils.equals(this.statusRef.get(), Status.DELETED)) {
             return false;
         } else if (parent == AzResource.NONE || this instanceof AbstractAzServiceSubscription || this instanceof ResourceGroup) {
             return this.remoteOptional().isPresent();
@@ -139,7 +137,7 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
     @Nullable
     public final R getRemote(boolean... sync) {
         log.debug("[{}:{}]:getRemote()", this.module.getName(), this.getName());
-        if (!isEmulatorResource()) {
+        if (isAuthRequired()) {
             Azure.az(IAzureAccount.class).account();
         }
         if (this.isDraftForCreating()) {
@@ -480,11 +478,7 @@ public abstract class AbstractAzResource<T extends AbstractAzResource<T, P, R>, 
         return this instanceof Draft && Objects.nonNull(((Draft<?, ?>) this).getOrigin());
     }
 
-    public boolean isEmulatorResource() {
-        return this.getParent() instanceof AbstractAzResource && ((AbstractAzResource<?, ?, ?>) this.getParent()).isEmulatorResource();
-    }
-
-    public boolean isAuthRequired() {
-        return !isEmulatorResource();
+    protected boolean isAuthRequired() {
+        return true;
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzResourceModule.java
@@ -137,10 +137,6 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
         return this.resources.values().stream().filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
     }
 
-    public boolean isEmulatorResource() {
-        return this.getParent() instanceof AbstractAzResource && ((AbstractAzResource<?, ?, ?>) this.getParent()).isEmulatorResource();
-    }
-
     private void reloadResources() {
         log.debug("[{}]:reloadResources()", this.name);
         this.syncTimeRef.set(0);
@@ -618,7 +614,7 @@ public abstract class AbstractAzResourceModule<T extends AbstractAzResource<T, P
         return Azure.az().config().getPageSize();
     }
 
-    public boolean isAuthRequired() {
-        return !isEmulatorResource();
+    protected boolean isAuthRequired() {
+        return true;
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractEmulatableAzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractEmulatableAzResource.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+package com.microsoft.azure.toolkit.lib.common.model;
+
+
+import javax.annotation.Nonnull;
+
+public abstract class AbstractEmulatableAzResource <T extends AbstractEmulatableAzResource<T, P, R>, P extends AzResource, R> extends AbstractAzResource<T, P, R> implements Emulatable {
+
+    protected AbstractEmulatableAzResource(@Nonnull String name, @Nonnull String resourceGroupName, @Nonnull AbstractAzResourceModule<T, P, R> module) {
+        super(name, resourceGroupName, module);
+    }
+
+    @Override
+    public boolean exists() {
+        return this.isEmulatorResource() ? this.getParent().exists() && this.remoteOptional().isPresent() : super.exists();
+    }
+
+    protected AbstractEmulatableAzResource(@Nonnull String name, @Nonnull AbstractAzResourceModule<T, P, R> module) {
+        super(name, module);
+    }
+
+    protected AbstractEmulatableAzResource(@Nonnull AbstractAzResource<T, P, R> origin) {
+        super(origin);
+    }
+
+    protected boolean isAuthRequired() {
+        return !isEmulatorResource();
+    }
+
+    @Override
+    public boolean isEmulatorResource() {
+        return this.getParent() instanceof Emulatable && ((Emulatable) this.getParent()).isEmulatorResource();
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractEmulatableAzResourceModule.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractEmulatableAzResourceModule.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+package com.microsoft.azure.toolkit.lib.common.model;
+
+import javax.annotation.Nonnull;
+
+public abstract class AbstractEmulatableAzResourceModule<T extends AbstractEmulatableAzResource<T, P, R>, P extends AzResource, R>
+    extends AbstractAzResourceModule<T, P, R> implements Emulatable {
+
+    public AbstractEmulatableAzResourceModule(@Nonnull String name, @Nonnull P parent) {
+        super(name, parent);
+    }
+
+    @Override
+    protected boolean isAuthRequired() {
+        return !isEmulatorResource();
+    }
+
+    @Override
+    public boolean isEmulatorResource() {
+        return this.getParent() instanceof Emulatable && ((Emulatable) this.getParent()).isEmulatorResource();
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AzResource.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AzResource.java
@@ -262,11 +262,6 @@ public interface AzResource extends Refreshable {
         public int hashCode() {
             return this.getClass().hashCode();
         }
-
-        @Override
-        public boolean isEmulatorResource() {
-            return false;
-        }
     }
 
     @SuppressWarnings("unused")

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/Emulatable.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/Emulatable.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.common.model;
+
+public interface Emulatable {
+    boolean isEmulatorResource();
+}

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageAccount.java
@@ -10,8 +10,8 @@ import com.azure.resourcemanager.resources.fluentcore.utils.ResourceManagerUtils
 import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.auth.AzureCloud;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
-import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractEmulatableAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
 import com.microsoft.azure.toolkit.lib.storage.blob.BlobContainerModule;
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Objects;
 
 @Getter
-public class StorageAccount extends AbstractAzResource<StorageAccount, StorageServiceSubscription, com.azure.resourcemanager.storage.models.StorageAccount>
+public class StorageAccount extends AbstractEmulatableAzResource<StorageAccount, StorageServiceSubscription, com.azure.resourcemanager.storage.models.StorageAccount>
     implements Deletable {
 
     protected final BlobContainerModule blobContainerModule;
@@ -87,6 +87,11 @@ public class StorageAccount extends AbstractAzResource<StorageAccount, StorageSe
             this.subModules.add(this.tableModule);
         }
         return this.subModules;
+    }
+
+    @Override
+    public boolean exists() {
+        return true;
     }
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageAccountModule.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/StorageAccountModule.java
@@ -8,7 +8,6 @@ package com.microsoft.azure.toolkit.lib.storage;
 import com.azure.resourcemanager.storage.StorageManager;
 import com.azure.resourcemanager.storage.models.StorageAccounts;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
-import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/blob/BlobContainer.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/blob/BlobContainer.java
@@ -8,8 +8,8 @@ package com.microsoft.azure.toolkit.lib.storage.blob;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.models.BlobContainerProperties;
 import com.azure.storage.blob.specialized.BlobClientBase;
-import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractEmulatableAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
 import com.microsoft.azure.toolkit.lib.storage.StorageAccount;
 import lombok.Getter;
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Getter
-public class BlobContainer extends AbstractAzResource<BlobContainer, StorageAccount, BlobContainerClient>
+public class BlobContainer extends AbstractEmulatableAzResource<BlobContainer, StorageAccount, BlobContainerClient>
     implements Deletable, IBlobFile {
 
     private final BlobFileModule subFileModule;

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/blob/BlobContainerModule.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/blob/BlobContainerModule.java
@@ -10,7 +10,7 @@ import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
-import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractEmulatableAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.page.ItemPage;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import com.microsoft.azure.toolkit.lib.storage.StorageAccount;
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 
-public class BlobContainerModule extends AbstractAzResourceModule<BlobContainer, StorageAccount, BlobContainerClient> {
+public class BlobContainerModule extends AbstractEmulatableAzResourceModule<BlobContainer, StorageAccount, BlobContainerClient> {
 
     public static final String NAME = "Azure.BlobContainer";
     private BlobServiceClient client;

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/blob/BlobFile.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/blob/BlobFile.java
@@ -9,8 +9,8 @@ import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.models.BlobItemProperties;
 import com.azure.storage.blob.specialized.BlobClientBase;
-import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractEmulatableAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
 import lombok.Getter;
 import org.apache.commons.lang3.BooleanUtils;
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Getter
-public class BlobFile extends AbstractAzResource<BlobFile, IBlobFile, BlobItem> implements Deletable, IBlobFile {
+public class BlobFile extends AbstractEmulatableAzResource<BlobFile, IBlobFile, BlobItem> implements Deletable, IBlobFile {
     private final BlobFileModule subFileModule;
 
     protected BlobFile(@Nonnull String name, @Nonnull BlobFileModule module) {

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/blob/BlobFileModule.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/blob/BlobFileModule.java
@@ -10,7 +10,7 @@ import com.azure.core.util.paging.ContinuablePage;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.specialized.BlobClientBase;
-import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractEmulatableAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import org.apache.commons.lang3.BooleanUtils;
@@ -24,7 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-public class BlobFileModule extends AbstractAzResourceModule<BlobFile, IBlobFile, BlobItem> {
+public class BlobFileModule extends AbstractEmulatableAzResourceModule<BlobFile, IBlobFile, BlobItem> {
 
     public static final String NAME = "file";
 

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/queue/Queue.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/queue/Queue.java
@@ -6,8 +6,8 @@
 package com.microsoft.azure.toolkit.lib.storage.queue;
 
 import com.azure.storage.queue.QueueClient;
-import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractEmulatableAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
 import com.microsoft.azure.toolkit.lib.storage.StorageAccount;
 
@@ -15,7 +15,7 @@ import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
-public class Queue extends AbstractAzResource<Queue, StorageAccount, QueueClient>
+public class Queue extends AbstractEmulatableAzResource<Queue, StorageAccount, QueueClient>
     implements Deletable {
 
     protected Queue(@Nonnull String name, @Nonnull QueueModule module) {

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/queue/QueueModule.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/queue/QueueModule.java
@@ -12,7 +12,7 @@ import com.azure.storage.queue.QueueClient;
 import com.azure.storage.queue.QueueServiceClient;
 import com.azure.storage.queue.QueueServiceClientBuilder;
 import com.azure.storage.queue.models.QueuesSegmentOptions;
-import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractEmulatableAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.page.ItemPage;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import com.microsoft.azure.toolkit.lib.storage.StorageAccount;
@@ -24,7 +24,7 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-public class QueueModule extends AbstractAzResourceModule<Queue, StorageAccount, QueueClient> {
+public class QueueModule extends AbstractEmulatableAzResourceModule<Queue, StorageAccount, QueueClient> {
 
     public static final String NAME = "Azure.Queue";
     private QueueServiceClient client;

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/share/Share.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/share/Share.java
@@ -9,8 +9,8 @@ import com.azure.storage.file.share.ShareClient;
 import com.azure.storage.file.share.ShareDirectoryClient;
 import com.azure.storage.file.share.ShareServiceClient;
 import com.azure.storage.file.share.models.ShareProperties;
-import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractEmulatableAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
 import com.microsoft.azure.toolkit.lib.storage.StorageAccount;
 import lombok.Getter;
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Getter
-public class Share extends AbstractAzResource<Share, StorageAccount, ShareClient>
+public class Share extends AbstractEmulatableAzResource<Share, StorageAccount, ShareClient>
     implements Deletable, IShareFile {
 
     private final ShareFileModule subFileModule;

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/share/ShareFile.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/share/ShareFile.java
@@ -8,8 +8,8 @@ package com.microsoft.azure.toolkit.lib.storage.share;
 import com.azure.storage.file.share.ShareDirectoryClient;
 import com.azure.storage.file.share.models.ShareFileItem;
 import com.azure.storage.file.share.models.ShareFileItemProperties;
-import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractEmulatableAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
 import lombok.Getter;
 
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Objects;
 
 @Getter
-public class ShareFile extends AbstractAzResource<ShareFile, IShareFile, ShareFileItem> implements Deletable, IShareFile {
+public class ShareFile extends AbstractEmulatableAzResource<ShareFile, IShareFile, ShareFileItem> implements Deletable, IShareFile {
     private final ShareFileModule subFileModule;
 
     protected ShareFile(@Nonnull String name, @Nonnull ShareFileModule module) {

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/share/ShareFileModule.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/share/ShareFileModule.java
@@ -9,7 +9,7 @@ import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.util.paging.ContinuablePage;
 import com.azure.storage.file.share.ShareDirectoryClient;
 import com.azure.storage.file.share.models.ShareFileItem;
-import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractEmulatableAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.AzResource;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 
@@ -21,7 +21,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-public class ShareFileModule extends AbstractAzResourceModule<ShareFile, IShareFile, ShareFileItem> {
+public class ShareFileModule extends AbstractEmulatableAzResourceModule<ShareFile, IShareFile, ShareFileItem> {
 
     public static final String NAME = "file";
 

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/share/ShareModule.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/share/ShareModule.java
@@ -10,7 +10,7 @@ import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import com.azure.storage.file.share.ShareClient;
 import com.azure.storage.file.share.ShareServiceClient;
 import com.azure.storage.file.share.ShareServiceClientBuilder;
-import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractEmulatableAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.page.ItemPage;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import com.microsoft.azure.toolkit.lib.storage.StorageAccount;
@@ -22,7 +22,7 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-public class ShareModule extends AbstractAzResourceModule<Share, StorageAccount, ShareClient> {
+public class ShareModule extends AbstractEmulatableAzResourceModule<Share, StorageAccount, ShareClient> {
 
     public static final String NAME = "Azure.FileShare";
     private ShareServiceClient client;

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/table/Table.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/table/Table.java
@@ -6,8 +6,8 @@
 package com.microsoft.azure.toolkit.lib.storage.table;
 
 import com.azure.data.tables.TableClient;
-import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractEmulatableAzResource;
 import com.microsoft.azure.toolkit.lib.common.model.Deletable;
 import com.microsoft.azure.toolkit.lib.storage.StorageAccount;
 
@@ -15,7 +15,7 @@ import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
-public class Table extends AbstractAzResource<Table, StorageAccount, TableClient>
+public class Table extends AbstractEmulatableAzResource<Table, StorageAccount, TableClient>
     implements Deletable {
 
     protected Table(@Nonnull String name, @Nonnull TableModule module) {

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/table/TableModule.java
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/src/main/java/com/microsoft/azure/toolkit/lib/storage/table/TableModule.java
@@ -10,7 +10,7 @@ import com.azure.data.tables.TableClient;
 import com.azure.data.tables.TableServiceClient;
 import com.azure.data.tables.TableServiceClientBuilder;
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
-import com.microsoft.azure.toolkit.lib.common.model.AbstractAzResourceModule;
+import com.microsoft.azure.toolkit.lib.common.model.AbstractEmulatableAzResourceModule;
 import com.microsoft.azure.toolkit.lib.common.model.page.ItemPage;
 import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import com.microsoft.azure.toolkit.lib.storage.StorageAccount;
@@ -22,7 +22,7 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-public class TableModule extends AbstractAzResourceModule<Table, StorageAccount, TableClient> {
+public class TableModule extends AbstractEmulatableAzResourceModule<Table, StorageAccount, TableClient> {
 
     public static final String NAME = "Azure.Table";
     private TableServiceClient client;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Extract emulator interface from AbstractAzResource/Module
- Remove redunt set auth required interface in action

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
