### PR TITLE
Add McpResourceTrigger and McpMetadata binding support

### DIFF
--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-functions-maven-plugin</artifactId>
-    <version>1.41.0-beta</version>
+    <version>1.41.0</version>
     <packaging>maven-plugin</packaging>
     <name>Maven Plugin for Azure Functions</name>
     <description>Maven Plugin for Azure Functions</description>

--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-functions-maven-plugin</artifactId>
-    <version>1.40.0</version>
+    <version>1.41.0-beta</version>
     <packaging>maven-plugin</packaging>
     <name>Maven Plugin for Azure Functions</name>
     <description>Maven Plugin for Azure Functions</description>

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/core/AzureFunctionsAnnotationConstants.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/core/AzureFunctionsAnnotationConstants.java
@@ -11,6 +11,7 @@ public class AzureFunctionsAnnotationConstants {
     public static final String CUSTOM_BINDING = "com.microsoft.azure.functions.annotation.CustomBinding";
     public static final String MCP_TOOL_TRIGGER = "com.microsoft.azure.functions.annotation.McpToolTrigger";
     public static final String MCP_TOOL_PROPERTY = "com.microsoft.azure.functions.annotation.McpToolProperty";
+    public static final String MCP_RESOURCE_TRIGGER = "com.microsoft.azure.functions.annotation.McpResourceTrigger";
     public static final String FIXED_DELAY_RETRY = "com.microsoft.azure.functions.annotation.FixedDelayRetry";
     public static final String EXPONENTIAL_BACKOFF_RETRY = "com.microsoft.azure.functions.annotation.ExponentialBackoffRetry";
 

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/core/AzureFunctionsAnnotationConstants.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/core/AzureFunctionsAnnotationConstants.java
@@ -12,6 +12,7 @@ public class AzureFunctionsAnnotationConstants {
     public static final String MCP_TOOL_TRIGGER = "com.microsoft.azure.functions.annotation.McpToolTrigger";
     public static final String MCP_TOOL_PROPERTY = "com.microsoft.azure.functions.annotation.McpToolProperty";
     public static final String MCP_RESOURCE_TRIGGER = "com.microsoft.azure.functions.annotation.McpResourceTrigger";
+    public static final String MCP_METADATA = "com.microsoft.azure.functions.annotation.McpMetadata";
     public static final String FIXED_DELAY_RETRY = "com.microsoft.azure.functions.annotation.FixedDelayRetry";
     public static final String EXPONENTIAL_BACKOFF_RETRY = "com.microsoft.azure.functions.annotation.ExponentialBackoffRetry";
 

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/bindings/Binding.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/bindings/Binding.java
@@ -30,6 +30,7 @@ public class Binding {
         requiredAttributeMap.put(BindingEnum.HttpTrigger, Collections.singletonList("authLevel"));
         requiredAttributeMap.put(BindingEnum.McpToolProperty, Arrays.asList("isRequired", "description"));
         requiredAttributeMap.put(BindingEnum.McpToolTrigger, Collections.singletonList("description"));
+        requiredAttributeMap.put(BindingEnum.McpResourceTrigger, Arrays.asList("uri", "resourceName", "description"));
     }
 
     public Binding(BindingEnum bindingEnum) {

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/bindings/Binding.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/bindings/Binding.java
@@ -31,6 +31,7 @@ public class Binding {
         requiredAttributeMap.put(BindingEnum.McpToolProperty, Arrays.asList("isRequired", "description"));
         requiredAttributeMap.put(BindingEnum.McpToolTrigger, Collections.singletonList("description"));
         requiredAttributeMap.put(BindingEnum.McpResourceTrigger, Arrays.asList("uri", "resourceName", "description"));
+        requiredAttributeMap.put(BindingEnum.McpMetadata, Collections.singletonList("json"));
     }
 
     public Binding(BindingEnum bindingEnum) {

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/bindings/BindingEnum.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/bindings/BindingEnum.java
@@ -26,6 +26,7 @@ public enum BindingEnum {
     McpToolTrigger("mcpToolTrigger", Direction.IN),
     McpToolProperty("mcpToolProperty", Direction.IN),
     McpResourceTrigger("mcpResourceTrigger", Direction.IN),
+    McpMetadata("mcpMetadata", Direction.IN),
     QueueTrigger("queueTrigger", Direction.IN, true),
     QueueOutput("queue", Direction.OUT, true),
     SendGridOutput("sendGrid", Direction.OUT),

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/bindings/BindingEnum.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/bindings/BindingEnum.java
@@ -25,6 +25,7 @@ public enum BindingEnum {
     KafkaOutput("kafka", Direction.OUT),
     McpToolTrigger("mcpToolTrigger", Direction.IN),
     McpToolProperty("mcpToolProperty", Direction.IN),
+    McpResourceTrigger("mcpResourceTrigger", Direction.IN),
     QueueTrigger("queueTrigger", Direction.IN, true),
     QueueOutput("queue", Direction.OUT, true),
     SendGridOutput("sendGrid", Direction.OUT),

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/McpAnnotationProcessor.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/McpAnnotationProcessor.java
@@ -17,11 +17,12 @@ import java.util.Map;
 
 /**
  * Processor for handling MCP (Model Context Protocol) annotations in Azure Functions.
- * This class is responsible for processing McpToolTrigger and McpToolProperty annotations
- * and generating the appropriate binding configurations for function.json.
+ * This class is responsible for processing McpToolTrigger, McpToolProperty, and McpResourceTrigger
+ * annotations and generating the appropriate binding configurations for function.json.
  * 
  * McpToolTrigger annotations define tool invocation triggers with a toolName.
  * McpToolProperty annotations define tool properties that are aggregated into toolProperties JSON.
+ * McpResourceTrigger annotations define resource triggers that expose content via MCP.
  */
 public class McpAnnotationProcessor {
 
@@ -60,6 +61,8 @@ public class McpAnnotationProcessor {
             } else if (bindingType == BindingEnum.McpToolTrigger) {
                 patchMcpToolTrigger(binding);
                 mcpTriggers.add(binding);
+            } else if (bindingType == BindingEnum.McpResourceTrigger) {
+                patchMcpResourceTrigger(binding);
             }
         }
         
@@ -83,6 +86,20 @@ public class McpAnnotationProcessor {
         if (StringUtils.isNotEmpty(name)) {
             binding.setAttribute("toolName", name);
         }
+    }
+
+    /**
+     * Patches the McpResourceTrigger binding for function.json generation.
+     * The 'name' attribute from the Java annotation is the binding parameter name,
+     * not the resource name. The 'resourceName' and 'uri' attributes are already
+     * set directly from the annotation properties.
+     * 
+     * @param binding the binding to update
+     */
+    private static void patchMcpResourceTrigger(final Binding binding) {
+        // No patching needed for McpResourceTrigger — unlike McpToolTrigger where
+        // 'name' maps to 'toolName', the McpResourceTrigger annotation has explicit
+        // 'resourceName' and 'uri' properties that are already correctly named.
     }
 
     /**

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/McpAnnotationProcessor.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/McpAnnotationProcessor.java
@@ -17,12 +17,13 @@ import java.util.Map;
 
 /**
  * Processor for handling MCP (Model Context Protocol) annotations in Azure Functions.
- * This class is responsible for processing McpToolTrigger, McpToolProperty, and McpResourceTrigger
- * annotations and generating the appropriate binding configurations for function.json.
+ * This class is responsible for processing McpToolTrigger, McpToolProperty, McpResourceTrigger,
+ * and McpMetadata annotations and generating the appropriate binding configurations for function.json.
  * 
  * McpToolTrigger annotations define tool invocation triggers with a toolName.
  * McpToolProperty annotations define tool properties that are aggregated into toolProperties JSON.
  * McpResourceTrigger annotations define resource triggers that expose content via MCP.
+ * McpMetadata annotations attach arbitrary JSON metadata to a trigger, surfaced in the MCP protocol's _meta field.
  */
 public class McpAnnotationProcessor {
 
@@ -51,6 +52,7 @@ public class McpAnnotationProcessor {
         
         final List<Map<String, Object>> allProperties = new ArrayList<>();
         final List<Binding> mcpTriggers = new ArrayList<>();
+        final List<Binding> mcpMetadataBindings = new ArrayList<>();
         
         // Single pass: Process all bindings and categorize them
         for (final Binding binding : bindings) {
@@ -63,16 +65,28 @@ public class McpAnnotationProcessor {
                 mcpTriggers.add(binding);
             } else if (bindingType == BindingEnum.McpResourceTrigger) {
                 patchMcpResourceTrigger(binding);
+                mcpTriggers.add(binding);
+            } else if (bindingType == BindingEnum.McpMetadata) {
+                mcpMetadataBindings.add(binding);
             }
         }
         
-        // Apply toolProperties to all triggers (only generate JSON once if needed)
-        if (!allProperties.isEmpty() && !mcpTriggers.isEmpty()) {
+        // Apply toolProperties to tool triggers (only generate JSON once if needed)
+        if (!allProperties.isEmpty()) {
             final String toolPropertiesJson = JsonUtils.toJson(allProperties);
             for (final Binding trigger : mcpTriggers) {
-                trigger.setAttribute("toolProperties", toolPropertiesJson);
+                if (trigger.getBindingEnum() == BindingEnum.McpToolTrigger) {
+                    trigger.setAttribute("toolProperties", toolPropertiesJson);
+                }
             }
         }
+
+        // Apply metadata from McpMetadata bindings to their associated triggers
+        applyMetadataToTriggers(mcpMetadataBindings, mcpTriggers);
+
+        // Remove McpMetadata bindings — they are not real bindings and should not
+        // appear in function.json as separate entries
+        bindings.removeAll(mcpMetadataBindings);
     }
 
     /**
@@ -148,5 +162,43 @@ public class McpAnnotationProcessor {
         }
         
         return propertyAttributes;
+    }
+
+    /**
+     * Applies metadata from McpMetadata bindings to their associated trigger bindings.
+     * Each McpMetadata binding's {@code json} attribute is set as the {@code metadata}
+     * property on the trigger binding that shares the same parameter {@code name}.
+     * If only one trigger exists, all metadata is applied to it regardless of name matching.
+     *
+     * @param metadataBindings the list of McpMetadata bindings to process
+     * @param triggers the list of MCP trigger bindings to apply metadata to
+     */
+    private static void applyMetadataToTriggers(final List<Binding> metadataBindings,
+                                                 final List<Binding> triggers) {
+        if (metadataBindings.isEmpty() || triggers.isEmpty()) {
+            return;
+        }
+
+        for (final Binding metadata : metadataBindings) {
+            final String json = (String) metadata.getAttribute("json");
+            if (StringUtils.isEmpty(json)) {
+                continue;
+            }
+
+            final String metadataName = metadata.getName();
+
+            if (triggers.size() == 1) {
+                // Single trigger: apply metadata directly
+                triggers.get(0).setAttribute("metadata", json);
+            } else {
+                // Multiple triggers: match by parameter name
+                for (final Binding trigger : triggers) {
+                    if (StringUtils.equals(trigger.getName(), metadataName)) {
+                        trigger.setAttribute("metadata", json);
+                        break;
+                    }
+                }
+            }
+        }
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/bindings.json
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/bindings.json
@@ -1074,6 +1074,46 @@
           "help": "$mcp_tool_trigger_toolDescription_help"
         }
       ]
+    },
+    {
+      "type": "mcpResourceTrigger",
+      "displayName": "$mcp_resource_trigger_displayName",
+      "direction": "trigger",
+      "enabledInTryMode": true,
+      "settings": [
+        {
+          "name": "uri",
+          "value": "string",
+          "defaultValue": "file://readme.md",
+          "required": true,
+          "label": "$mcp_resource_trigger_uri_label",
+          "help": "$mcp_resource_trigger_uri_help"
+        },
+        {
+          "name": "resourceName",
+          "value": "string",
+          "defaultValue": "MyResource",
+          "required": true,
+          "label": "$mcp_resource_trigger_resourceName_label",
+          "help": "$mcp_resource_trigger_resourceName_help"
+        },
+        {
+          "name": "description",
+          "value": "string",
+          "defaultValue": "A simple MCP Resource.",
+          "required": false,
+          "label": "$mcp_resource_trigger_description_label",
+          "help": "$mcp_resource_trigger_description_help"
+        },
+        {
+          "name": "mimeType",
+          "value": "string",
+          "defaultValue": "text/plain",
+          "required": false,
+          "label": "$mcp_resource_trigger_mimeType_label",
+          "help": "$mcp_resource_trigger_mimeType_help"
+        }
+      ]
     }
   ]
 }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/bindings.json
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/bindings.json
@@ -1114,6 +1114,22 @@
           "help": "$mcp_resource_trigger_mimeType_help"
         }
       ]
+    },
+    {
+      "type": "mcpMetadata",
+      "displayName": "$mcp_metadata_displayName",
+      "direction": "in",
+      "enabledInTryMode": true,
+      "settings": [
+        {
+          "name": "json",
+          "value": "string",
+          "defaultValue": "{}",
+          "required": true,
+          "label": "$mcp_metadata_json_label",
+          "help": "$mcp_metadata_json_help"
+        }
+      ]
     }
   ]
 }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/resources.json
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/resources.json
@@ -233,6 +233,17 @@
     "mcp_tool_trigger_toolName_label": "MCP Tool Name",
     "mcp_tool_trigger_toolName_help": "The name of the MCP Tool.",
     "mcp_tool_trigger_toolDescription_label": "MCP Tool Description",
