### PR TITLE
Update README.md Typo "a `azure～`"→"an `azure～`")

### DIFF
--- a/azure-webapp-maven-plugin/README.md
+++ b/azure-webapp-maven-plugin/README.md
@@ -28,7 +28,7 @@ You can prepare your application for Azure Web App easily with one command:
 mvn com.microsoft.azure:azure-webapp-maven-plugin:2.9.0:config
 ```
 
-This command adds a `azure-webapp-maven-plugin` plugin and related configuration by prompting you to select an existing Azure Web App or create a new one. Then you can deploy your Java app to Azure using the following command:
+This command adds an `azure-webapp-maven-plugin` plugin and related configuration by prompting you to select an existing Azure Web App or create a new one. Then you can deploy your Java app to Azure using the following command:
 ```shell
 mvn package azure-webapp:deploy
 ```


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
* Typo "a `azure～`"→"an `azure～`"
* https://github.com/microsoft/azure-maven-plugins/blob/develop/azure-webapp-maven-plugin/README.md
* #PingMSftDocs

Does this close any currently open issues?
------------------------------------------
<!-- AB#123 -->
<!-- #123 -->


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Has this been tested?
---------------------------
- [ ] Tested
