### PR TITLE
Preprare endgame of 202309

### DIFF
--- a/azure-appservice-maven-plugin-lib/pom.xml
+++ b/azure-appservice-maven-plugin-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-maven-plugins</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>1.32.0-SNAPSHOT</version>
+        <version>1.32.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-appservice-maven-plugin-lib</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0</version>
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>

--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-functions-maven-plugin</artifactId>
-    <version>1.28.0-SNAPSHOT</version>
+    <version>1.28.0</version>
     <packaging>maven-plugin</packaging>
     <name>Maven Plugin for Azure Functions</name>
     <description>Maven Plugin for Azure Functions</description>

--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.32.0-SNAPSHOT</version>
+        <version>1.32.0</version>
     </parent>
 
     <groupId>com.microsoft.azure</groupId>

--- a/azure-maven-plugin-lib/pom.xml
+++ b/azure-maven-plugin-lib/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.32.0-SNAPSHOT</version>
+        <version>1.32.0</version>
     </parent>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-maven-plugin-lib</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0</version>
     <name>Azure Maven Plugin Library</name>
     <description>Common library for Azure Maven Plugins</description>
     <url>https://github.com/microsoft/azure-maven-plugins</url>

--- a/azure-sfmesh-maven-plugin/pom.xml
+++ b/azure-sfmesh-maven-plugin/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.32.0-SNAPSHOT</version>
+        <version>1.32.0</version>
     </parent>
 
     <groupId>com.microsoft.azure</groupId>

--- a/azure-spring-apps-maven-plugin/pom.xml
+++ b/azure-spring-apps-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.32.0-SNAPSHOT</version>
+        <version>1.32.0</version>
     </parent>
 
     <groupId>com.microsoft.azure</groupId>

--- a/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-applicationinsights-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
     <build>
         <plugins>
             <plugin>

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-appservice-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <dependencies>
         <dependency>

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-auth-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
     <dependencies>
         <dependency>
             <groupId>com.azure</groupId>

--- a/azure-toolkit-libs/azure-toolkit-cognitiveservices-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-cognitiveservices-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-toolkit-libs</artifactId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-cognitiveservices-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/azure-toolkit-libs/azure-toolkit-common-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-common-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <dependencies>
         <dependency>

--- a/azure-toolkit-libs/azure-toolkit-compute-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-compute-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-compute-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <build>
         <plugins>

--- a/azure-toolkit-libs/azure-toolkit-containerapps-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-containerapps-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-containerapps-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
     <build>
         <plugins>
             <plugin>

--- a/azure-toolkit-libs/azure-toolkit-containerregistry-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-containerregistry-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-containerregistry-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
     <build>
         <plugins>
             <plugin>

--- a/azure-toolkit-libs/azure-toolkit-containerservice-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-containerservice-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-containerservice-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/azure-toolkit-libs/azure-toolkit-cosmos-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-cosmos-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-cosmos-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/azure-toolkit-libs/azure-toolkit-database-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-database-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-database-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <dependencies>
 

--- a/azure-toolkit-libs/azure-toolkit-eventhubs-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-eventhubs-lib/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-toolkit-libs</artifactId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-eventhubs-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
     <build>
         <plugins>
             <plugin>

--- a/azure-toolkit-libs/azure-toolkit-monitor-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-monitor-lib/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-monitor-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
     <build>
         <plugins>
             <plugin>

--- a/azure-toolkit-libs/azure-toolkit-mysql-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-mysql-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-mysql-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <dependencies>
 

--- a/azure-toolkit-libs/azure-toolkit-mysql-single-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-mysql-single-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-mysql-single-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <dependencies>
 

--- a/azure-toolkit-libs/azure-toolkit-postgre-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-postgre-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-postgre-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <dependencies>
 

--- a/azure-toolkit-libs/azure-toolkit-postgre-single-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-postgre-single-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-postgre-single-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <dependencies>
 

--- a/azure-toolkit-libs/azure-toolkit-redis-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-redis-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-redis-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <dependencies>
 

--- a/azure-toolkit-libs/azure-toolkit-servicebus-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-servicebus-lib/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-toolkit-libs</artifactId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-servicebus-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <build>
         <plugins>

--- a/azure-toolkit-libs/azure-toolkit-servicelinker-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-servicelinker-lib/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-toolkit-libs</artifactId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-servicelinker-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <build>
         <plugins>

--- a/azure-toolkit-libs/azure-toolkit-springcloud-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-springcloud-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-springcloud-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <dependencies>
         <dependency>

--- a/azure-toolkit-libs/azure-toolkit-sqlserver-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-sqlserver-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-sqlserver-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <dependencies>
         <dependency>

--- a/azure-toolkit-libs/azure-toolkit-storage-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-storage-lib/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>azure-toolkit-libs</artifactId>
         <groupId>com.microsoft.azure</groupId>
-        <version>0.37.0-SNAPSHOT</version>
+        <version>0.37.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-storage-lib</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
 
     <dependencies>
         <dependency>

--- a/azure-toolkit-libs/pom.xml
+++ b/azure-toolkit-libs/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-toolkit-libs</artifactId>
-    <version>0.37.0-SNAPSHOT</version>
+    <version>0.37.0</version>
     <packaging>pom</packaging>
     <name>Libs for Azure Toolkits</name>
     <description>Wrapped libs for Microsoft Azure Toolkits</description>

--- a/azure-webapp-maven-plugin/pom.xml
+++ b/azure-webapp-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.32.0-SNAPSHOT</version>
+        <version>1.32.0</version>
     </parent>
 
     <groupId>com.microsoft.azure</groupId>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -7,9 +7,9 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-maven-plugins</artifactId>
-        <version>1.32.0-SNAPSHOT</version>
+        <version>1.32.0</version>
     </parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>maven-plugins-build-tools</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-maven-plugins</artifactId>
-    <version>1.32.0-SNAPSHOT</version>
+    <version>1.32.0</version>
     <packaging>pom</packaging>
     <name>Maven Plugins for Azure</name>
     <description>Maven plugins for Microsoft Azure services</description>
@@ -82,7 +82,7 @@
         <maven.javadoc-plugin.version>2.9.1</maven.javadoc-plugin.version>
         <maven.checkstyle-plugin.version>3.1.2</maven.checkstyle-plugin.version>
         <maven.aspectj-plugin.version>1.12.6</maven.aspectj-plugin.version>
-        <azure.maven-plugin-lib.version>1.32.0-SNAPSHOT</azure.maven-plugin-lib.version>
+        <azure.maven-plugin-lib.version>1.32.0</azure.maven-plugin-lib.version>
         <jacoco.version>0.8.8</jacoco.version>
 
         <json.schema-validator.version>1.0.56</json.schema-validator.version>
@@ -270,7 +270,7 @@
                         <dependency>
                             <groupId>com.microsoft.azure</groupId>
                             <artifactId>maven-plugins-build-tools</artifactId>
-                            <version>1.32.0-SNAPSHOT</version>
+                            <version>1.32.0</version>
                         </dependency>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-toolkit-libs</artifactId>
-                <version>0.37.0-SNAPSHOT</version>
+                <version>0.37.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Remove SNAPSHOT of toolkit lib version, prepare for release
- Remove SNAPSHOT for maven plugin lib version, prepare for release
- Remove SNAPSHOT of functions maven plugin, prepare for release


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