-    "mcp_tool_trigger_toolDescription_help": "A description of the MCP Tool's functionality."
+    "mcp_tool_trigger_toolDescription_help": "A description of the MCP Tool's functionality.",
+
+    "McpResourceTrigger_description": "A function that creates an MCP Resource exposed through a MCP Server managed by the platform and triggers when an MCP Client reads the resource.",
+    "mcp_resource_trigger_displayName": "MCP Resource Trigger",
+    "mcp_resource_trigger_uri_label": "MCP Resource URI",
+    "mcp_resource_trigger_uri_help": "The URI of the MCP Resource (e.g., file://readme.md).",
+    "mcp_resource_trigger_resourceName_label": "MCP Resource Name",
+    "mcp_resource_trigger_resourceName_help": "The display name of the MCP Resource.",
+    "mcp_resource_trigger_description_label": "MCP Resource Description",
+    "mcp_resource_trigger_description_help": "A description of the MCP Resource.",
+    "mcp_resource_trigger_mimeType_label": "MCP Resource MIME Type",
+    "mcp_resource_trigger_mimeType_help": "The MIME type of the MCP Resource (e.g., text/plain, image/png)."
   }
 }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/resources.json
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/resources.json
@@ -244,6 +244,10 @@
     "mcp_resource_trigger_description_label": "MCP Resource Description",
     "mcp_resource_trigger_description_help": "A description of the MCP Resource.",
     "mcp_resource_trigger_mimeType_label": "MCP Resource MIME Type",
