### PR TITLE
Prepare Azure SDK maven plugin for GA release

### DIFF
--- a/azure-sdk-build-tool-maven-plugin/pom.xml
+++ b/azure-sdk-build-tool-maven-plugin/pom.xml
@@ -8,13 +8,13 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-maven-plugins</artifactId>
-    <version>1.40.0-SNAPSHOT</version>
+    <version>1.39.0</version>
   </parent>
 
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-sdk-build-tool-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.0</version>
 
   <name>Azure SDK for Java Build Tool Maven Plugin</name>
   <description>A tool that makes working with the Azure SDK for Java more productive.</description>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This updates the Azure SDK build tool plugin's version to 1.0.0 to prepare for first GA release.


Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/A

Any other comments?
-------------------
None

Has this been tested?
---------------------------
- [x] Tested
