### PR TITLE
WIP: Generate native binary from java code

### DIFF
--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
@@ -61,6 +61,7 @@ public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
     private static final String FUNCTION_REGION_KEY = "region";
     private static final String FUNCTION_PRICING_KEY = "pricingTier";
     private static final String FUNCTION_DEPLOY_TO_SLOT_KEY = "isDeployToFunctionSlot";
+    private static final String FUNCTION_NATIVE_EXECUTABLE_PATH = "nativeExecutablePath";
 
     //region Properties
     @Parameter(defaultValue = "${project.build.finalName}", readonly = true, required = true)
@@ -214,6 +215,24 @@ public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
     @Parameter
     protected String storageAccountResourceGroup;
 
+    /**
+     * Boolean flag to run function with custom runtime instead of java
+     *
+     * @since 1.27.0
+     */
+    @Getter
+    @Parameter(property = "functions.nativeExecutablePath")
+    protected String nativeExecutablePath;
+
+    /**
+     * Args to be used by custom handler.
+     *
+     * @since 1.27.0
+     */
+    @Getter
+    @Parameter(property = "functions.customHandlerArgs", defaultValue = "")
+    protected String customHandlerArgs;
+
     @Getter
     protected final ConfigParser parser = new ConfigParser(this);
 
@@ -269,6 +288,10 @@ public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
             throw new AzureToolkitRuntimeException(CAN_NOT_FIND_ARTIFACT);
         }
         return result;
+    }
+
+    protected boolean isNativeExecutable() {
+        return !StringUtils.isEmpty(getNativeExecutablePath());
     }
 
     protected File getHostJsonFile() {
@@ -355,6 +378,7 @@ public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
         result.put(DISABLE_APP_INSIGHTS_KEY, String.valueOf(isDisableAppInsights()));
         final boolean isDeployToFunctionSlot = getDeploymentSlotSetting() != null && StringUtils.isNotEmpty(getDeploymentSlotSetting().getName());
         result.put(FUNCTION_DEPLOY_TO_SLOT_KEY, String.valueOf(isDeployToFunctionSlot));
+        result.put(FUNCTION_NATIVE_EXECUTABLE_PATH, nativeExecutablePath);
         return result;
     }
     //endregion

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
@@ -62,6 +62,7 @@ public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
     private static final String FUNCTION_PRICING_KEY = "pricingTier";
     private static final String FUNCTION_DEPLOY_TO_SLOT_KEY = "isDeployToFunctionSlot";
     private static final String FUNCTION_NATIVE_EXECUTABLE_PATH = "nativeExecutablePath";
+    private static final String FUNCTION_IS_NATIVE = "isNativeFunction";
 
     //region Properties
     @Parameter(defaultValue = "${project.build.finalName}", readonly = true, required = true)
@@ -291,7 +292,7 @@ public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
     }
 
     protected boolean isNativeExecutable() {
-        return !StringUtils.isEmpty(getNativeExecutablePath());
+        return StringUtils.isNotEmpty(getNativeExecutablePath());
     }
 
     protected File getHostJsonFile() {
@@ -378,7 +379,7 @@ public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
         result.put(DISABLE_APP_INSIGHTS_KEY, String.valueOf(isDisableAppInsights()));
         final boolean isDeployToFunctionSlot = getDeploymentSlotSetting() != null && StringUtils.isNotEmpty(getDeploymentSlotSetting().getName());
         result.put(FUNCTION_DEPLOY_TO_SLOT_KEY, String.valueOf(isDeployToFunctionSlot));
-        result.put(FUNCTION_NATIVE_EXECUTABLE_PATH, nativeExecutablePath);
+        result.put(FUNCTION_IS_NATIVE, String.valueOf(isNativeExecutable()));
         return result;
     }
     //endregion

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/ConfigParser.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/ConfigParser.java
@@ -38,6 +38,8 @@ public class ConfigParser {
                 .appInsightsInstance(mojo.getAppInsightsInstance())
                 .storageAccountName(mojo.getStorageAccountName())
                 .storageAccountResourceGroup(StringUtils.firstNonBlank(mojo.getStorageAccountResourceGroup(), mojo.getResourceGroup()))
+                .nativeExecutablePath(mojo.getNativeExecutablePath())
+                .customHandlerArgs(mojo.getCustomHandlerArgs())
                 .subscriptionId(mojo.getSubscriptionId())
                 .resourceGroup(mojo.getResourceGroup())
                 .appName(mojo.getAppName())

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/config/FunctionAppConfig.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/config/FunctionAppConfig.java
@@ -19,6 +19,8 @@ public class FunctionAppConfig extends AppServiceConfig {
     private boolean disableAppInsights;
     private String storageAccountName;
     private String storageAccountResourceGroup;
+    private String nativeExecutablePath;
+    private String customHandlerArgs;
     private LogAnalyticsWorkspaceConfig workspaceConfig;
     private FlexConsumptionConfiguration flexConsumptionConfiguration;
 }


### PR DESCRIPTION
Checkstyle is not ok.

What does this implement/fix? Explain your changes.
---------------------------------------------------
Java projects could generate jar or native files to run (Quarkus, Micronaut or SpringBoot). Now it's very easy after accept this PR. Example with Quarkus using this plugin:  https://github.com/viniciusfcf/quarkus-azure-functions-http/tree/using-new-versions
…


Does this close any currently open issues?
------------------------------------------
No, however I'm working with Sandra Ahlgrimm to allow native function using customHandler from java projects


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
