### PR TITLE
Update parent pom version for sdk build tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ hs_err_pid*
 
 jacoco.exec
 bin/
+
+# ignore azure-sdk-usage-report.txt
+azure-sdk-usage-report.txt

--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,4 @@ jacoco.exec
 bin/
 
 # ignore azure-sdk-usage-report.txt
-azure-sdk-usage-report.txt
+**/azure-sdk-usage-report.txt

--- a/azure-sdk-build-tool/pom.xml
+++ b/azure-sdk-build-tool/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-maven-plugins</artifactId>
-    <version>1.36.0-SNAPSHOT</version>
+    <version>1.39.0-SNAPSHOT</version>
   </parent>
 
   <groupId>com.microsoft.azure</groupId>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes the parent pom version to use the latest and also updated .gitignore to ignore the report file that gets created when the build tool runs.


Does this close any currently open issues?
------------------------------------------
None

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/A

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [x] Tested
