### PR TITLE
update function app defaults to use Flex Consumption on Linux with Ja…

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/config/AppServiceConfig.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/config/AppServiceConfig.java
@@ -134,7 +134,7 @@ public class AppServiceConfig {
             .os(defaultRuntime.getOperatingSystem())
             .javaVersion(defaultRuntime.getJavaVersionUserText());
         result.runtime(runtimeConfig);
-        result.pricingTier(PricingTier.CONSUMPTION);
+        result.pricingTier(PricingTier.FLEX_CONSUMPTION);
         result.flexConsumptionConfiguration(FlexConsumptionConfiguration.DEFAULT_CONFIGURATION);
         return result;
     }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/FunctionAppRuntime.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/FunctionAppRuntime.java
@@ -36,7 +36,7 @@ public interface FunctionAppRuntime extends Runtime {
     static FunctionAppRuntime getDefault() {
         // use static method instead of constant to avoid cyclic dependency
         // https://stackoverflow.com/questions/41016957/java-interface-static-variable-is-not-initialized
-        return FunctionAppWindowsRuntime.FUNCTION_JAVA17;
+        return FunctionAppLinuxRuntime.FUNCTION_JAVA21;
     }
 
     static List<FunctionAppRuntime> getMajorRuntimes() {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This pull request updates the default configurations for Azure Function Apps, specifically targeting runtime and pricing tier adjustments. The changes ensure compatibility with newer runtime environments and introduce a more flexible pricing model.

### Configuration Updates:

* Updated the default pricing tier in `buildDefaultFunctionConfig` to use `PricingTier.FLEX_CONSUMPTION` instead of `PricingTier.CONSUMPTION`, and added a default configuration for flexible consumption. (`AppServiceConfig.java`, [azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/config/AppServiceConfig.javaL137-R137](diffhunk://#diff-7d51464ec8bc731c572f9cb03e7bd68ccd4826be18be19449f6f4488f01840acL137-R137))

* Changed the default runtime in `getDefault` from `FunctionAppWindowsRuntime.FUNCTION_JAVA17` to `FunctionAppLinuxRuntime.FUNCTION_JAVA21`, reflecting a shift to a more modern runtime environment. (`FunctionAppRuntime.java`, [azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/FunctionAppRuntime.javaL39-R39](diffhunk://#diff-4b56d92262dbee6d8af816462221a696a571e1d15709807bbe98664a4bb46045L39-R39))


Has this been tested?
---------------------------
- [x] Tested
