### PR TITLE
Redact github token/cli credentials in AzureTelemetryClient

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemetryClient.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemetryClient.java
@@ -41,12 +41,17 @@ public class AzureTelemetryClient {
     private static final Pattern EMAIL_PATTERN = Pattern.compile("@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-]+");
     private static final Pattern SECRET_PATTERN = Pattern.compile("(key|token|sig|secret|signature|password|passwd|pwd|android:value)[^a-zA-Z0-9]", Pattern.CASE_INSENSITIVE);
     private static final Pattern TOKEN_REGEX = Pattern.compile("xox[pbar]-[a-zA-Z0-9]", Pattern.CASE_INSENSITIVE);
+    private static final Pattern GITHUB_TOKEN_REGEX = Pattern.compile("(gh[psuro]_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59})");
+    private static final Pattern CLI_CREDENTIALS_REGEX = Pattern.compile("((login|psexec|(certutil|psexec)\\.exe).{1,50}(\\s-u(ser(name)?)?\\s+.{3,100})?\\s-(admin|user|vm|root)?p(ass(word)?)?\\s+[\"']?[^$\\-/\\s]|(^|[\\s\\r\\n\\\\])net(\\.exe)?.{1,5}(user\\s+|share\\s+/user:| user -? secrets ? set) \\s + [^ $\\s/])");
+
 
     private static final Map<Pattern, String> PATTERN_MAP = new HashMap<Pattern, String>() {{
         put(EMAIL_PATTERN, "<REDACTED: Email>");
         put(SECRET_PATTERN, "<REDACTED: Generic Secret>");
         put(TOKEN_REGEX, "<REDACTED: Slack Toke>");
         put(GOOGLE_API_KEY, "<REDACTED: Google API Key>");
+        put(GITHUB_TOKEN_REGEX, "<REDACTED: GitHub Token>");
+        put(CLI_CREDENTIALS_REGEX, "<REDACTED: CLI Credentials>");
     }};
 
     @Nonnull

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/test/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemetryClientTest.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/test/java/com/microsoft/azure/toolkit/lib/common/telemetry/AzureTelemetryClientTest.java
@@ -20,6 +20,8 @@ public class AzureTelemetryClientTest extends AzureTelemetryClient {
             put("fake-token", "token=FAKE");
             put("fake-slack-token", "xoxp-FAKE"); // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="fake credential for test case")]
             put("fake-path", "/Users/username/.AzureToolkitforIntelliJ/extensions");
+            put("fake-github-token", "ghp_000000000000000000000000000000000000"); // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="fake credential for test case")]
+            put("fake-cli-credential", "login.exe -adminpassword FAKE"); // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="fake credential for test case")]
         }};
         AzureTelemetryClientTest.anonymizePersonallyIdentifiableInformation(map);
         assert StringUtils.equals(map.get("fake-password"), "<REDACTED: Generic Secret>");
@@ -27,5 +29,7 @@ public class AzureTelemetryClientTest extends AzureTelemetryClient {
         assert StringUtils.equals(map.get("fake-token"), "<REDACTED: Generic Secret>");
         assert StringUtils.equals(map.get("fake-slack-token"), "<REDACTED: Slack Toke>");
         assert StringUtils.equals(map.get("fake-path"), "<REDACTED: user-file-path>");
+        assert StringUtils.equals(map.get("fake-github-token"), "<REDACTED: GitHub Token>");
+        assert StringUtils.equals(map.get("fake-cli-credential"), "<REDACTED: CLI Credentials>");
     }
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Redact github token/cli credentials in AzureTelemetryClient


Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
