### PR TITLE
Use dot to indicate deployment is running instead of print duplicate message

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/CsmDeploymentStatus.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/CsmDeploymentStatus.java
@@ -10,6 +10,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 @Data
 @Builder
@@ -22,4 +23,10 @@ public class CsmDeploymentStatus {
     private Integer numberOfInstancesFailed;
     private List<String> failedInstancesLogs;
     private List<ErrorEntity> errors;
+
+    public int getTotalInstanceCount() {
+        return Stream.of(numberOfInstancesInProgress, numberOfInstancesFailed, numberOfInstancesSuccessful)
+            .filter(i -> i != null)
+            .mapToInt(Integer::intValue).sum();
+    }
 }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/DeployWebAppTask.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/DeployWebAppTask.java
@@ -87,7 +87,6 @@ public class DeployWebAppTask extends AzureTask<WebAppBase<?, ?, ?>> {
         }
         this.messager.info(String.format(DEPLOY_START, webApp.getName()));
         deployArtifacts();
-        this.messager.info(AzureString.fromString(String.format(DEPLOY_FINISH, webApp.getHostName())));
         startAppService(webApp);
         return webApp;
     }

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/DeployMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/DeployMojo.java
@@ -23,6 +23,7 @@ import com.microsoft.azure.toolkit.lib.appservice.utils.AppServiceConfigUtils;
 import com.microsoft.azure.toolkit.lib.appservice.webapp.AzureWebApp;
 import com.microsoft.azure.toolkit.lib.appservice.webapp.WebApp;
 import com.microsoft.azure.toolkit.lib.appservice.webapp.WebAppBase;
+import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureExecutionException;
 import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
@@ -90,6 +91,7 @@ public class DeployMojo extends AbstractWebAppMojo {
             final WebAppBase<?, ?, ?> target = createOrUpdateResource(app);
             deployExternalResources(target, getConfigParser().getExternalArtifacts());
             deploy(target, getConfigParser().getArtifacts());
+            AzureMessager.getMessager().info(AzureString.format("Application url: %s", "https://" + target.getHostName()));
         } catch (final Exception e) {
             new StreamingLogTask(app).execute();
             throw new AzureToolkitRuntimeException(e);

--- a/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/DeployMojo.java
+++ b/azure-webapp-maven-plugin/src/main/java/com/microsoft/azure/maven/webapp/DeployMojo.java
@@ -148,6 +148,7 @@ public class DeployMojo extends AbstractWebAppMojo {
         final DeployWebAppTask deployWebAppTask = new DeployWebAppTask(target, artifacts, this.getRestartSite(), this.getWaitDeploymentComplete(), true);
         Optional.ofNullable(this.getDeploymentStatusRefreshInterval()).ifPresent(deployWebAppTask::setDeploymentStatusRefreshInterval);
         Optional.ofNullable(this.getDeploymentStatusMaxRefreshTimes()).ifPresent(deployWebAppTask::setDeploymentStatusMaxRefreshTimes);
+        deployWebAppTask.setDeploymentStatusStream(System.out);
         deployWebAppTask.doExecute();
     }
 


### PR DESCRIPTION
Use dot to indicate deployment is running instead of print duplicate message

What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
