### PR TITLE
Fix maxLength for App Service Plan Name

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/resources/schema/com/microsoft/azure/toolkit/appservice/AppServicePlanName.json
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/resources/schema/com/microsoft/azure/toolkit/appservice/AppServicePlanName.json
@@ -5,5 +5,5 @@
   "type": "string",
   "pattern": "^[a-zA-Z0-9\\-]+$",
   "minLength": 1,
-  "maxLength": 40
+  "maxLength": 60
 }


### PR DESCRIPTION
The app service plan name can be up to 60 characters

See also: https://github.com/MicrosoftDocs/azure-docs/issues/110753

What does this implement/fix? Explain your changes.
---------------------------------------------------
The maximum characters for the app service plan name


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
![image](https://github.com/user-attachments/assets/11bb3f26-8b89-4e67-b2b1-980995d4e3db)
![image](https://github.com/user-attachments/assets/a00f3fe1-0296-4e3b-b9a6-2160dfe27c43)


Any other comments?
-------------------
…

Has this been tested?
---------------------------
No, I don't know how