-    "mcp_resource_trigger_mimeType_help": "The MIME type of the MCP Resource (e.g., text/plain, image/png)."
+    "mcp_resource_trigger_mimeType_help": "The MIME type of the MCP Resource (e.g., text/plain, image/png).",
+
+    "mcp_metadata_displayName": "MCP Metadata",
+    "mcp_metadata_json_label": "MCP Metadata JSON",
+    "mcp_metadata_json_help": "A JSON string containing arbitrary metadata to attach to the MCP trigger. Surfaced in the _meta field of the MCP protocol."
   }
 }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/templates.json
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/templates.json
@@ -868,6 +868,32 @@
       "files": {
         "function.java": "package $packageName$;\n\nimport com.microsoft.azure.functions.ExecutionContext;\nimport com.microsoft.azure.functions.annotation.FunctionName;\nimport com.microsoft.azure.functions.annotation.McpToolProperty;\nimport com.microsoft.azure.functions.annotation.McpToolTrigger;\n\n/**\n * Demonstrates a simple Azure Function that prints a provided string and logs \\\"Hello, World!\\\".\n * This function is triggered by an MCP Tool Trigger, which provides the input JSON.\n */\npublic class $className$ {\n    /**\n     *\n     * @param toolArguments The JSON argument provided by the MCP tool. Extracted as a string.\n     * @param message       The message to be logged, provided as an MCP tool property.\n     * @param context       The execution context for logging and tracing function execution.\n     */\n    @FunctionName(\"$functionName$\")\n    public String logCustomTriggerInput(\n            @McpToolTrigger(\n                    name = \"$toolName$\",\n                    description = \"$toolDescription$\")\n            String toolArguments,\n            @McpToolProperty(\n                name = \"message\",\n                propertyType = \"string\",\n                description = \"The message to be logged.\",\n                isRequired = true)\n            String message,\n            final ExecutionContext context\n    ) {\n        context.getLogger().info(\"Hello, World!\");\n        // Log a simple message\n        context.getLogger().info(\"Message:\");\n        context.getLogger().info(message);\n\n        return \"Hello! I received and processed your message: '\" + message + \"'\";\n    }\n}\n"
       }
