### PR TITLE
CVE-2025-24970 fix

### DIFF
--- a/azure-toolkit-libs/pom.xml
+++ b/azure-toolkit-libs/pom.xml
@@ -80,7 +80,7 @@
         <azure-core.version>1.54.1</azure-core.version>
         <azure-core-management.version>1.15.6</azure-core-management.version>
         <azure-identity.version>1.12.2</azure-identity.version>
-        <azure-core-http-netty.version>1.14.1</azure-core-http-netty.version>
+        <azure-core-http-netty.version>1.15.10</azure-core-http-netty.version>
         <reactor-netty.version>1.1.13</reactor-netty.version>
         <reactor-core.version>3.6.4</reactor-core.version>
         <httpcore.version>4.4.15</httpcore.version>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch version update is fixing and closing CVE-2025-24970, CVE-2025-25193, CVE-2024-47535 and CVE-2024-29025 indicated by Dependabot security analysis, among the project dependencies.


Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, screenshots, error output, etc.?
-------------------------------------
I enabled Automatic dependency submission feature in the forked repository. I took the below report only after I applied this fix. So 4 out of the 6 alerts are fixed.

```
azure-maven-plugins/security/dependabot/4 [High]
#4 closed as [fixed] 11 minutes ago • Detected in io.netty:netty-handler (Maven) • pom.xml

azure-maven-plugins/security/dependabot/6 [Moderate]
#6 closed as [fixed] 11 minutes ago • Detected in io.netty:netty-common (Maven) • pom.xml

azure-maven-plugins/security/dependabot/5 [Moderate]
#5 closed as [fixed] 11 minutes ago • Detected in io.netty:netty-common (Maven) • pom.xml

azure-maven-plugins/security/dependabot/2 [Moderate]
#2 closed as [fixed] 11 minutes ago • Detected in io.netty:netty-codec-http (Maven) • pom.xml 
```

Any other comments?
-------------------
I went after the secutiry alerts raised in my project. Instead of handling transitive dependency upgrading, I wanted to contribute.

Has this been tested?
---------------------------
- [X] Tested
