### PR TITLE
Fix OAuth reauthentication after token expiry

### DIFF
--- a/azure-toolkit-libs/azure-toolkit-auth-lib/pom.xml
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/pom.xml
@@ -67,6 +67,11 @@
             <groupId>com.github.zafarkhaja</groupId>
             <artifactId>java-semver</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/Account.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/Account.java
@@ -13,8 +13,7 @@ import com.azure.core.http.policy.RetryPolicy;
 import com.azure.core.management.AzureEnvironment;
 import com.azure.core.management.profile.AzureProfile;
 import com.azure.core.util.logging.ClientLogger;
-import com.azure.identity.DeviceCodeCredential;
-import com.azure.identity.InteractiveBrowserCredential;
+import com.azure.identity.AuthenticationRequiredException;
 import com.azure.identity.TokenCachePersistenceOptions;
 import com.azure.identity.implementation.MsalToken;
 import com.azure.identity.implementation.util.ScopeUtil;
@@ -22,6 +21,8 @@ import com.azure.resourcemanager.resources.ResourceManager;
 import com.microsoft.azure.toolkit.lib.Azure;
 import com.microsoft.azure.toolkit.lib.account.IAccount;
 import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
+import com.microsoft.azure.toolkit.lib.common.action.Action;
+import com.microsoft.azure.toolkit.lib.common.action.AzureActionManager;
 import com.microsoft.azure.toolkit.lib.common.cache.CacheEvict;
 import com.microsoft.azure.toolkit.lib.common.cache.Preloader;
 import com.microsoft.azure.toolkit.lib.common.event.AzureEventBus;
