### PR TITLE
Update azure-webapp-maven-plugin documentation to use the latest version

### DIFF
--- a/azure-webapp-maven-plugin/README.md
+++ b/azure-webapp-maven-plugin/README.md
@@ -25,7 +25,7 @@ Maven plugins supports Azure Cli and some other auth methods, see [Authenticatio
 You can prepare your application for Azure Web App easily with one command:
 
 ```shell
-mvn com.microsoft.azure:azure-webapp-maven-plugin:2.9.0:config
+mvn com.microsoft.azure:azure-webapp-maven-plugin:2.13.0:config
 ```
 
 This command adds an `azure-webapp-maven-plugin` plugin and related configuration by prompting you to select an existing Azure Web App or create a new one. Then you can deploy your Java app to Azure using the following command:
@@ -39,8 +39,9 @@ Here is a typical configuration for Azure Web App Maven Plugin:
 <plugin> 
   <groupId>com.microsoft.azure</groupId>  
   <artifactId>azure-webapp-maven-plugin</artifactId>  
-  <version>2.9.0</version>  
+  <version>2.13.0</version>  
   <configuration>
+    <schemaVersion>v2</schemaVersion>
     <subscriptionId>111111-11111-11111-1111111</subscriptionId>
     <resourceGroup>spring-boot-xxxxxxxxxx-rg</resourceGroup>
     <appName>spring-boot-xxxxxxxxxx</appName>
@@ -49,7 +50,7 @@ Here is a typical configuration for Azure Web App Maven Plugin:
     <runtime>
       <os>Linux</os>      
       <webContainer>Java SE</webContainer>
-      <javaVersion>Java 11</javaVersion>
+      <javaVersion>Java 17</javaVersion>
     </runtime>
     <deployment>
       <resources>


### PR DESCRIPTION
This PR updates the documentation for the azure-webapp-maven-plugin to be the latest version available at the time, 2.13.0. The Java version was raised to 17 because all versions of Spring Boot in OSS support at the time of writing are on a 17 baseline.

What does this implement/fix? Explain your changes.
---------------------------------------------------
The documentation in the `README` should match the [latest version in Maven central](https://central.sonatype.com/search?q=g:com.microsoft.azure%20%20a:azure-webapp-maven-plugin&smo=true).

I debated using a placeholder `{latest_version}` instead of updating the version number explicitly. This would match the `README` in [`azure-maven-plugins`](https://github.com/microsoft/azure-maven-plugins/blob/develop/azure-sdk-build-tool-maven-plugin/README.md). I opted for using the explicit version number to keep the same format, but this may get out of date again on a subsequent release.


Does this close any currently open issues?
------------------------------------------
#2287 


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
N/A

Any other comments?
-------------------
I was following a getting started tutorials that should also match the version. [Get started with Java on Azure](https://learn.microsoft.com/en-us/training/modules/deploy-java-spring-boot-app-service-mysql/5-exercise-deploy) uses `1.12.0`.


Has this been tested?
---------------------------
- [N/A] Tested
Documentation only, no code. Although my `hello world` app did work fine with `2.13.0`.