+    },
+    {
+      "id": "McpResourceTrigger-Java",
+      "metadata": {
+        "name": "McpResourceTrigger",
+        "description": "$McpResourceTrigger_description",
+        "defaultFunctionName": "mcpResourceTriggerJava",
+        "language": "Java",
+        "userPrompt": [
+          "uri",
+          "resourceName"
+        ]
+      },
+      "bundle": ["~4"],
+      "function": {
+        "disabled": false,
+        "bindings": [
+          {
+          "type": "mcpResourceTrigger",
+          "direction": "trigger"
+          }
+        ]
+      },
+      "files": {
+        "function.java": "package $packageName$;\n\nimport com.microsoft.azure.functions.ExecutionContext;\nimport com.microsoft.azure.functions.annotation.FunctionName;\nimport com.microsoft.azure.functions.annotation.McpResourceTrigger;\n\n/**\n * Demonstrates a simple Azure Function that exposes content as an MCP Resource.\n * This function is triggered when an MCP Client reads the resource.\n */\npublic class $className$ {\n    /**\n     *\n     * @param context           The resource invocation context JSON from the MCP trigger.\n     * @param executionContext   The execution context for logging.\n     * @return The text content of the resource.\n     */\n    @FunctionName(\"$functionName$\")\n    public String getResource(\n            @McpResourceTrigger(\n                    name = \"context\",\n                    uri = \"$uri$\",\n                    resourceName = \"$resourceName$\",\n                    description = \"An MCP Resource\",\n                    mimeType = \"text/plain\")\n            String context,\n            final ExecutionContext executionContext\n    ) {\n        executionContext.getLogger().info(\"MCP Resource trigger fired\");\n        return \"Hello from MCP Resource!\";\n    }\n}\n"
+      }
     }
   ]
 }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/templates.json
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/templates.json
@@ -894,6 +894,32 @@
       "files": {
         "function.java": "package $packageName$;\n\nimport com.microsoft.azure.functions.ExecutionContext;\nimport com.microsoft.azure.functions.annotation.FunctionName;\nimport com.microsoft.azure.functions.annotation.McpResourceTrigger;\n\n/**\n * Demonstrates a simple Azure Function that exposes content as an MCP Resource.\n * This function is triggered when an MCP Client reads the resource.\n */\npublic class $className$ {\n    /**\n     *\n     * @param context           The resource invocation context JSON from the MCP trigger.\n     * @param executionContext   The execution context for logging.\n     * @return The text content of the resource.\n     */\n    @FunctionName(\"$functionName$\")\n    public String getResource(\n            @McpResourceTrigger(\n                    name = \"context\",\n                    uri = \"$uri$\",\n                    resourceName = \"$resourceName$\",\n                    description = \"An MCP Resource\",\n                    mimeType = \"text/plain\")\n            String context,\n            final ExecutionContext executionContext\n    ) {\n        executionContext.getLogger().info(\"MCP Resource trigger fired\");\n        return \"Hello from MCP Resource!\";\n    }\n}\n"
       }