@@ -37,17 +38,14 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import lombok.SneakyThrows;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,6 +56,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 @Getter
@@ -72,12 +71,18 @@ public abstract class Account implements IAccount {
     @Setter(AccessLevel.PACKAGE)
     protected boolean persistenceEnabled = true;
     @Getter(AccessLevel.PACKAGE)
-    private TokenCredential defaultTokenCredential;
+    private volatile TokenCredential defaultTokenCredential;
     @Getter(AccessLevel.NONE)
-    private List<Subscription> subscriptions;
+    private volatile InteractiveAuthenticationController interactiveAuthenticationController;
+    @Getter(AccessLevel.NONE)
+    private volatile List<Subscription> subscriptions;
 
     @Nonnull
     protected abstract TokenCredential buildDefaultTokenCredential();
+
+    protected boolean supportsInteractiveAuthentication() {
+        return false;
+    }
 
     public TokenCredential getTokenCredential(String subscriptionId) {
         final Subscription subscription = getSubscription(subscriptionId);
@@ -95,16 +100,27 @@ public abstract class Account implements IAccount {
 
     void login() {
         this.defaultTokenCredential = this.buildDefaultTokenCredential();
-        this.reloadSubscriptions();
-        this.setupAfterLogin(this.defaultTokenCredential);
-        this.config.setType(this.getType());
-        this.config.setClient(this.getClientId());
-        final List<String> tenantIds = this.getTenantIds();
-        if (StringUtils.isEmpty(this.config.getTenant())) {
-            this.config.setTenant(CollectionUtils.isEmpty(tenantIds) ? null : tenantIds.get(0));
+        this.interactiveAuthenticationController = this.supportsInteractiveAuthentication() ?
+            new InteractiveAuthenticationController(this.defaultTokenCredential) : null;
+        if (Objects.nonNull(this.interactiveAuthenticationController)) {
+            this.interactiveAuthenticationController.enableAutomaticAuthentication();
         }
-        this.config.setEnvironment(AzureEnvironmentUtils.azureEnvironmentToString(this.getEnvironment()));
-        this.config.setUsername(this.getUsername());
+        try {
+            this.reloadSubscriptions();
+            this.setupAfterLogin(this.defaultTokenCredential);
+            this.config.setType(this.getType());
+            this.config.setClient(this.getClientId());
+            final List<String> tenantIds = this.getTenantIds();
+            if (StringUtils.isEmpty(this.config.getTenant())) {
+                this.config.setTenant(CollectionUtils.isEmpty(tenantIds) ? null : tenantIds.get(0));
+            }
+            this.config.setEnvironment(AzureEnvironmentUtils.azureEnvironmentToString(this.getEnvironment()));
+            this.config.setUsername(this.getUsername());
+        } finally {
+            if (Objects.nonNull(this.interactiveAuthenticationController)) {
+                this.interactiveAuthenticationController.disableAutomaticAuthentication();
+            }
+        }
     }
 
     public abstract boolean checkAvailable();
@@ -123,8 +139,7 @@ public abstract class Account implements IAccount {
     }
 
     protected void setupAfterLogin(TokenCredential defaultTokenCredential) {
-        final String[] scopes = ScopeUtil.resourceToScopes(this.getEnvironment().getManagementEndpoint());
-        final TokenRequestContext request = new TokenRequestContext().addScopes(scopes);
+        final TokenRequestContext request = this.getManagementTokenRequest();
         final AccessToken token = defaultTokenCredential.getToken(request).blockOptional()
             .orElseThrow(() -> new AzureToolkitAuthenticationException("Failed to retrieve token."));
         if (token instanceof MsalToken) {
@@ -140,6 +155,8 @@ public abstract class Account implements IAccount {
     void logout() {
         this.subscriptions = null;
         this.defaultTokenCredential = null;
+        this.interactiveAuthenticationController = null;
+        this.tenantCredentialCache.clear();
     }
 
     @AzureOperation(name = "azure/account.reload_subscriptions")
@@ -259,6 +276,12 @@ public abstract class Account implements IAccount {
         return isPersistenceEnabled() ? PERSISTENCE_OPTIONS : null;
     }
 
+    @Nonnull
+    private TokenRequestContext getManagementTokenRequest() {
+        final String[] scopes = ScopeUtil.resourceToScopes(this.getEnvironment().getManagementEndpoint());
+        return new TokenRequestContext().addScopes(scopes);
+    }
+
     private static ResourceManager.Configurable configureAzure() {
         // disable retry for getting tenant and subscriptions
         return ResourceManager.configure()
@@ -282,11 +305,12 @@ public abstract class Account implements IAccount {
     }
 
     @RequiredArgsConstructor
-    private static class TenantTokenCredential implements TokenCredential {
+    private class TenantTokenCredential implements TokenCredential {
         // cache for different resources on the same tenant
         // private final Map<String, SimpleTokenCache> resourceTokenCache = new ConcurrentHashMap<>();
         private final String tenantId;
         private final TokenCredential defaultCredential;
+        private final AtomicReference<ReauthenticationRequest> reauthenticationRequest = new AtomicReference<>();
 
         @Override
         public Mono<AccessToken> getToken(TokenRequestContext request) {
@@ -296,20 +320,51 @@ public abstract class Account implements IAccount {
             // return resourceTokenCache.computeIfAbsent(resource, func).getToken();
             // final Mono<AccessToken> token = defaultCredential.getToken(request);
             // final String resource = ScopeUtil.scopesToResource(request.getScopes());
-            return defaultCredential.getToken(request).doOnTerminate(() -> {
-                if (defaultCredential instanceof InteractiveBrowserCredential || defaultCredential instanceof DeviceCodeCredential) {
-                    disableAutomaticAuthentication(); // disable after first success.
-                }
-            });
+            return Account.this.getToken(this.defaultCredential, request)
+                .doOnSuccess(token -> this.reauthenticationRequest.set(null))
+                .onErrorMap(AuthenticationRequiredException.class, e -> this.createReauthenticationException(e, request));
         }
 
-        @SneakyThrows
-        private void disableAutomaticAuthentication() {
-            final Field automaticField = FieldUtils.getField(this.defaultCredential.getClass(), "automaticAuthentication", true);
-            if (Objects.nonNull(automaticField) && ((boolean) FieldUtils.readField(automaticField, this.defaultCredential))) {
-                FieldUtils.writeField(automaticField, this.defaultCredential, false);
+        private RuntimeException createReauthenticationException(AuthenticationRequiredException cause, TokenRequestContext context) {
+            if (!Account.this.supportsInteractiveAuthentication()) {
+                return cause;
+            }
+            final ReauthenticationRequest request = this.getOrCreateReauthenticationRequest(context);
+            final Action<ReauthenticationRequest> registered = AzureActionManager.getInstance().getAction(IAccountActions.REAUTHENTICATE);
+            final Object action = Objects.nonNull(registered) ?
+                registered.bind(request).withLabel("Reauthenticate") : IAccountActions.REAUTHENTICATE;
+            return new AzureToolkitReauthenticationException(cause, request, action);
+        }
+
+        @Nonnull
+        private ReauthenticationRequest getOrCreateReauthenticationRequest(TokenRequestContext context) {
+            while (true) {
+                final ReauthenticationRequest current = this.reauthenticationRequest.get();
+                if (Objects.nonNull(current) && !current.isCompleted()) {
+                    return current;
+                }
+                final ReauthenticationRequest created = new ReauthenticationRequest(this.tenantId, context, r -> {
+                    final InteractiveAuthenticationController controller = Account.this.interactiveAuthenticationController;
+                    if (Objects.isNull(controller)) {
+                        throw new AzureToolkitRuntimeException(String.format(
+                            "Auth type '%s' does not support interactive reauthentication.", Account.this.getType()));
+                    }
+                    controller.authenticate(r.getTokenRequestContext());
+                    this.reauthenticationRequest.compareAndSet(r, null);
+                    AzureEventBus.emit("account.reauthenticated.account", Account.this);
+                });
+                if (this.reauthenticationRequest.compareAndSet(current, created)) {
+                    return created;
+                }
             }
         }
+    }
+
+    @Nonnull
+    private Mono<AccessToken> getToken(@Nonnull TokenCredential credential, @Nonnull TokenRequestContext request) {
+        final InteractiveAuthenticationController controller = this.interactiveAuthenticationController;
+        return Objects.nonNull(controller) && controller.isFor(credential) ?
+            controller.getToken(request) : credential.getToken(request);
     }
 
     public abstract AuthType getType();

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/AzureToolkitReauthenticationException.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/AzureToolkitReauthenticationException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.auth;
+
+import com.azure.identity.AuthenticationRequiredException;
+import com.microsoft.azure.toolkit.lib.common.exception.AzureToolkitRuntimeException;
+import lombok.Getter;
+
+import javax.annotation.Nonnull;
+
+@Getter
+public class AzureToolkitReauthenticationException extends AzureToolkitRuntimeException {
+    @Nonnull
+    private final ReauthenticationRequest request;
+
+    AzureToolkitReauthenticationException(@Nonnull AuthenticationRequiredException cause,
+                                          @Nonnull ReauthenticationRequest request, @Nonnull Object action) {
+        super("Your Azure session needs reauthentication.", cause, action);
+        this.request = request;
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/IAccountActions.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/IAccountActions.java
@@ -11,6 +11,7 @@ public interface IAccountActions {
     Action.Id<Object> TRY_AZURE = Action.TRY_AZURE;
     Action.Id<Object> SELECT_SUBS = Action.SELECT_SUBS;
     Action.Id<Object> AUTHENTICATE = Action.AUTHENTICATE;
+    Action.Id<ReauthenticationRequest> REAUTHENTICATE = Action.Id.of("user/account.reauthenticate");
     Action.Id<Object> SIGN_IN = Action.SIGN_IN;
     Action.Id<Object> SIGN_OUT = Action.SIGN_OUT;
 }

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/InteractiveAuthenticationController.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/InteractiveAuthenticationController.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.auth;
+
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import reactor.core.publisher.Mono;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+final class InteractiveAuthenticationController {
+    private static final String AUTOMATIC_AUTHENTICATION_FIELD = "automaticAuthentication";
+
+    @Nonnull
+    private final TokenCredential credential;
+    private int activeTokenRequests;
+    private CompletableFuture<Void> authentication;
+
+    InteractiveAuthenticationController(@Nonnull TokenCredential credential) {
+        this.credential = credential;
+        this.getAutomaticAuthenticationField();
+    }
+
+    boolean isFor(@Nonnull TokenCredential credential) {
+        return this.credential == credential;
+    }
+
+    Mono<AccessToken> getToken(@Nonnull TokenRequestContext request) {
+        return Mono.defer(() -> {
+            final CompletableFuture<Void> ongoingAuthentication;
+            synchronized (this) {
+                ongoingAuthentication = this.authentication;
+                if (Objects.isNull(ongoingAuthentication)) {
+                    this.activeTokenRequests++;
+                }
+            }
+            if (Objects.nonNull(ongoingAuthentication)) {
+                return Mono.fromFuture(ongoingAuthentication).then(this.getToken(request));
+            }
+            return this.credential.getToken(request).doFinally(ignored -> this.completeTokenRequest());
+        });
+    }
+
+    void authenticate(@Nonnull TokenRequestContext request) {
+        while (true) {
+            final CompletableFuture<Void> currentAuthentication;
+            final boolean owner;
+            synchronized (this) {
+                if (Objects.nonNull(this.authentication)) {
+                    currentAuthentication = this.authentication;
+                    owner = false;
+                } else {
+                    currentAuthentication = new CompletableFuture<>();
+                    this.authentication = currentAuthentication;
+                    owner = true;
+                }
+            }
+            if (!owner) {
+                currentAuthentication.join();
+                continue;
+            }
+
+            try {
+                this.awaitActiveTokenRequests();
+                this.enableAutomaticAuthentication();
+                this.credential.getToken(request).blockOptional()
+                    .orElseThrow(() -> new AzureToolkitAuthenticationException("Failed to retrieve token."));
+            } catch (final RuntimeException e) {
+                this.finishAuthentication(currentAuthentication, e);
+                throw e;
+            } catch (final Error e) {
+                this.finishAuthentication(currentAuthentication, e);
+                throw e;
+            }
+            this.finishAuthentication(currentAuthentication, null);
+            return;
+        }
+    }
+
+    void enableAutomaticAuthentication() {
+        this.setAutomaticAuthentication(true);
+    }
+
+    void disableAutomaticAuthentication() {
+        this.setAutomaticAuthentication(false);
+    }
+
+    private void awaitActiveTokenRequests() {
+        synchronized (this) {
+            while (this.activeTokenRequests > 0) {
+                try {
+                    this.wait();
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AzureToolkitAuthenticationException("Interrupted while waiting to reauthenticate.", e);
+                }
+            }
+        }
+    }
+
+    private void completeTokenRequest() {
+        synchronized (this) {
+            this.activeTokenRequests--;
+            this.notifyAll();
+        }
+    }
+
+    private void finishAuthentication(@Nonnull CompletableFuture<Void> currentAuthentication,
+                                      @Nullable Throwable failure) {
+        Throwable completionFailure = failure;
+        try {
+            this.disableAutomaticAuthentication();
+        } catch (final RuntimeException | Error e) {
+            if (Objects.isNull(completionFailure)) {
+                completionFailure = e;
+            } else {
+                completionFailure.addSuppressed(e);
+            }
+        } finally {
+            synchronized (this) {
+                this.authentication = null;
+                this.notifyAll();
+            }
+        }
+        if (Objects.isNull(completionFailure)) {
+            currentAuthentication.complete(null);
+        } else {
+            currentAuthentication.completeExceptionally(completionFailure);
+            if (Objects.isNull(failure)) {
+                if (completionFailure instanceof RuntimeException) {
+                    throw (RuntimeException) completionFailure;
+                }
+                throw (Error) completionFailure;
+            }
+        }
+    }
+
+    private void setAutomaticAuthentication(boolean enabled) {
+        try {
+            // Azure Identity has no public runtime switch for this behavior.
+            FieldUtils.writeField(this.getAutomaticAuthenticationField(), this.credential, enabled, true);
+        } catch (final IllegalAccessException e) {
+            throw new AzureToolkitAuthenticationException("Failed to configure interactive authentication.", e);
+        }
+    }
+
+    @Nonnull
+    private Field getAutomaticAuthenticationField() {
+        final Field field = FieldUtils.getField(this.credential.getClass(), AUTOMATIC_AUTHENTICATION_FIELD, true);
+        if (Objects.isNull(field) || field.getType() != boolean.class) {
+            throw new AzureToolkitAuthenticationException("The Azure Identity credential does not support controlled interactive authentication.");
+        }
+        return field;
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/ReauthenticationRequest.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/ReauthenticationRequest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.auth;
+
+import com.azure.core.credential.TokenRequestContext;
+import lombok.Getter;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+public final class ReauthenticationRequest {
+    private enum State {
+        REQUIRED,
+        AUTHENTICATING,
+        COMPLETED
+    }
+
+    @Getter
+    @Nonnull
+    private final String tenantId;
+    @Getter
+    @Nonnull
+    private final TokenRequestContext tokenRequestContext;
+    @Nonnull
+    private final Consumer<ReauthenticationRequest> authenticator;
+    private final AtomicReference<State> state = new AtomicReference<>(State.REQUIRED);
+
+    ReauthenticationRequest(@Nonnull String tenantId, @Nonnull TokenRequestContext tokenRequestContext,
+                            @Nonnull Consumer<ReauthenticationRequest> authenticator) {
+        this.tenantId = tenantId;
+        this.tokenRequestContext = tokenRequestContext;
+        this.authenticator = authenticator;
+    }
+
+    public void authenticate() {
+        if (!this.state.compareAndSet(State.REQUIRED, State.AUTHENTICATING)) {
+            return;
+        }
+        try {
+            this.authenticator.accept(this);
+            this.state.set(State.COMPLETED);
+        } catch (final RuntimeException | Error e) {
+            this.state.set(State.REQUIRED);
+            throw e;
+        }
+    }
+
+    boolean isCompleted() {
+        return this.state.get() == State.COMPLETED;
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/devicecode/DeviceCodeAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/devicecode/DeviceCodeAccount.java
@@ -49,6 +49,12 @@ public class DeviceCodeAccount extends Account {
             .tokenCachePersistenceOptions(this.getPersistenceOptions())
             .executorService(config.getExecutorService())
             .challengeConsumer(config.getDeviceCodeConsumer())
+            .disableAutomaticAuthentication()
             .build();
+    }
+
+    @Override
+    protected boolean supportsInteractiveAuthentication() {
+        return true;
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/oauth/OAuthAccount.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/main/java/com/microsoft/azure/toolkit/lib/auth/oauth/OAuthAccount.java
@@ -50,6 +50,12 @@ public class OAuthAccount extends Account {
             .tokenCachePersistenceOptions(getPersistenceOptions())
             .redirectUrl("http://localhost:" + FreePortFinder.findFreeLocalPort())
             .executorService(this.getConfig().getExecutorService())
+            .disableAutomaticAuthentication()
             .build();
+    }
+
+    @Override
+    protected boolean supportsInteractiveAuthentication() {
+        return true;
     }
 }

--- a/azure-toolkit-libs/azure-toolkit-auth-lib/src/test/java/com/microsoft/azure/toolkit/lib/auth/AccountTest.java
+++ b/azure-toolkit-libs/azure-toolkit-auth-lib/src/test/java/com/microsoft/azure/toolkit/lib/auth/AccountTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.auth;
+
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
+import com.azure.core.management.AzureEnvironment;
+import com.azure.identity.AuthenticationRequiredException;
+import com.azure.identity.InteractiveBrowserCredential;
+import com.azure.identity.InteractiveBrowserCredentialBuilder;
+import com.microsoft.azure.toolkit.lib.common.model.Subscription;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+
+import javax.annotation.Nonnull;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class AccountTest {
+    @Test
+    public void controlsAzureIdentityAutomaticAuthentication() throws IllegalAccessException {
+        final InteractiveBrowserCredential credential = new InteractiveBrowserCredentialBuilder()
+            .disableAutomaticAuthentication()
+            .build();
+        final InteractiveAuthenticationController controller = new InteractiveAuthenticationController(credential);
+
+        controller.enableAutomaticAuthentication();
+        assertTrue((boolean) FieldUtils.readField(credential, "automaticAuthentication", true));
+        controller.disableAutomaticAuthentication();
+        assertFalse((boolean) FieldUtils.readField(credential, "automaticAuthentication", true));
+    }
+
+    @Test
+    public void tokenRequestsWaitForOngoingInteractiveAuthentication() throws Exception {
+        final BlockingCredential credential = new BlockingCredential();
+        final InteractiveAuthenticationController controller = new InteractiveAuthenticationController(credential);
+        final TokenRequestContext request = new TokenRequestContext().addScopes("scope");
+
+        final CompletableFuture<Void> authentication = CompletableFuture.runAsync(() -> controller.authenticate(request));
+        assertTrue(credential.authenticationStarted.await(5, TimeUnit.SECONDS));
+        final CompletableFuture<AccessToken> queuedToken = controller.getToken(request).toFuture();
+        assertFalse(queuedToken.isDone());
+
+        credential.continueAuthentication.countDown();
+        authentication.get(5, TimeUnit.SECONDS);
+        queuedToken.get(5, TimeUnit.SECONDS);
+        assertEquals(1, credential.authenticationCount.get());
+        assertFalse(credential.automaticAuthentication);
+    }
+
+    @Test
+    public void concurrentTenantReauthenticationVerifiesEachTenant() throws Exception {
+        final MultiTenantCredential credential = new MultiTenantCredential();
+        final InteractiveAuthenticationController controller = new InteractiveAuthenticationController(credential);
+        final TokenRequestContext firstRequest = new TokenRequestContext().addScopes("scope").setTenantId("first");
+        final TokenRequestContext secondRequest = new TokenRequestContext().addScopes("scope").setTenantId("second");
+
+        final CompletableFuture<Void> first = CompletableFuture.runAsync(() -> controller.authenticate(firstRequest));
+        assertTrue(credential.firstAuthenticationStarted.await(5, TimeUnit.SECONDS));
+        final CompletableFuture<Void> second = CompletableFuture.runAsync(() -> controller.authenticate(secondRequest));
+        credential.continueFirstAuthentication.countDown();
+
+        first.get(5, TimeUnit.SECONDS);
+        second.get(5, TimeUnit.SECONDS);
+        assertEquals(2, credential.authenticationCount.get());
+        assertTrue(credential.authenticatedTenants.contains("first"));
+        assertTrue(credential.authenticatedTenants.contains("second"));
+        assertFalse(credential.automaticAuthentication);
+    }
+
+    @Test
+    public void interactiveAuthenticationCanBeRepeatedForOneTenant() {
+        final TestAccount account = new TestAccount();
+        account.login();
+        assertEquals(1, account.credential.authenticationCount.get());
+        assertFalse(account.credential.automaticAuthentication);
+
+        account.credential.requireAuthentication.set(true);
+        final TokenCredential tenantCredential = account.getTenantTokenCredential("tenant");
+        final TokenRequestContext context = new TokenRequestContext().addScopes("https://management.core.windows.net//.default");
+        final AzureToolkitReauthenticationException first = getAuthenticationException(tenantCredential, context);
+        final AzureToolkitReauthenticationException second = getAuthenticationException(tenantCredential, context);
+        assertSame(first.getRequest(), second.getRequest());
+
+        first.getRequest().authenticate();
+        assertEquals(2, account.credential.authenticationCount.get());
+        assertFalse(account.credential.automaticAuthentication);
+        assertFalse(account.credential.requireAuthentication.get());
+        tenantCredential.getToken(context).block();
+    }
+
+    private static AzureToolkitReauthenticationException getAuthenticationException(TokenCredential credential,
+                                                                                     TokenRequestContext context) {
+        try {
+            credential.getToken(context).block();
+            throw new AssertionError("Expected AzureToolkitReauthenticationException");
+        } catch (AzureToolkitReauthenticationException e) {
+            return e;
+        }
+    }
+
+    private static class TestAccount extends Account {
+        private final TestCredential credential = new TestCredential();
+
+        private TestAccount() {
+            super(new AuthConfiguration(AuthType.OAUTH2));
+        }
+
+        @Nonnull
+        @Override
+        protected TokenCredential buildDefaultTokenCredential() {
+            return this.credential;
+        }
+
+        @Override
+        protected boolean supportsInteractiveAuthentication() {
+            return true;
+        }
+
+        @Override
+        public List<Subscription> reloadSubscriptions() {
+            this.getTenantTokenCredential("tenant").getToken(
+                new TokenRequestContext().addScopes("https://management.core.windows.net//.default")).block();
+            return Collections.emptyList();
+        }
+
+        @Nonnull
+        @Override
+        public List<String> getTenantIds() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        protected void setupAfterLogin(TokenCredential defaultTokenCredential) {
+        }
+
+        @Override
+        public boolean checkAvailable() {
+            return true;
+        }
+
+        @Override
+        public AzureEnvironment getEnvironment() {
+            return AzureEnvironment.AZURE;
+        }
+
+        @Override
+        public AuthType getType() {
+            return AuthType.OAUTH2;
+        }
+    }
+
+    private static class TestCredential implements TokenCredential {
+        private final AtomicBoolean requireAuthentication = new AtomicBoolean(true);
+        private final AtomicInteger authenticationCount = new AtomicInteger();
+        private boolean automaticAuthentication;
+
+        @Override
+        public Mono<AccessToken> getToken(TokenRequestContext request) {
+            if (this.requireAuthentication.get()) {
+                if (!this.automaticAuthentication) {
+                    return Mono.error(new AuthenticationRequiredException("Authentication required", request));
+                }
+                this.requireAuthentication.set(false);
+                this.authenticationCount.incrementAndGet();
+            }
+            return Mono.just(new AccessToken("token", OffsetDateTime.now().plusHours(1)));
+        }
+    }
+
+    private static class BlockingCredential implements TokenCredential {
+        private final AtomicInteger authenticationCount = new AtomicInteger();
+        private final CountDownLatch authenticationStarted = new CountDownLatch(1);
+        private final CountDownLatch continueAuthentication = new CountDownLatch(1);
+        private final AtomicBoolean requireAuthentication = new AtomicBoolean(true);
+        private boolean automaticAuthentication;
+
+        @Override
+        public Mono<AccessToken> getToken(TokenRequestContext request) {
+            return Mono.fromCallable(() -> {
+                if (this.requireAuthentication.get()) {
+                    if (!this.automaticAuthentication) {
+                        throw new AuthenticationRequiredException("Authentication required", request);
+                    }
+                    this.authenticationCount.incrementAndGet();
+                    this.authenticationStarted.countDown();
+                    try {
+                        this.continueAuthentication.await();
+                    } catch (final InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new AzureToolkitAuthenticationException("Authentication interrupted.", e);
+                    }
+                    this.requireAuthentication.set(false);
+                }
+                return new AccessToken("token", OffsetDateTime.now().plusHours(1));
+            });
+        }
+    }
+
+    private static class MultiTenantCredential implements TokenCredential {
+        private final AtomicInteger authenticationCount = new AtomicInteger();
+        private final AtomicBoolean firstAuthentication = new AtomicBoolean(true);
+        private final CountDownLatch firstAuthenticationStarted = new CountDownLatch(1);
+        private final CountDownLatch continueFirstAuthentication = new CountDownLatch(1);
+        private final Set<String> authenticatedTenants = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        private boolean automaticAuthentication;
+
+        @Override
+        public Mono<AccessToken> getToken(TokenRequestContext request) {
+            return Mono.fromCallable(() -> {
+                final String tenantId = request.getTenantId();
+                if (!this.authenticatedTenants.contains(tenantId)) {
+                    if (!this.automaticAuthentication) {
+                        throw new AuthenticationRequiredException("Authentication required", request);
+                    }
+                    this.authenticationCount.incrementAndGet();
+                    if (this.firstAuthentication.compareAndSet(true, false)) {
+                        this.firstAuthenticationStarted.countDown();
+                        try {
+                            this.continueFirstAuthentication.await();
+                        } catch (final InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new AzureToolkitAuthenticationException("Authentication interrupted.", e);
+                        }
+                    }
+                    this.authenticatedTenants.add(tenantId);
+                }
+                return new AccessToken("token", OffsetDateTime.now().plusHours(1));
+            });
+        }
+    }
+}

--- a/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzService.java
+++ b/azure-toolkit-libs/azure-toolkit-common-lib/src/main/java/com/microsoft/azure/toolkit/lib/common/model/AbstractAzService.java
@@ -36,6 +36,7 @@ public abstract class AbstractAzService<T extends AbstractAzServiceSubscription<
         super(name, AzResource.NONE);
         AzureEventBus.on("account.logged_out.account", new AzureEventBus.EventListener((e) -> this.clear()));
         AzureEventBus.on("account.subscription_changed.account", new AzureEventBus.EventListener((e) -> refreshOnSubscriptionChanged()));
+        AzureEventBus.on("account.reauthenticated.account", new AzureEventBus.EventListener((e) -> refreshOnSubscriptionChanged()));
     }
 
     @Nullable


### PR DESCRIPTION
Fixes OAuth and device-code sessions that remain signed in but can no longer silently acquire a tenant token.

The change adds a tenant-scoped reauthentication request, keeps background token acquisition silent, serializes explicit interactive authentication, and refreshes resources after success.

Validation: Maven auth/common build and 10 tests passed on JDK 8.