### PR TITLE
Don't log the message: "default messager has already been registered"

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/messager/AzureMessager.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/messager/AzureMessager.java
@@ -17,8 +17,6 @@ public abstract class AzureMessager implements IAzureMessager {
     public static synchronized void setDefaultMessager(@Nonnull IAzureMessager messager) {
         if (AzureMessager.defaultMessager == null) { // not allow overwriting...
             AzureMessager.defaultMessager = messager;
-        } else {
-            AzureMessager.getMessager().warning("default messager has already been registered");
         }
     }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Removes a noisy log-message that appears multiple times in a multi-project gradle build when we apply the azure-functions plugin in multiple projects.

Does this close any currently open issues?
------------------------------------------
https://github.com/microsoft/azure-maven-plugins/issues/2323

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
```
> Configure project :common:client
default messager has already been registered

> Configure project :common:service:server
default messager has already been registered

BUILD SUCCESSFUL in 1s
```

Any other comments?
-------------------

Has this been tested?
---------------------------
- [x] Tested
