### PR TITLE
Add MCP structured content and prompt support to Maven plugin

### DIFF
--- a/azure-functions-maven-plugin/pom.xml
+++ b/azure-functions-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-functions-maven-plugin</artifactId>
-    <version>1.41.0</version>
+    <version>1.42.0</version>
     <packaging>maven-plugin</packaging>
     <name>Maven Plugin for Azure Functions</name>
     <description>Maven Plugin for Azure Functions</description>

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/core/AzureFunctionsAnnotationConstants.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/function/core/AzureFunctionsAnnotationConstants.java
@@ -13,6 +13,8 @@ public class AzureFunctionsAnnotationConstants {
     public static final String MCP_TOOL_PROPERTY = "com.microsoft.azure.functions.annotation.McpToolProperty";
     public static final String MCP_RESOURCE_TRIGGER = "com.microsoft.azure.functions.annotation.McpResourceTrigger";
     public static final String MCP_METADATA = "com.microsoft.azure.functions.annotation.McpMetadata";
+    public static final String MCP_PROMPT_TRIGGER = "com.microsoft.azure.functions.annotation.McpPromptTrigger";
+    public static final String MCP_PROMPT_ARGUMENT = "com.microsoft.azure.functions.annotation.McpPromptArgument";
     public static final String FIXED_DELAY_RETRY = "com.microsoft.azure.functions.annotation.FixedDelayRetry";
     public static final String EXPONENTIAL_BACKOFF_RETRY = "com.microsoft.azure.functions.annotation.ExponentialBackoffRetry";
 

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/bindings/Binding.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/bindings/Binding.java
@@ -32,6 +32,8 @@ public class Binding {
         requiredAttributeMap.put(BindingEnum.McpToolTrigger, Collections.singletonList("description"));
         requiredAttributeMap.put(BindingEnum.McpResourceTrigger, Arrays.asList("uri", "resourceName", "description"));
         requiredAttributeMap.put(BindingEnum.McpMetadata, Collections.singletonList("json"));
+        requiredAttributeMap.put(BindingEnum.McpPromptTrigger, Collections.singletonList("description"));
+        requiredAttributeMap.put(BindingEnum.McpPromptArgument, Arrays.asList("isRequired", "description"));
     }
 
     public Binding(BindingEnum bindingEnum) {

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/bindings/BindingEnum.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/bindings/BindingEnum.java
@@ -27,6 +27,8 @@ public enum BindingEnum {
     McpToolProperty("mcpToolProperty", Direction.IN),
     McpResourceTrigger("mcpResourceTrigger", Direction.IN),
     McpMetadata("mcpMetadata", Direction.IN),
+    McpPromptTrigger("mcpPromptTrigger", Direction.IN),
+    McpPromptArgument("mcpPromptArgument", Direction.IN),
     QueueTrigger("queueTrigger", Direction.IN, true),
     QueueOutput("queue", Direction.OUT, true),
     SendGridOutput("sendGrid", Direction.OUT),

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/AnnotationHandlerImpl.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/AnnotationHandlerImpl.java
@@ -108,6 +108,9 @@ public class AnnotationHandlerImpl implements AnnotationHandler {
         // Process MCP annotations (McpToolTrigger and McpToolProperty)
         McpAnnotationProcessor.processMcpAnnotations(bindings);
 
+        // Set useResultSchema for MCP tool triggers when return type needs middleware wrapping
+        McpAnnotationProcessor.setUseResultSchemaIfNeeded(method, bindings);
+
         patchStorageBinding(method, bindings);
 
         // Validate all bindings for duplicate names after all processing is complete

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/McpAnnotationProcessor.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/McpAnnotationProcessor.java
@@ -14,8 +14,12 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -291,9 +295,11 @@ public class McpAnnotationProcessor {
     // For MCP SDK types, we check if the return type implements the Content interface rather
     // than listing every concrete type — this automatically covers TextContent, ImageContent,
     // AudioContent, ResourceLink, EmbeddedResource, and any future Content implementations.
-    private static final Set<String> RICH_RESULT_TYPE_FQCNS = Set.of(
-        "com.microsoft.azure.functions.mcp.McpToolResult",
-        "io.modelcontextprotocol.spec.McpSchema.CallToolResult"
+    private static final Set<String> RICH_RESULT_TYPE_FQCNS = Collections.unmodifiableSet(
+        new HashSet<>(Arrays.asList(
+            "com.microsoft.azure.functions.mcp.McpToolResult",
+            "io.modelcontextprotocol.spec.McpSchema.CallToolResult"
+        ))
     );
 
     // The sealed Content interface that all MCP SDK content types implement.
@@ -325,7 +331,7 @@ public class McpAnnotationProcessor {
                 .filter(b -> b.getBindingEnum() == BindingEnum.McpToolTrigger)
                 .findFirst();
 
-        if (mcpToolTrigger.isEmpty()) {
+        if (!mcpToolTrigger.isPresent()) {
             return;
         }
 
@@ -379,17 +385,12 @@ public class McpAnnotationProcessor {
         if (List.class.isAssignableFrom(returnType) && genericReturnType instanceof ParameterizedType) {
             final ParameterizedType pt = (ParameterizedType) genericReturnType;
             final Type[] typeArgs = pt.getActualTypeArguments();
-            if (typeArgs.length > 0 && typeArgs[0] instanceof Class<?>) {
-                final Class<?> elemClass = (Class<?>) typeArgs[0];
-                final String elemFqcn = elemClass.getCanonicalName();
-                if (elemFqcn != null && RICH_RESULT_TYPE_FQCNS.contains(elemFqcn)) {
-                    return true;
-                }
-                if (implementsInterface(elemClass, MCP_CONTENT_INTERFACE_FQCN)) {
-                    return true;
-                }
-                if (isSubclassOfRichType(elemClass)) {
-                    return true;
+            if (typeArgs.length > 0) {
+                final Class<?> elemClass = resolveTypeArgClass(typeArgs[0]);
+                if (elemClass != null) {
+                    if (isRichElementType(elemClass)) {
+                        return true;
+                    }
                 }
             }
         }
@@ -411,8 +412,50 @@ public class McpAnnotationProcessor {
     }
 
     /**
-     * Checks whether a class implements or extends any known rich result type by walking
-     * both the superclass chain and the implemented interfaces.
+     * Resolves the concrete {@code Class<?>} from a generic type argument.
+     * Handles both direct {@code Class<?>} arguments (e.g., {@code List<Content>})
+     * and wildcard types (e.g., {@code List<? extends Content>}).
+     *
+     * @param typeArg the type argument to resolve
+     * @return the resolved class, or null if it cannot be determined
+     */
+    private static Class<?> resolveTypeArgClass(final Type typeArg) {
+        if (typeArg instanceof Class<?>) {
+            return (Class<?>) typeArg;
+        }
+        if (typeArg instanceof WildcardType) {
+            final Type[] upperBounds = ((WildcardType) typeArg).getUpperBounds();
+            if (upperBounds.length > 0 && upperBounds[0] instanceof Class<?>) {
+                return (Class<?>) upperBounds[0];
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks whether a list element class is a known rich result type by FQCN,
+     * interface implementation, annotation, or superclass.
+     */
+    private static boolean isRichElementType(final Class<?> elemClass) {
+        final String elemFqcn = elemClass.getCanonicalName();
+        if (elemFqcn != null && RICH_RESULT_TYPE_FQCNS.contains(elemFqcn)) {
+            return true;
+        }
+        if (implementsInterface(elemClass, MCP_CONTENT_INTERFACE_FQCN)) {
+            return true;
+        }
+        if (hasAnnotationByFqcn(elemClass, MCP_CONTENT_ANNOTATION_FQCN)) {
+            return true;
+        }
+        if (isSubclassOfRichType(elemClass)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether a class extends any known rich result type by walking
+     * up the superclass chain.
      */
     private static boolean isSubclassOfRichType(final Class<?> clazz) {
         // Check superclass chain

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/McpAnnotationProcessor.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/McpAnnotationProcessor.java
@@ -24,11 +24,14 @@ import java.util.Set;
 /**
  * Processor for handling MCP (Model Context Protocol) annotations in Azure Functions.
  * This class is responsible for processing McpToolTrigger, McpToolProperty, McpResourceTrigger,
- * and McpMetadata annotations and generating the appropriate binding configurations for function.json.
+ * McpPromptTrigger, McpPromptArgument, and McpMetadata annotations and generating the
+ * appropriate binding configurations for function.json.
  * 
  * McpToolTrigger annotations define tool invocation triggers with a toolName.
  * McpToolProperty annotations define tool properties that are aggregated into toolProperties JSON.
  * McpResourceTrigger annotations define resource triggers that expose content via MCP.
+ * McpPromptTrigger annotations define prompt triggers with a promptName.
+ * McpPromptArgument annotations define prompt arguments that are aggregated into promptArguments JSON.
  * McpMetadata annotations attach arbitrary JSON metadata to a trigger, surfaced in the MCP protocol's _meta field.
  */
 public class McpAnnotationProcessor {
@@ -57,6 +60,7 @@ public class McpAnnotationProcessor {
         }
         
         final List<Map<String, Object>> allProperties = new ArrayList<>();
+        final List<Map<String, Object>> allPromptArguments = new ArrayList<>();
         final List<Binding> mcpTriggers = new ArrayList<>();
         final List<Binding> mcpMetadataBindings = new ArrayList<>();
         
@@ -72,6 +76,11 @@ public class McpAnnotationProcessor {
             } else if (bindingType == BindingEnum.McpResourceTrigger) {
                 patchMcpResourceTrigger(binding);
                 mcpTriggers.add(binding);
+            } else if (bindingType == BindingEnum.McpPromptTrigger) {
+                patchMcpPromptTrigger(binding);
+                mcpTriggers.add(binding);
+            } else if (bindingType == BindingEnum.McpPromptArgument) {
+                processPromptArgumentBinding(binding, allPromptArguments);
             } else if (bindingType == BindingEnum.McpMetadata) {
                 mcpMetadataBindings.add(binding);
             }
@@ -83,6 +92,16 @@ public class McpAnnotationProcessor {
             for (final Binding trigger : mcpTriggers) {
                 if (trigger.getBindingEnum() == BindingEnum.McpToolTrigger) {
                     trigger.setAttribute("toolProperties", toolPropertiesJson);
+                }
+            }
+        }
+
+        // Apply promptArguments to prompt triggers
+        if (!allPromptArguments.isEmpty()) {
+            final String promptArgumentsJson = JsonUtils.toJson(allPromptArguments);
+            for (final Binding trigger : mcpTriggers) {
+                if (trigger.getBindingEnum() == BindingEnum.McpPromptTrigger) {
+                    trigger.setAttribute("promptArguments", promptArgumentsJson);
                 }
             }
         }
@@ -120,6 +139,66 @@ public class McpAnnotationProcessor {
         // No patching needed for McpResourceTrigger — unlike McpToolTrigger where
         // 'name' maps to 'toolName', the McpResourceTrigger annotation has explicit
         // 'resourceName' and 'uri' properties that are already correctly named.
+    }
+
+    /**
+     * Extracts the 'name' attribute from an McpPromptTrigger binding and sets it as 'promptName'
+     * on the binding for function.json generation.
+     *
+     * @param binding the binding to update
+     */
+    private static void patchMcpPromptTrigger(final Binding binding) {
+        final String name = (String) binding.getAttribute("name");
+        if (StringUtils.isNotEmpty(name)) {
+            binding.setAttribute("promptName", name);
+        }
+    }
+
+    /**
+     * Extracts the 'name' attribute from an McpPromptArgument binding and sets it as 'argumentName'
+     * on the binding.
+     *
+     * @param binding the binding to update
+     */
+    private static void patchMcpPromptArgument(final Binding binding) {
+        final String name = (String) binding.getAttribute("name");
+        if (StringUtils.isNotEmpty(name)) {
+            binding.setAttribute("argumentName", name);
+        }
+    }
+
+    /**
+     * Processes a single McpPromptArgument binding: patches it and adds its attributes
+     * to the prompt arguments collection. The output format matches the host extension's
+     * expected promptArguments schema: [{name, description, required}].
+     *
+     * @param binding the prompt argument binding to process
+     * @param allPromptArguments the collection to add processed attributes to
+     */
+    private static void processPromptArgumentBinding(final Binding binding,
+                                                     final List<Map<String, Object>> allPromptArguments) {
+        patchMcpPromptArgument(binding);
+
+        final Map<String, Object> bindingAttributes = binding.getBindingAttributes();
+        final Map<String, Object> argDef = new HashMap<>();
+
+        // Map to the host extension's expected schema: name, description, required
+        final Object argumentName = bindingAttributes.get("argumentName");
+        if (argumentName != null && StringUtils.isNotEmpty(argumentName.toString())) {
+            argDef.put("name", argumentName);
+        }
+
+        final Object description = bindingAttributes.get("description");
+        if (description != null && StringUtils.isNotEmpty(description.toString())) {
+            argDef.put("description", description);
+        }
+
+        final Object isRequired = bindingAttributes.get("isRequired");
+        if (isRequired instanceof Boolean) {
+            argDef.put("required", isRequired);
+        }
+
+        allPromptArguments.add(argDef);
     }
 
     /**

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/McpAnnotationProcessor.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/McpAnnotationProcessor.java
@@ -10,10 +10,16 @@ import com.microsoft.azure.toolkit.lib.legacy.function.bindings.Binding;
 import com.microsoft.azure.toolkit.lib.legacy.function.bindings.BindingEnum;
 import org.apache.commons.lang3.StringUtils;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Processor for handling MCP (Model Context Protocol) annotations in Azure Functions.
@@ -200,5 +206,171 @@ public class McpAnnotationProcessor {
                 }
             }
         }
+    }
+
+    // Fully-qualified class names of types that require useResultSchema=true in function.json.
+    // For MCP SDK types, we check if the return type implements the Content interface rather
+    // than listing every concrete type — this automatically covers TextContent, ImageContent,
+    // AudioContent, ResourceLink, EmbeddedResource, and any future Content implementations.
+    private static final Set<String> RICH_RESULT_TYPE_FQCNS = Set.of(
+        "com.microsoft.azure.functions.mcp.McpToolResult",
+        "io.modelcontextprotocol.spec.McpSchema.CallToolResult"
+    );
+
+    // The sealed Content interface that all MCP SDK content types implement.
+    private static final String MCP_CONTENT_INTERFACE_FQCN = "io.modelcontextprotocol.spec.McpSchema.Content";
+
+    private static final String MCP_CONTENT_ANNOTATION_FQCN = "com.microsoft.azure.functions.mcp.McpContent";
+
+    /**
+     * Inspects the function method's return type and sets {@code useResultSchema=true}
+     * on the McpToolTrigger binding when the return type requires middleware wrapping.
+     *
+     * <p>This flag tells the host extension to use {@code ToolReturnValueBinder} (which
+     * understands the {@code McpToolResult} envelope) instead of {@code SimpleToolReturnValueBinder}
+     * (which just calls {@code .toString()}).</p>
+     *
+     * <p>The flag is only set when:</p>
+     * <ul>
+     *   <li>There is an McpToolTrigger binding</li>
+     *   <li>The function has no output bindings</li>
+     *   <li>The return type is a known rich result type or annotated with {@code @McpContent}</li>
+     * </ul>
+     *
+     * @param method   the function method to inspect
+     * @param bindings the list of bindings for this function
+     */
+    public static void setUseResultSchemaIfNeeded(final Method method, final List<Binding> bindings) {
+        // Find the MCP tool trigger binding
+        final Optional<Binding> mcpToolTrigger = bindings.stream()
+                .filter(b -> b.getBindingEnum() == BindingEnum.McpToolTrigger)
+                .findFirst();
+
+        if (mcpToolTrigger.isEmpty()) {
+            return;
+        }
+
+        // Don't set useResultSchema when there are output bindings
+        final boolean hasOutputBindings = bindings.stream()
+                .anyMatch(b -> b.getBindingEnum().getDirection() == BindingEnum.Direction.OUT);
+        if (hasOutputBindings) {
+            return;
+        }
+
+        final Class<?> returnType = method.getReturnType();
+        if (returnType.equals(Void.TYPE)) {
+            return;
+        }
+
+        if (needsResultSchema(returnType, method.getGenericReturnType())) {
+            mcpToolTrigger.get().setAttribute("useResultSchema", true);
+        }
+    }
+
+    /**
+     * Determines whether the given return type requires {@code useResultSchema=true}.
+     *
+     * @param returnType        the raw return type class
+     * @param genericReturnType the generic return type (for inspecting List type arguments)
+     * @return true if the return type needs middleware wrapping
+     */
+    private static boolean needsResultSchema(final Class<?> returnType, final Type genericReturnType) {
+        // Check if return type is a known rich result type (by FQCN)
+        final String fqcn = returnType.getCanonicalName();
+        if (fqcn != null && RICH_RESULT_TYPE_FQCNS.contains(fqcn)) {
+            return true;
+        }
+
+        // Check if return type implements MCP SDK Content interface
+        if (implementsInterface(returnType, MCP_CONTENT_INTERFACE_FQCN)) {
+            return true;
+        }
+
+        // Check if return type is annotated with @McpContent
+        if (hasAnnotationByFqcn(returnType, MCP_CONTENT_ANNOTATION_FQCN)) {
+            return true;
+        }
+
+        // Check if return type is a subclass of a known rich result type
+        if (isSubclassOfRichType(returnType)) {
+            return true;
+        }
+
+        // Check List<Content> or List<? extends Content> via generic return type
+        if (List.class.isAssignableFrom(returnType) && genericReturnType instanceof ParameterizedType) {
+            final ParameterizedType pt = (ParameterizedType) genericReturnType;
+            final Type[] typeArgs = pt.getActualTypeArguments();
+            if (typeArgs.length > 0 && typeArgs[0] instanceof Class<?>) {
+                final Class<?> elemClass = (Class<?>) typeArgs[0];
+                final String elemFqcn = elemClass.getCanonicalName();
+                if (elemFqcn != null && RICH_RESULT_TYPE_FQCNS.contains(elemFqcn)) {
+                    return true;
+                }
+                if (implementsInterface(elemClass, MCP_CONTENT_INTERFACE_FQCN)) {
+                    return true;
+                }
+                if (isSubclassOfRichType(elemClass)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks whether a class has an annotation with the given fully-qualified class name.
+     * Uses FQCN string comparison to avoid requiring the annotation class on the plugin's classpath.
+     */
+    private static boolean hasAnnotationByFqcn(final Class<?> clazz, final String annotationFqcn) {
+        for (final Annotation a : clazz.getAnnotations()) {
+            if (annotationFqcn.equals(a.annotationType().getCanonicalName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether a class implements or extends any known rich result type by walking
+     * both the superclass chain and the implemented interfaces.
+     */
+    private static boolean isSubclassOfRichType(final Class<?> clazz) {
+        // Check superclass chain
+        Class<?> current = clazz.getSuperclass();
+        while (current != null && !current.equals(Object.class)) {
+            final String superFqcn = current.getCanonicalName();
+            if (superFqcn != null && RICH_RESULT_TYPE_FQCNS.contains(superFqcn)) {
+                return true;
+            }
+            current = current.getSuperclass();
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether a class is, or implements (directly or transitively), an interface
+     * with the given fully-qualified class name.
+     */
+    private static boolean implementsInterface(final Class<?> clazz, final String interfaceFqcn) {
+        // Check if the class itself is the interface
+        if (interfaceFqcn.equals(clazz.getCanonicalName())) {
+            return true;
+        }
+        // Check interfaces on this class and all superclasses
+        Class<?> current = clazz;
+        while (current != null) {
+            for (final Class<?> iface : current.getInterfaces()) {
+                if (interfaceFqcn.equals(iface.getCanonicalName())) {
+                    return true;
+                }
+                // Check super-interfaces recursively
+                if (implementsInterface(iface, interfaceFqcn)) {
+                    return true;
+                }
+            }
+            current = current.getSuperclass();
+        }
+        return false;
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/bindings.json
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/bindings.json
@@ -1130,6 +1130,70 @@
           "help": "$mcp_metadata_json_help"
         }
       ]
+    },
+    {
+      "type": "mcpPromptTrigger",
+      "displayName": "$mcp_prompt_trigger_displayName",
+      "direction": "trigger",
+      "enabledInTryMode": true,
+      "settings": [
+        {
+          "name": "promptName",
+          "value": "string",
+          "defaultValue": "MyMcpPrompt",
+          "required": true,
+          "label": "$mcp_prompt_trigger_promptName_label",
+          "help": "$mcp_prompt_trigger_promptName_help"
+        },
+        {
+          "name": "description",
+          "value": "string",
+          "defaultValue": "A simple MCP Prompt that generates a prompt template.",
+          "required": false,
+          "label": "$mcp_prompt_trigger_description_label",
+          "help": "$mcp_prompt_trigger_description_help"
+        },
+        {
+          "name": "title",
+          "value": "string",
+          "defaultValue": "",
+          "required": false,
+          "label": "$mcp_prompt_trigger_title_label",
+          "help": "$mcp_prompt_trigger_title_help"
+        }
+      ]
+    },
+    {
+      "type": "mcpPromptArgument",
+      "displayName": "$mcp_prompt_argument_displayName",
+      "direction": "in",
+      "enabledInTryMode": true,
+      "settings": [
+        {
+          "name": "argumentName",
+          "value": "string",
+          "defaultValue": "myArgument",
+          "required": true,
+          "label": "$mcp_prompt_argument_argumentName_label",
+          "help": "$mcp_prompt_argument_argumentName_help"
+        },
+        {
+          "name": "description",
+          "value": "string",
+          "defaultValue": "",
+          "required": false,
+          "label": "$mcp_prompt_argument_description_label",
+          "help": "$mcp_prompt_argument_description_help"
+        },
+        {
+          "name": "isRequired",
+          "value": "boolean",
+          "defaultValue": "false",
+          "required": false,
+          "label": "$mcp_prompt_argument_isRequired_label",
+          "help": "$mcp_prompt_argument_isRequired_help"
+        }
+      ]
     }
   ]
 }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/resources.json
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/resources.json
@@ -248,6 +248,23 @@
 
     "mcp_metadata_displayName": "MCP Metadata",
     "mcp_metadata_json_label": "MCP Metadata JSON",
-    "mcp_metadata_json_help": "A JSON string containing arbitrary metadata to attach to the MCP trigger. Surfaced in the _meta field of the MCP protocol."
+    "mcp_metadata_json_help": "A JSON string containing arbitrary metadata to attach to the MCP trigger. Surfaced in the _meta field of the MCP protocol.",
+
+    "McpPromptTrigger_description": "A function that creates an MCP Prompt exposed through a MCP Server managed by the platform and triggers when an MCP Client invokes the prompt.",
+    "mcp_prompt_trigger_displayName": "MCP Prompt Trigger",
+    "mcp_prompt_trigger_promptName_label": "MCP Prompt Name",
+    "mcp_prompt_trigger_promptName_help": "The name of the MCP Prompt.",
+    "mcp_prompt_trigger_title_label": "MCP Prompt Title",
+    "mcp_prompt_trigger_title_help": "An optional human-readable title for display purposes.",
+    "mcp_prompt_trigger_description_label": "MCP Prompt Description",
+    "mcp_prompt_trigger_description_help": "A description of the MCP Prompt's purpose.",
+
+    "mcp_prompt_argument_displayName": "MCP Prompt Argument",
+    "mcp_prompt_argument_argumentName_label": "MCP Prompt Argument Name",
+    "mcp_prompt_argument_argumentName_help": "The name of the prompt argument.",
+    "mcp_prompt_argument_description_label": "MCP Prompt Argument Description",
+    "mcp_prompt_argument_description_help": "A description of the prompt argument.",
+    "mcp_prompt_argument_isRequired_label": "Is Required",
+    "mcp_prompt_argument_isRequired_help": "Whether the prompt argument is required."
   }
 }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/templates.json
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/resources/templates.json
@@ -920,6 +920,32 @@
       "files": {
         "function.java": "package $packageName$;\n\nimport com.microsoft.azure.functions.ExecutionContext;\nimport com.microsoft.azure.functions.annotation.FunctionName;\nimport com.microsoft.azure.functions.annotation.McpMetadata;\nimport com.microsoft.azure.functions.annotation.McpResourceTrigger;\n\n/**\n * Demonstrates an MCP Resource with metadata.\n * The metadata is surfaced in the MCP protocol's _meta field when clients\n * call resources/list.\n */\npublic class $className$ {\n    @FunctionName(\"$functionName$\")\n    public String getResource(\n            @McpResourceTrigger(\n                    name = \"context\",\n                    uri = \"$uri$\",\n                    resourceName = \"$resourceName$\",\n                    description = \"An MCP Resource with metadata\",\n                    mimeType = \"text/plain\")\n            @McpMetadata(\n                    name = \"context\",\n                    json = \"{\\\"author\\\": \\\"My Name\\\", \\\"version\\\": 1.0}\")\n            String context,\n            final ExecutionContext executionContext\n    ) {\n        executionContext.getLogger().info(\"MCP Resource trigger fired\");\n        return \"Hello from MCP Resource with metadata!\";\n    }\n}\n"
       }
+    },
+    {
+      "id": "McpPromptTrigger-Java",
+      "metadata": {
+        "name": "McpPromptTrigger",
+        "description": "$McpPromptTrigger_description",
+        "defaultFunctionName": "mcpPromptTriggerJava",
+        "language": "Java",
+        "userPrompt": [
+          "promptName",
+          "description"
+        ]
+      },
+      "bundle": ["~4"],
+      "function": {
+        "disabled": false,
+        "bindings": [
+          {
+          "type": "mcpPromptTrigger",
+          "direction": "trigger"
+          }
+        ]
+      },
+      "files": {
+        "function.java": "package $packageName$;\n\nimport com.microsoft.azure.functions.ExecutionContext;\nimport com.microsoft.azure.functions.annotation.FunctionName;\nimport com.microsoft.azure.functions.annotation.McpPromptArgument;\nimport com.microsoft.azure.functions.annotation.McpPromptTrigger;\n\n/**\n * Demonstrates an MCP Prompt that exposes a prompt template to MCP clients.\n * Clients discover prompts via prompts/list and invoke them via prompts/get.\n * Return a plain string (auto-wrapped into a user message by the host)\n * or a JSON-serialized GetPromptResult for multi-message responses.\n */\npublic class $className$ {\n    @FunctionName(\"$functionName$\")\n    public String runPrompt(\n            @McpPromptTrigger(\n                    name = \"$promptName$\",\n                    description = \"$description$\")\n            String context,\n            @McpPromptArgument(\n                    name = \"input\",\n                    description = \"The input to process\",\n                    isRequired = true)\n            String input,\n            final ExecutionContext executionContext\n    ) {\n        executionContext.getLogger().info(\"MCP Prompt trigger fired\");\n        String text = (input != null && !input.isEmpty()) ? input : \"No input provided\";\n        return \"Please process the following input:\\n\\n\" + text;\n    }\n}\n"
+      }
     }
   ]
 }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/test/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/McpAnnotationProcessorTest.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/test/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/McpAnnotationProcessorTest.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.toolkit.lib.legacy.function.bindings.Binding;
 import com.microsoft.azure.toolkit.lib.legacy.function.bindings.BindingEnum;
 import org.junit.Test;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -329,6 +330,151 @@ public class McpAnnotationProcessorTest {
     private Binding createMcpToolTriggerBinding(String name) {
         Binding binding = new Binding(BindingEnum.McpToolTrigger);
         binding.setAttribute("name", name);
+        return binding;
+    }
+
+    // ========== Tests for setUseResultSchemaIfNeeded ==========
+
+    // Test fixture classes with various return types for reflection
+    @SuppressWarnings("unused")
+    static class ReturnTypeFixtures {
+        public String returnsString() { return ""; }
+        public void returnsVoid() { }
+    }
+
+    private Method getFixtureMethod(String methodName) throws NoSuchMethodException {
+        return ReturnTypeFixtures.class.getMethod(methodName);
+    }
+
+    @Test
+    public void testSetUseResultSchema_WithStringReturn_ShouldNotSet() throws Exception {
+        List<Binding> bindings = new ArrayList<>();
+        Binding trigger = createMcpToolTriggerBinding("myTool");
+        bindings.add(trigger);
+
+        McpAnnotationProcessor.setUseResultSchemaIfNeeded(
+                getFixtureMethod("returnsString"), bindings);
+
+        assertNull("useResultSchema should not be set for String return",
+                trigger.getAttribute("useResultSchema"));
+    }
+
+    @Test
+    public void testSetUseResultSchema_WithVoidReturn_ShouldNotSet() throws Exception {
+        List<Binding> bindings = new ArrayList<>();
+        Binding trigger = createMcpToolTriggerBinding("myTool");
+        bindings.add(trigger);
+
+        McpAnnotationProcessor.setUseResultSchemaIfNeeded(
+                getFixtureMethod("returnsVoid"), bindings);
+
+        assertNull("useResultSchema should not be set for void return",
+                trigger.getAttribute("useResultSchema"));
+    }
+
+    @Test
+    public void testSetUseResultSchema_WithOutputBindings_ShouldNotSet() throws Exception {
+        List<Binding> bindings = new ArrayList<>();
+        Binding trigger = createMcpToolTriggerBinding("myTool");
+        Binding output = new Binding(BindingEnum.HttpOutput);
+        bindings.add(trigger);
+        bindings.add(output);
+
+        McpAnnotationProcessor.setUseResultSchemaIfNeeded(
+                getFixtureMethod("returnsString"), bindings);
+
+        assertNull("useResultSchema should not be set when output bindings exist",
+                trigger.getAttribute("useResultSchema"));
+    }
+
+    @Test
+    public void testSetUseResultSchema_WithNoToolTrigger_ShouldNotThrow() throws Exception {
+        List<Binding> bindings = new ArrayList<>();
+        Binding httpTrigger = new Binding(BindingEnum.HttpTrigger);
+        bindings.add(httpTrigger);
+
+        // Should not throw
+        McpAnnotationProcessor.setUseResultSchemaIfNeeded(
+                getFixtureMethod("returnsString"), bindings);
+    }
+
+    @Test
+    public void testSetUseResultSchema_WithEmptyBindings_ShouldNotThrow() throws Exception {
+        List<Binding> bindings = new ArrayList<>();
+
+        McpAnnotationProcessor.setUseResultSchemaIfNeeded(
+                getFixtureMethod("returnsString"), bindings);
+    }
+
+    // ========== Tests for prompt annotation processing ==========
+
+    @Test
+    public void testProcessMcpAnnotations_WithPromptTriggerAndArguments_ShouldSetPromptArguments() throws Exception {
+        List<Binding> bindings = new ArrayList<>();
+
+        Binding arg1 = createMcpPromptArgumentBinding("code", "The code to review", true);
+        Binding arg2 = createMcpPromptArgumentBinding("language", "The programming language", false);
+        Binding trigger = createMcpPromptTriggerBinding("code_review");
+
+        bindings.add(arg1);
+        bindings.add(arg2);
+        bindings.add(trigger);
+
+        McpAnnotationProcessor.processMcpAnnotations(bindings);
+
+        // Check trigger is patched
+        assertEquals("code_review", trigger.getAttribute("promptName"));
+
+        // Check promptArguments is set
+        String promptArgsJson = (String) trigger.getAttribute("promptArguments");
+        assertNotNull(promptArgsJson);
+
+        List<Map<String, Object>> promptArgs = OBJECT_MAPPER.readValue(
+                promptArgsJson,
+                new TypeReference<List<Map<String, Object>>>() {}
+        );
+        assertEquals(2, promptArgs.size());
+        assertEquals("code", promptArgs.get(0).get("name"));
+        assertEquals(true, promptArgs.get(0).get("required"));
+        assertEquals("language", promptArgs.get(1).get("name"));
+        assertEquals(false, promptArgs.get(1).get("required"));
+    }
+
+    @Test
+    public void testProcessMcpAnnotations_WithPromptTriggerOnly_ShouldNotSetPromptArguments() {
+        List<Binding> bindings = new ArrayList<>();
+        Binding trigger = createMcpPromptTriggerBinding("my_prompt");
+        bindings.add(trigger);
+
+        McpAnnotationProcessor.processMcpAnnotations(bindings);
+
+        assertEquals("my_prompt", trigger.getAttribute("promptName"));
+        assertNull(trigger.getAttribute("promptArguments"));
+    }
+
+    @Test
+    public void testProcessMcpAnnotations_WithPromptArgumentsOnly_ShouldPatchArguments() {
+        List<Binding> bindings = new ArrayList<>();
+        Binding arg = createMcpPromptArgumentBinding("text", "Some text", true);
+        bindings.add(arg);
+
+        McpAnnotationProcessor.processMcpAnnotations(bindings);
+
+        assertEquals("text", arg.getAttribute("argumentName"));
+    }
+
+    private Binding createMcpPromptTriggerBinding(String name) {
+        Binding binding = new Binding(BindingEnum.McpPromptTrigger);
+        binding.setAttribute("name", name);
+        return binding;
+    }
+
+    private Binding createMcpPromptArgumentBinding(String name, String description, boolean isRequired) {
+        Binding binding = new Binding(BindingEnum.McpPromptArgument);
+        binding.setAttribute("name", name);
+        binding.setAttribute("argumentName", name);
+        binding.setAttribute("description", description);
+        binding.setAttribute("isRequired", isRequired);
         return binding;
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/test/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/McpAnnotationProcessorTest.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/test/java/com/microsoft/azure/toolkit/lib/legacy/function/handlers/McpAnnotationProcessorTest.java
@@ -472,7 +472,6 @@ public class McpAnnotationProcessorTest {
     private Binding createMcpPromptArgumentBinding(String name, String description, boolean isRequired) {
         Binding binding = new Binding(BindingEnum.McpPromptArgument);
         binding.setAttribute("name", name);
-        binding.setAttribute("argumentName", name);
         binding.setAttribute("description", description);
         binding.setAttribute("isRequired", isRequired);
         return binding;


### PR DESCRIPTION
## Summary

Adds two features to the Azure Functions Maven plugin's MCP annotation processing:

1. **useResultSchema for rich return types** — Automatically sets `useResultSchema=true` on `mcpToolTrigger` bindings in function.json when the function returns a rich content type (McpToolResult, MCP SDK Content types, @McpContent POJOs).

2. **McpPromptTrigger and McpPromptArgument binding support** — Registers the new prompt annotations so the Maven plugin can generate correct function.json for MCP prompt functions.

## Changes

### useResultSchema (existing commit)

**McpAnnotationProcessor.java**
- New method `setUseResultSchemaIfNeeded(Method, List<Binding>)` that inspects the function method's return type
- Detects rich types by FQCN string matching, @McpContent annotation, interface/superclass checks
- Only sets the flag when there are no output bindings

**AnnotationHandlerImpl.java**
- Calls `McpAnnotationProcessor.setUseResultSchemaIfNeeded(method, bindings)` after MCP annotation processing

### McpPromptTrigger and McpPromptArgument (new commit)

**BindingEnum.java**
- Added `McpPromptTrigger("mcpPromptTrigger", Direction.IN)` and `McpPromptArgument("mcpPromptArgument", Direction.IN)`

**AzureFunctionsAnnotationConstants.java**
- Added fully-qualified class names for both annotations

**Binding.java**
- Added `requiredAttributeMap` entries: `description` for prompt trigger, `isRequired`/`description` for prompt argument

**McpAnnotationProcessor.java**
- `name` → `promptName` patching for prompt triggers (same pattern as tool's `name` → `toolName`)
- Aggregates `McpPromptArgument` bindings into `promptArguments` JSON array on the trigger (same pattern as `McpToolProperty` → `toolProperties`)
- Prompt triggers included in metadata application

**resources.json**
- Added display labels for prompt trigger and argument

## Related PRs
- [Azure/azure-functions-java-library#235](https://github.com/Azure/azure-functions-java-library/pull/235) — Annotation definitions (McpPromptTrigger, McpPromptArgument)
- [Azure-Samples/remote-mcp-functions-java#17](https://github.com/Azure-Samples/remote-mcp-functions-java/pull/17) — Sample prompt functions
- [Azure/azure-functions-java-additions#49](https://github.com/Azure/azure-functions-java-additions/pull/49) — azure-functions-java-mcp module
