### PR TITLE
Changes to support flex consumption in gradle plugin

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/FunctionAppDraft.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/FunctionAppDraft.java
@@ -234,7 +234,7 @@ public class FunctionAppDraft extends FunctionApp implements AzResource.Draft<Fu
         final boolean runtimeModified = !oldRuntime.isDocker() && Objects.nonNull(newRuntime) && !Objects.equals(newRuntime, oldRuntime);
         final boolean dockerModified = oldRuntime.isDocker() && Objects.nonNull(newDockerConfig);
         final boolean flexConsumptionModified = getAppServicePlan().getPricingTier().isFlexConsumption() &&
-            Objects.nonNull(newFlexConsumptionConfiguration) && !Objects.equals(newFlexConsumptionConfiguration, oldFlexConsumptionConfiguration);
+            Objects.nonNull(newFlexConsumptionConfiguration) && !newFlexConsumptionConfiguration.isEmpty() && !Objects.equals(newFlexConsumptionConfiguration, oldFlexConsumptionConfiguration);
         final boolean isAppSettingsModified = MapUtils.isNotEmpty(settingsToAdd) || CollectionUtils.isNotEmpty(settingsToRemove);
         final boolean isDiagnosticConfigModified = Objects.nonNull(newDiagnosticConfig) && !Objects.equals(newDiagnosticConfig, oldDiagnosticConfig);
         final boolean modified = planModified || runtimeModified || dockerModified || flexConsumptionModified ||

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/FlexConsumptionConfiguration.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/FlexConsumptionConfiguration.java
@@ -13,6 +13,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.commons.lang3.ObjectUtils;
 
 import javax.annotation.Nonnull;
 import java.util.Optional;
@@ -31,6 +32,10 @@ public class FlexConsumptionConfiguration {
     private Integer instanceSize;
     private Integer alwaysReadyInstances;
     private Integer maximumInstances;
+
+    public boolean isEmpty() {
+        return ObjectUtils.allNull(instanceSize, alwaysReadyInstances, maximumInstances);
+    }
 
     public static FlexConsumptionConfiguration fromWebAppBase(@Nonnull final WebAppBase app) {
         return FlexConsumptionConfiguration.builder()

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/AzureConfiguration.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/AzureConfiguration.java
@@ -27,6 +27,7 @@ public class AzureConfiguration {
     private String machineId;
     private String product;
     private String version;
+    private String sessionId;
     private String databasePasswordSaveType;
     private Boolean telemetryEnabled; // null means true
     private String functionCoreToolsPath;

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/messager/AzureMessager.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/messager/AzureMessager.java
@@ -16,7 +16,7 @@ import java.util.ServiceLoader;
 public abstract class AzureMessager {
 
     private static final class Holder {
-        private static final IAzureMessager defaultMessager = loadMessager();
+        private static IAzureMessager defaultMessager = loadMessager();
 
         @Nonnull
         private static IAzureMessager loadMessager() {
@@ -34,6 +34,11 @@ public abstract class AzureMessager {
                 Thread.currentThread().setContextClassLoader(current);
             }
         }
+
+    }
+
+    public static void setDefaultMessager(@Nonnull final IAzureMessager defaultMessager) {
+        Holder.defaultMessager = defaultMessager;
     }
 
     @Nonnull


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Support set azure messager in run time
- Add session id in azure configuration
- Fix possible npe in flex consumption function update


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