+    },
+    {
+      "id": "McpMetadata-Java",
+      "metadata": {
+        "name": "McpMetadata",
+        "description": "Attaches arbitrary JSON metadata to an MCP trigger (tool or resource). The metadata is surfaced in the MCP protocol's _meta field.",
+        "defaultFunctionName": "mcpResourceWithMetadataJava",
+        "language": "Java",
+        "userPrompt": [
+          "uri",
+          "resourceName"
+        ]
+      },
+      "bundle": ["~4"],
+      "function": {
+        "disabled": false,
+        "bindings": [
+          {
+          "type": "mcpResourceTrigger",
+          "direction": "trigger"
+          }
+        ]
+      },
+      "files": {
+        "function.java": "package $packageName$;\n\nimport com.microsoft.azure.functions.ExecutionContext;\nimport com.microsoft.azure.functions.annotation.FunctionName;\nimport com.microsoft.azure.functions.annotation.McpMetadata;\nimport com.microsoft.azure.functions.annotation.McpResourceTrigger;\n\n/**\n * Demonstrates an MCP Resource with metadata.\n * The metadata is surfaced in the MCP protocol's _meta field when clients\n * call resources/list.\n */\npublic class $className$ {\n    @FunctionName(\"$functionName$\")\n    public String getResource(\n            @McpResourceTrigger(\n                    name = \"context\",\n                    uri = \"$uri$\",\n                    resourceName = \"$resourceName$\",\n                    description = \"An MCP Resource with metadata\",\n                    mimeType = \"text/plain\")\n            @McpMetadata(\n                    name = \"context\",\n                    json = \"{\\\"author\\\": \\\"My Name\\\", \\\"version\\\": 1.0}\")\n            String context,\n            final ExecutionContext executionContext\n    ) {\n        executionContext.getLogger().info(\"MCP Resource trigger fired\");\n        return \"Hello from MCP Resource with metadata!\";\n    }\n}\n"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds build-time support for two new MCP annotations from azure-functions-java-library v3.2.4:

### McpResourceTrigger
- Registered in `BindingEnum` as `mcpResourceTrigger` (Direction.IN)
- Added to `AzureFunctionsAnnotationConstants`
- Required attributes: `uri`, `resourceName`, `description`
- No post-processing needed (annotation properties map directly to function.json)

### McpMetadata
- Registered in `BindingEnum` as `mcpMetadata` (Direction.IN)
- Required attribute: `json`
- `McpAnnotationProcessor` collects McpMetadata bindings, matches them to their trigger by parameter name, and injects the `json` value as a `metadata` field on the trigger binding in function.json
- McpMetadata bindings are removed from the final binding list (they are not standalone bindings)

### Updated resources
- `bindings.json`, `resources.json`, `templates.json` updated with new binding definitions

### Plugin version
Updated to **1.41.0**.

### Related PRs
- Java library: https://github.com/Azure/azure-functions-java-library/pull/231
- Test app: https://github.com/Azure-Samples/remote-mcp-functions-java/pull/10