### PR TITLE
[#2562] Fix app insights wiring with connection string

### DIFF
--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/AbstractFunctionMojo.java
@@ -143,12 +143,23 @@ public abstract class AbstractFunctionMojo extends AbstractAppServiceMojo {
     protected String appInsightsInstance;
 
     /**
-     * Instrumentation key of the application insights instance
+     * Instrumentation key of the application insights instance.
+     * Will be skipped if `appInsightsConnectionString` is specified
      *
      * @since 1.6.0
      */
+    @Deprecated
     @Parameter(property = "functions.appInsightsKey")
     protected String appInsightsKey;
+
+    /**
+     * Connection string of the application insights instance.
+     *
+     * @since 1.46.0
+     */
+    @Getter
+    @Parameter(property = "functions.appInsightsConnectionString")
+    protected String appInsightsConnectionString;
 
     /**
      * Boolean flag to monitor the Function App with application insights

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/ConfigParser.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/ConfigParser.java
@@ -36,6 +36,7 @@ public class ConfigParser {
                 .disableAppInsights(mojo.isDisableAppInsights())
                 .enableDistributedTracing(mojo.getEnableDistributedTracing())
                 .appInsightsKey(mojo.getAppInsightsKey())
+                .appInsightsConnectionString(mojo.getAppInsightsConnectionString())
                 .appInsightsInstance(mojo.getAppInsightsInstance())
                 .storageAccountName(mojo.getStorageAccountName())
                 .storageAccountResourceGroup(StringUtils.firstNonBlank(mojo.getStorageAccountResourceGroup(), mojo.getResourceGroup()))

--- a/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
+++ b/azure-functions-maven-plugin/src/main/java/com/microsoft/azure/maven/function/DeployMojo.java
@@ -58,8 +58,10 @@ import static com.microsoft.azure.toolkit.lib.common.utils.Utils.selectFirstOpti
 @Mojo(name = "deploy", defaultPhase = LifecyclePhase.DEPLOY)
 public class DeployMojo extends AbstractFunctionMojo {
     private static final String APPLICATION_INSIGHTS_CONFIGURATION_CONFLICT = "Contradictory configurations for application insights," +
-            " specify 'appInsightsKey' or 'appInsightsInstance' if you want to enable it, and specify " +
-            "'disableAppInsights=true' if you want to disable it.";
+        " specify 'appInsightsKey', 'appInsightsInstance' or 'appInsightsConnectionString' if you want to enable it, and specify " +
+        "'disableAppInsights=true' if you want to disable it.";
+    private static final String APPLICATION_INSIGHTS_KEY_AND_CONNECTION_STRING_CONFLICT = "Contradictory configurations for application insights," +
+        " specify either 'appInsightsKey' or 'appInsightsConnectionString', but not both.";
     private static final String APP_NAME_PATTERN = "[a-zA-Z0-9\\-]{2,60}";
     private static final String RESOURCE_GROUP_PATTERN = "[a-zA-Z0-9._\\-()]{1,90}";
     private static final String SLOT_NAME_PATTERN = "[A-Za-z0-9-]{1,60}";
@@ -69,18 +71,18 @@ public class DeployMojo extends AbstractFunctionMojo {
     private static final String INVALID_APP_NAME = "The <appName> only allow alphanumeric characters, hyphens and cannot start or end in a hyphen.";
     private static final String EMPTY_RESOURCE_GROUP = "Please config the <resourceGroup> in pom.xml.";
     private static final String INVALID_RESOURCE_GROUP_NAME = "The <resourceGroup> only allow alphanumeric characters, periods, underscores, " +
-            "hyphens and parenthesis and cannot end in a period.";
+        "hyphens and parenthesis and cannot end in a period.";
     private static final String INVALID_SERVICE_PLAN_NAME = "Invalid value for <appServicePlanName>, it need to match the pattern %s";
     private static final String INVALID_SERVICE_PLAN_RESOURCE_GROUP_NAME = "Invalid value for <appServicePlanResourceGroup>, " +
-            "it only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period.";
+        "it only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period.";
     private static final String EMPTY_SLOT_NAME = "Please config the <name> of <deploymentSlot> in pom.xml";
     private static final String INVALID_SLOT_NAME = "Invalid value of <name> inside <deploymentSlot> in pom.xml, it needs to match the pattern '%s'";
     private static final String EMPTY_IMAGE_NAME = "Please config the <image> of <runtime> in pom.xml.";
     private static final String INVALID_OS = "The value of <os> is not correct, supported values are: windows, linux and docker.";
     private static final String EXPANDABLE_PRICING_TIER_WARNING = "'%s' may not be a valid pricing tier, " +
-            "please refer to https://aka.ms/maven_function_configuration#supported-pricing-tiers for valid values";
+        "please refer to https://aka.ms/maven_function_configuration#supported-pricing-tiers for valid values";
     private static final String EXPANDABLE_REGION_WARNING = "'%s' may not be a valid region, " +
-            "please refer to https://aka.ms/maven_function_configuration#supported-regions for valid values";
+        "please refer to https://aka.ms/maven_function_configuration#supported-regions for valid values";
     private static final String CV2_INVALID_CONTAINER_SIZE = "Invalid container size for flex consumption plan, valid values are: %s";
     public static final int MAX_MAX_INSTANCES = 1000;
     public static final int MIN_MAX_INSTANCES = 40;
@@ -95,6 +97,7 @@ public class DeployMojo extends AbstractFunctionMojo {
      * For Windows Function Apps, the default deployment method is RUN_FROM_ZIP <p>
      * For Linux Function Apps, RUN_FROM_BLOB will be used for apps with Consumption and Premium App Service Plan,
      * RUN_FROM_ZIP will be used for apps with Dedicated App Service Plan.
+     *
      * @since 0.1.0
      */
     @JsonProperty
@@ -102,10 +105,10 @@ public class DeployMojo extends AbstractFunctionMojo {
     protected String deploymentType;
 
     /**
-     *  Set the amount of memory allocated to each instance of the function app in MB.
-     *  CPU and network bandwidth are allocated proportionally.
-     *  Values must be one of 512, 2048, 4096
-     *  Default value is 2048
+     * Set the amount of memory allocated to each instance of the function app in MB.
+     * CPU and network bandwidth are allocated proportionally.
+     * Values must be one of 512, 2048, 4096
+     * Default value is 2048
      */
     @JsonProperty
     @Getter
@@ -184,7 +187,7 @@ public class DeployMojo extends AbstractFunctionMojo {
      * </alwaysReadyInstances>
      * }
      * </pre>
-     *
+     * <p>
      * For additional information see https://aka.ms/flexconsumption/alwaysready.
      */
     @JsonProperty
@@ -340,7 +343,7 @@ public class DeployMojo extends AbstractFunctionMojo {
         if (Objects.nonNull(instanceMemory) && !VALID_CONTAINER_SIZE.contains(instanceMemory)) {
             throw new AzureToolkitRuntimeException(String.format(CV2_INVALID_CONTAINER_SIZE, VALID_CONTAINER_SIZE.stream().map(String::valueOf).collect(Collectors.joining(","))));
         }
-        if (Objects.nonNull(maximumInstances) && (maximumInstances > MAX_MAX_INSTANCES || maximumInstances < MIN_MAX_INSTANCES)){
+        if (Objects.nonNull(maximumInstances) && (maximumInstances > MAX_MAX_INSTANCES || maximumInstances < MIN_MAX_INSTANCES)) {
             throw new AzureToolkitRuntimeException("Invalid value for <maximumInstances>, it should be in range [40, 1000]");
         }
         if (Objects.nonNull(httpInstanceConcurrency) && (httpInstanceConcurrency < MIN_HTTP_INSTANCE_CONCURRENCY || httpInstanceConcurrency > MAX_HTTP_INSTANCE_CONCURRENCY)) {
@@ -376,7 +379,7 @@ public class DeployMojo extends AbstractFunctionMojo {
             throw new AzureToolkitRuntimeException(String.format(INVALID_SERVICE_PLAN_NAME, APP_SERVICE_PLAN_NAME_PATTERN));
         }
         if (StringUtils.isNotEmpty(appServicePlanResourceGroup) &&
-                (appServicePlanResourceGroup.endsWith(".") || !appServicePlanResourceGroup.matches(RESOURCE_GROUP_PATTERN))) {
+            (appServicePlanResourceGroup.endsWith(".") || !appServicePlanResourceGroup.matches(RESOURCE_GROUP_PATTERN))) {
             throw new AzureToolkitRuntimeException(INVALID_SERVICE_PLAN_RESOURCE_GROUP_NAME);
         }
         // slot name
@@ -410,12 +413,29 @@ public class DeployMojo extends AbstractFunctionMojo {
         final FunctionAppConfig defaultConfig = !newFunctionApp ?
             fromFunctionApp(app) : buildDefaultConfig(config.subscriptionId(), config.resourceGroup(), config.appName());
         mergeAppServiceConfig(config, defaultConfig);
-        if (!newFunctionApp && !config.disableAppInsights() && StringUtils.isEmpty(config.appInsightsKey())) {
-            // fill ai key from existing app settings
+        if (!newFunctionApp && !config.disableAppInsights()) {
+            applyExistingInsightsSettings(config, app);
+        }
+        return executeDeploymentTask(config);
+    }
+
+    static void applyExistingInsightsSettings(final FunctionAppConfig config, final FunctionApp app) {
+        if (StringUtils.isEmpty(config.appInsightsConnectionString())) {
+            // fill ai connection string from existing app settings
+            Optional.ofNullable(app.getAppSettings())
+                .map(map -> map.get(CreateOrUpdateFunctionAppTask.APPLICATIONINSIGHTS_CONNECTION_STRING))
+                .ifPresent(config::appInsightsConnectionString);
+        }
+        if (StringUtils.isEmpty(config.appInsightsKey()) && StringUtils.isEmpty(config.appInsightsConnectionString())
+            && StringUtils.isEmpty(config.appInsightsInstance())) {
+            // fill ai key from existing app settings only when no other ai config is available
             Optional.ofNullable(app.getAppSettings())
                 .map(map -> map.get(CreateOrUpdateFunctionAppTask.APPINSIGHTS_INSTRUMENTATION_KEY))
                 .ifPresent(config::appInsightsKey);
         }
+    }
+
+    protected FunctionAppBase<?, ?, ?> executeDeploymentTask(final FunctionAppConfig config) throws Exception {
         return new CreateOrUpdateFunctionAppTask(config).doExecute();
     }
 
@@ -436,8 +456,12 @@ public class DeployMojo extends AbstractFunctionMojo {
     }
 
     private void validateApplicationInsightsConfiguration() {
-        if (isDisableAppInsights() && (StringUtils.isNotEmpty(getAppInsightsKey()) || StringUtils.isNotEmpty(getAppInsightsInstance()))) {
+        if (isDisableAppInsights() && (StringUtils.isNotEmpty(getAppInsightsKey()) || StringUtils.isNotEmpty(getAppInsightsInstance())
+            || StringUtils.isNotEmpty(getAppInsightsConnectionString()))) {
             throw new AzureToolkitRuntimeException(APPLICATION_INSIGHTS_CONFIGURATION_CONFLICT);
+        }
+        if (!isDisableAppInsights() && StringUtils.isNotEmpty(getAppInsightsKey()) && StringUtils.isNotEmpty(getAppInsightsConnectionString())) {
+            throw new AzureToolkitRuntimeException(APPLICATION_INSIGHTS_KEY_AND_CONNECTION_STRING_CONFLICT);
         }
     }
 }

--- a/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/DeployMojoTest.java
+++ b/azure-functions-maven-plugin/src/test/java/com/microsoft/azure/maven/function/DeployMojoTest.java
@@ -5,19 +5,41 @@
 
 package com.microsoft.azure.maven.function;
 
+import com.microsoft.azure.toolkit.lib.appservice.config.FunctionAppConfig;
+import com.microsoft.azure.toolkit.lib.appservice.function.FunctionApp;
+import com.microsoft.azure.toolkit.lib.appservice.function.FunctionAppBase;
+import com.microsoft.azure.toolkit.lib.appservice.utils.AppServiceConfigUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.microsoft.azure.toolkit.lib.appservice.task.CreateOrUpdateFunctionAppTask.APPINSIGHTS_INSTRUMENTATION_KEY;
+import static com.microsoft.azure.toolkit.lib.appservice.task.CreateOrUpdateFunctionAppTask.APPLICATIONINSIGHTS_CONNECTION_STRING;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeployMojoTest extends MojoTestBase {
     private DeployMojo mojo = null;
     private DeployMojo mojoSpy = null;
+
+    @Mock
+    private FunctionApp mockApp;
 
     @Before
     public void setUp() throws Exception {
@@ -28,10 +50,67 @@ public class DeployMojoTest extends MojoTestBase {
     @Test
     public void getConfiguration() {
         assertEquals("resourceGroupName", mojo.getResourceGroup());
-
         assertEquals("appName", mojo.getAppName());
+    }
 
-        assertEquals("westeurope", mojo.getRegion());
+    @Test
+    public void test_createOrUpdateResource_pickUpExistingSettings() throws Throwable {
+
+        /* GIVEN */
+        final String existingConnectionString = "InstrumentationKey=00000000;IngestionEndpoint=https://example.com/";
+
+        when(mockApp.exists()).thenReturn(true);
+        final Map<String, String> appSettings = new HashMap<>();
+        appSettings.put(APPLICATIONINSIGHTS_CONNECTION_STRING, existingConnectionString);
+        appSettings.put(APPINSIGHTS_INSTRUMENTATION_KEY, "stale-ikey-that-should-be-ignored");
+        when(mockApp.getAppSettings()).thenReturn(appSettings);
+
+        final ArgumentCaptor<FunctionAppConfig> configCaptor = ArgumentCaptor.forClass(FunctionAppConfig.class);
+        doReturn(mock(FunctionAppBase.class)).when(mojoSpy).executeDeploymentTask(configCaptor.capture());
+
+        try (final MockedStatic<AppServiceConfigUtils> utils = mockStatic(AppServiceConfigUtils.class)) {
+            utils.when(() -> AppServiceConfigUtils.fromFunctionApp(mockApp)).thenReturn(new FunctionAppConfig());
+            utils.when(() -> AppServiceConfigUtils.mergeAppServiceConfig(any(), any())).thenAnswer(inv -> null);
+
+            /* WHEN */
+            mojoSpy.createOrUpdateResource(mockApp);
+        }
+
+        /* THEN */
+        verify(mojoSpy).executeDeploymentTask(any());
+
+        final FunctionAppConfig deployedConfig = configCaptor.getValue();
+        assertEquals(existingConnectionString, deployedConfig.appInsightsConnectionString());
+        assertNull("Instrumentation key should not be backfilled when connection string is already present", deployedConfig.appInsightsKey());
+    }
+
+    @Test
+    public void test_createOrUpdateResource_pickUpInstrumentationKey_noExistingConnectionString() throws Throwable {
+
+        /* GIVEN */
+        when(mockApp.exists()).thenReturn(true);
+        final Map<String, String> appSettings = new HashMap<>();
+        // No APPLICATIONINSIGHTS_CONNECTION_STRING yet
+        appSettings.put(APPINSIGHTS_INSTRUMENTATION_KEY, "00000000");
+        when(mockApp.getAppSettings()).thenReturn(appSettings);
+
+        final ArgumentCaptor<FunctionAppConfig> configCaptor = ArgumentCaptor.forClass(FunctionAppConfig.class);
+        doReturn(mock(FunctionAppBase.class)).when(mojoSpy).executeDeploymentTask(configCaptor.capture());
+
+        try (final MockedStatic<AppServiceConfigUtils> utils = mockStatic(AppServiceConfigUtils.class)) {
+            utils.when(() -> AppServiceConfigUtils.fromFunctionApp(mockApp)).thenReturn(new FunctionAppConfig());
+            utils.when(() -> AppServiceConfigUtils.mergeAppServiceConfig(any(), any())).thenAnswer(inv -> null);
+
+            /* WHEN */
+            mojoSpy.createOrUpdateResource(mockApp);
+        }
+
+        /* THEN */
+        verify(mojoSpy).executeDeploymentTask(any());
+
+        final FunctionAppConfig deployedConfig = configCaptor.getValue();
+        assertNull(deployedConfig.appInsightsConnectionString());
+        assertEquals("00000000", deployedConfig.appInsightsKey());
     }
 
     private DeployMojo getMojoFromPom() throws Exception {

--- a/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/src/main/java/com/microsoft/azure/toolkit/lib/applicationinsights/ApplicationInsight.java
+++ b/azure-toolkit-libs/azure-toolkit-applicationinsights-lib/src/main/java/com/microsoft/azure/toolkit/lib/applicationinsights/ApplicationInsight.java
@@ -60,6 +60,7 @@ public class ApplicationInsight extends AbstractAzResource<ApplicationInsight, A
         return Optional.ofNullable(getRemote()).map(ApplicationInsightsComponent::instrumentationKey).orElse(null);
     }
 
+    @Nullable
     public String getConnectionString() {
         return Optional.ofNullable(getRemote()).map(ApplicationInsightsComponent::connectionString).orElse(null);
     }

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/config/FunctionAppConfig.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/config/FunctionAppConfig.java
@@ -75,6 +75,13 @@ public class FunctionAppConfig extends AppServiceConfig {
     }
 
     @Nullable
+    public String appInsightsConnectionString() {
+        return Optional.ofNullable(applicationInsightsConfig)
+            .filter(c -> BooleanUtils.isNotTrue(c.getDisableAppInsights()))
+            .map(ApplicationInsightsConfig::getConnectionString).orElse(null);
+    }
+
+    @Nullable
     public LogAnalyticsWorkspaceConfig workspaceConfig() {
         return Optional.ofNullable(applicationInsightsConfig)
             .filter(c -> BooleanUtils.isNotTrue(c.getDisableAppInsights()))
@@ -95,9 +102,17 @@ public class FunctionAppConfig extends AppServiceConfig {
     }
 
     @Nonnull
+    @Deprecated
     public FunctionAppConfig appInsightsKey(final String key) {
         this.applicationInsightsConfig = Optional.ofNullable(applicationInsightsConfig).orElseGet(ApplicationInsightsConfig::new);
         this.applicationInsightsConfig.setInstrumentationKey(key);
+        return this;
+    }
+
+    @Nonnull
+    public FunctionAppConfig appInsightsConnectionString(final String connectionString) {
+        this.applicationInsightsConfig = Optional.ofNullable(applicationInsightsConfig).orElseGet(ApplicationInsightsConfig::new);
+        this.applicationInsightsConfig.setConnectionString(connectionString);
         return this;
     }
 

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/ApplicationInsightsConfig.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/model/ApplicationInsightsConfig.java
@@ -20,8 +20,11 @@ import lombok.experimental.SuperBuilder;
 public class ApplicationInsightsConfig {
     @EqualsAndHashCode.Include
     private String name;
+    @Deprecated
     @EqualsAndHashCode.Include
     private String instrumentationKey;
+    @EqualsAndHashCode.Include
+    private String connectionString;
     private Boolean createNewInstance;
     private Boolean disableAppInsights;
     private LogAnalyticsWorkspaceConfig workspaceConfig;

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateFunctionAppTask.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/main/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateFunctionAppTask.java
@@ -69,6 +69,7 @@ import java.util.function.Consumer;
 
 public class CreateOrUpdateFunctionAppTask extends AzureTask<FunctionAppBase<?, ?, ?>> {
     public static final String APPINSIGHTS_INSTRUMENTATION_KEY = "APPINSIGHTS_INSTRUMENTATIONKEY";
+    public static final String APPLICATIONINSIGHTS_CONNECTION_STRING = "APPLICATIONINSIGHTS_CONNECTION_STRING";
     private static final String APPLICATION_INSIGHTS_CREATE_FAILED = "Unable to create the Application Insights " +
         "for the Function App due to error %s. Please use the Azure Portal to manually create and configure the " +
         "Application Insights if needed.";
@@ -97,6 +98,7 @@ public class CreateOrUpdateFunctionAppTask extends AzureTask<FunctionAppBase<?, 
     private String deploymentContainerUrl;
     private ContainerAppsEnvironment environment;
     private String instrumentationKey;
+    private String instrumentationConnectionString;
     private ApplicationInsight applicationInsight;
     private FunctionAppBase<?, ?, ?> functionApp;
 
@@ -115,17 +117,26 @@ public class CreateOrUpdateFunctionAppTask extends AzureTask<FunctionAppBase<?, 
             final String storageResourceGroup = StringUtils.firstNonBlank(functionAppConfig.storageAccountResourceGroup(), functionAppConfig.resourceGroup());
             registerSubTask(getStorageAccountTask(storageAccountName, storageResourceGroup), result -> this.storageAccount = result);
         }
-        // get/create AI instances only if user didn't specify AI connection string in app settings
-        final boolean isInstrumentKeyConfigured = MapUtils.isNotEmpty(functionAppConfig.appSettings()) &&
-            functionAppConfig.appSettings().containsKey(APPINSIGHTS_INSTRUMENTATION_KEY);
-        if (!functionAppConfig.disableAppInsights() && !isInstrumentKeyConfigured) {
-            if (StringUtils.isNotEmpty(functionAppConfig.appInsightsKey())) {
+
+        // get/create AI instances only if user didn't specify AI config in app settings
+        if (!functionAppConfig.disableAppInsights()) {
+            // Give precedence to app insights connection string and only fall back to the instrumentation key.
+            if (StringUtils.isNotEmpty(functionAppConfig.appInsightsConnectionString())) {
+                this.instrumentationConnectionString = functionAppConfig.appInsightsConnectionString();
+            } else if (StringUtils.isNotEmpty(functionAppConfig.appInsightsKey())) {
                 this.instrumentationKey = functionAppConfig.appInsightsKey();
-            } else if (StringUtils.isNotEmpty(functionAppConfig.appInsightsInstance()) || !appDraft.exists()) {
-                // create AI instance by default when create new function
+            } else {
+                // Always create/resolve the AI instance to automatically migrate to connection-string wiring
                 registerSubTask(getApplicationInsightsTask(), result -> {
+                    if (result == null) {
+                        return;
+                    }
                     this.applicationInsight = result;
-                    this.instrumentationKey = Optional.ofNullable(result).map(ApplicationInsight::getInstrumentationKey).orElse(null);
+                    if (StringUtils.isNotEmpty(result.getConnectionString())) {
+                        this.instrumentationConnectionString = result.getConnectionString();
+                    } else {
+                        this.instrumentationKey = result.getInstrumentationKey();
+                    }
                 });
             }
         }
@@ -152,7 +163,7 @@ public class CreateOrUpdateFunctionAppTask extends AzureTask<FunctionAppBase<?, 
 
     private AzureTask<String> getDeploymentStorageContainerUrl(final FunctionAppDraft appDraft) {
         return new AzureTask<>(() -> {
-            final String containerName =  Optional.ofNullable(functionAppConfig.flexConsumptionConfiguration())
+            final String containerName = Optional.ofNullable(functionAppConfig.flexConsumptionConfiguration())
                 .map(FlexConsumptionConfiguration::getDeploymentContainer)
                 .orElseGet(() -> getDeploymentContainerNameFromApp(appDraft));
             try {
@@ -293,8 +304,12 @@ public class CreateOrUpdateFunctionAppTask extends AzureTask<FunctionAppBase<?, 
             functionAppConfig.appName(), functionAppConfig.subscriptionId());
         return new AzureTask<>(title, () -> {
             final Map<String, String> appSettings = processAppSettingsWithDefaultValue();
-            Optional.ofNullable(instrumentationKey).filter(StringUtils::isNoneEmpty).ifPresent(key ->
-                appSettings.put(APPINSIGHTS_INSTRUMENTATION_KEY, key));
+            if (StringUtils.isNotEmpty(instrumentationConnectionString)) {
+                appSettings.put(APPLICATIONINSIGHTS_CONNECTION_STRING, instrumentationConnectionString);
+                appSettings.remove(APPINSIGHTS_INSTRUMENTATION_KEY);
+            } else if (StringUtils.isNotEmpty(instrumentationKey)) {
+                appSettings.put(APPINSIGHTS_INSTRUMENTATION_KEY, instrumentationKey);
+            }
             draft.setAppServicePlan(appServicePlan);
             draft.setRegion(functionAppConfig.region());
             draft.setRuntime(getRuntime(functionAppConfig.runtime()));
@@ -347,6 +362,11 @@ public class CreateOrUpdateFunctionAppTask extends AzureTask<FunctionAppBase<?, 
             final Map<String, String> appSettings = processAppSettingsWithDefaultValue();
             if (functionAppConfig.disableAppInsights()) {
                 draft.removeAppSetting(APPINSIGHTS_INSTRUMENTATION_KEY);
+                draft.removeAppSetting(APPLICATIONINSIGHTS_CONNECTION_STRING);
+            } else if (StringUtils.isNotEmpty(instrumentationConnectionString)) {
+                appSettings.put(APPLICATIONINSIGHTS_CONNECTION_STRING, instrumentationConnectionString);
+                appSettings.remove(APPINSIGHTS_INSTRUMENTATION_KEY);
+                draft.removeAppSetting(APPINSIGHTS_INSTRUMENTATION_KEY);
             } else if (StringUtils.isNotEmpty(instrumentationKey)) {
                 appSettings.put(APPINSIGHTS_INSTRUMENTATION_KEY, instrumentationKey);
             }
@@ -371,8 +391,12 @@ public class CreateOrUpdateFunctionAppTask extends AzureTask<FunctionAppBase<?, 
             functionAppConfig.deploymentSlotName(), functionAppConfig.appName());
         return new AzureTask<>(title, () -> {
             final Map<String, String> appSettings = processAppSettingsWithDefaultValue();
-            Optional.ofNullable(instrumentationKey).filter(StringUtils::isNoneEmpty).ifPresent(key ->
-                appSettings.put(APPINSIGHTS_INSTRUMENTATION_KEY, key));
+            if (StringUtils.isNotEmpty(instrumentationConnectionString)) {
+                appSettings.put(APPLICATIONINSIGHTS_CONNECTION_STRING, instrumentationConnectionString);
+                appSettings.remove(APPINSIGHTS_INSTRUMENTATION_KEY);
+            } else if (StringUtils.isNotEmpty(instrumentationKey)) {
+                appSettings.put(APPINSIGHTS_INSTRUMENTATION_KEY, instrumentationKey);
+            }
             draft.setAppSettings(appSettings);
             draft.setRuntime(getRuntime(functionAppConfig.runtime()));
             draft.setDiagnosticConfig(functionAppConfig.diagnosticConfig());
@@ -389,6 +413,11 @@ public class CreateOrUpdateFunctionAppTask extends AzureTask<FunctionAppBase<?, 
         return new AzureTask<>(title, () -> {
             final Map<String, String> appSettings = processAppSettingsWithDefaultValue();
             if (functionAppConfig.disableAppInsights()) {
+                draft.removeAppSetting(APPINSIGHTS_INSTRUMENTATION_KEY);
+                draft.removeAppSetting(APPLICATIONINSIGHTS_CONNECTION_STRING);
+            } else if (StringUtils.isNotEmpty(instrumentationConnectionString)) {
+                appSettings.put(APPLICATIONINSIGHTS_CONNECTION_STRING, instrumentationConnectionString);
+                appSettings.remove(APPINSIGHTS_INSTRUMENTATION_KEY);
                 draft.removeAppSetting(APPINSIGHTS_INSTRUMENTATION_KEY);
             } else if (StringUtils.isNotEmpty(instrumentationKey)) {
                 appSettings.put(APPINSIGHTS_INSTRUMENTATION_KEY, instrumentationKey);

--- a/azure-toolkit-libs/azure-toolkit-appservice-lib/src/test/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateFunctionAppTaskTest.java
+++ b/azure-toolkit-libs/azure-toolkit-appservice-lib/src/test/java/com/microsoft/azure/toolkit/lib/appservice/task/CreateOrUpdateFunctionAppTaskTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.toolkit.lib.appservice.task;
+
+import com.microsoft.azure.toolkit.lib.Azure;
+import com.microsoft.azure.toolkit.lib.applicationinsights.ApplicationInsight;
+import com.microsoft.azure.toolkit.lib.applicationinsights.task.GetOrCreateApplicationInsightsTask;
+import com.microsoft.azure.toolkit.lib.appservice.config.FunctionAppConfig;
+import com.microsoft.azure.toolkit.lib.appservice.config.RuntimeConfig;
+import com.microsoft.azure.toolkit.lib.appservice.function.AzureFunctions;
+import com.microsoft.azure.toolkit.lib.appservice.function.FunctionApp;
+import com.microsoft.azure.toolkit.lib.appservice.function.FunctionAppDeploymentSlot;
+import com.microsoft.azure.toolkit.lib.appservice.function.FunctionAppDeploymentSlotDraft;
+import com.microsoft.azure.toolkit.lib.appservice.function.FunctionAppDeploymentSlotModule;
+import com.microsoft.azure.toolkit.lib.appservice.function.FunctionAppDraft;
+import com.microsoft.azure.toolkit.lib.appservice.function.FunctionAppModule;
+import com.microsoft.azure.toolkit.lib.appservice.model.OperatingSystem;
+import com.microsoft.azure.toolkit.lib.appservice.model.PricingTier;
+import com.microsoft.azure.toolkit.lib.appservice.plan.AppServicePlan;
+import com.microsoft.azure.toolkit.lib.auth.AzureAccount;
+import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
+import com.microsoft.azure.toolkit.lib.common.model.Region;
+import com.microsoft.azure.toolkit.lib.resource.AzureResources;
+import com.microsoft.azure.toolkit.lib.resource.ResourceGroup;
+import com.microsoft.azure.toolkit.lib.resource.ResourceGroupModule;
+import com.microsoft.azure.toolkit.lib.storage.AzureStorageAccount;
+import com.microsoft.azure.toolkit.lib.storage.StorageAccount;
+import com.microsoft.azure.toolkit.lib.storage.StorageAccountModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Map;
+
+import static com.microsoft.azure.toolkit.lib.appservice.task.CreateOrUpdateFunctionAppTask.APPINSIGHTS_INSTRUMENTATION_KEY;
+import static com.microsoft.azure.toolkit.lib.appservice.task.CreateOrUpdateFunctionAppTask.APPLICATIONINSIGHTS_CONNECTION_STRING;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CreateOrUpdateFunctionAppTaskTest {
+
+    private static final String APP_NAME = "test-function";
+    private static final String RESOURCE_GROUP = "test-rg";
+    private static final String SUBSCRIPTION_ID = "test-subscription-id";
+    private static final String CONNECTION_STRING = "InstrumentationKey=00000000;IngestionEndpoint=https://example.com/";
+
+    @Mock
+    private AzureFunctions azureFunctions;
+    @Mock
+    private FunctionAppModule functionAppModule;
+    @Mock
+    private FunctionAppDraft appDraft;
+    @Mock
+    private FunctionApp functionApp;
+    @Mock
+    private AzureResources azureResources;
+    @Mock
+    private ResourceGroupModule resourceGroupModule;
+    @Mock
+    private ResourceGroup resourceGroup;
+    @Mock
+    private AzureAccount azureAccount;
+
+    /* mocks for the new-app (create) path */
+    @Mock
+    private AzureStorageAccount azureStorageAccount;
+    @Mock
+    private StorageAccountModule storageAccountModule;
+    @Mock
+    private StorageAccount storageAccount;
+
+    /* mocks for the deployment-slot paths */
+    @Mock
+    private AppServicePlan appServicePlan;
+    @Mock
+    private PricingTier pricingTier;
+    @Mock
+    private FunctionAppDeploymentSlotModule slotModule;
+    @Mock
+    private FunctionAppDeploymentSlotDraft slotDraft;
+    @Mock
+    private FunctionAppDeploymentSlot deploymentSlot;
+
+    private MockedStatic<Azure> azure;
+    private MockedConstruction<GetOrCreateApplicationInsightsTask> mockedGetOrCreateAiTask;
+
+    @Before
+    public void setUp() {
+        AzureMessager.setDefaultMessager(new AzureMessager.DummyMessager());
+
+        azure = mockStatic(Azure.class);
+        azure.when(() -> Azure.az(AzureFunctions.class)).thenReturn(azureFunctions);
+        azure.when(() -> Azure.az(AzureResources.class)).thenReturn(azureResources);
+        azure.when(() -> Azure.az(AzureAccount.class)).thenReturn(azureAccount);
+
+        when(azureFunctions.functionApps(SUBSCRIPTION_ID)).thenReturn(functionAppModule);
+        when(functionAppModule.updateOrCreate(APP_NAME, RESOURCE_GROUP)).thenReturn(appDraft);
+        when(appDraft.isDraftForCreating()).thenReturn(false); // existing app
+        when(appDraft.exists()).thenReturn(true);
+        when(appDraft.getAppServicePlan()).thenReturn(null); // no flex consumption
+        when(appDraft.updateIfExist()).thenReturn(functionApp);
+
+        when(azureResources.groups(SUBSCRIPTION_ID)).thenReturn(resourceGroupModule);
+        when(resourceGroupModule.getOrDraft(RESOURCE_GROUP, RESOURCE_GROUP)).thenReturn(resourceGroup);
+        when(resourceGroup.isDraftForCreating()).thenReturn(false); // already exists, skip creation
+
+        // Mock App Insight Subtask
+        mockedGetOrCreateAiTask = mockConstruction(GetOrCreateApplicationInsightsTask.class, (mock, context) -> {
+            final ApplicationInsight aiInstance = org.mockito.Mockito.mock(ApplicationInsight.class);
+            when(aiInstance.getConnectionString()).thenReturn(CONNECTION_STRING);
+            when(mock.getBody()).thenReturn(() -> aiInstance);
+        });
+    }
+
+    @After
+    public void tearDown() {
+        azure.close();
+        mockedGetOrCreateAiTask.close();
+    }
+
+    /**
+     * Verifies that when appInsightsConnectionString is set on the config, it takes precedence over appInsightsKey.
+     */
+    @Test
+    public void doExecute_withConnectionString_writesConnectionStringAndRemovesIKey() throws Exception {
+
+        /* GIVEN */
+        final FunctionAppConfig config = buildBaseConfig()
+            .appInsightsConnectionString(CONNECTION_STRING);
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Map<String, String>> settingsCaptor = ArgumentCaptor.forClass(Map.class);
+
+        /* WHEN */
+        new CreateOrUpdateFunctionAppTask(config).doExecute();
+
+        /* THEN */
+        verify(appDraft).setAppSettings(settingsCaptor.capture());
+        final Map<String, String> writtenSettings = settingsCaptor.getValue();
+        assertEquals(CONNECTION_STRING, writtenSettings.get(APPLICATIONINSIGHTS_CONNECTION_STRING));
+        assertFalse("instrumentation key must not be written when connection string is set",
+            writtenSettings.containsKey(APPINSIGHTS_INSTRUMENTATION_KEY));
+    }
+
+    /**
+     * Verifies that when appInsightsKey is set on the config (and no appInsightsConnectionString), it is written to the app settings.
+     */
+    @Test
+    public void doExecute_withInstrumentationKeyOnly_writesIKey() throws Exception {
+        /* GIVEN */
+        final FunctionAppConfig config = buildBaseConfig()
+            .appInsightsKey("legacy-ikey-value");
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Map<String, String>> settingsCaptor = ArgumentCaptor.forClass(Map.class);
+
+        /* WHEN */
+        new CreateOrUpdateFunctionAppTask(config).doExecute();
+
+        /* THEN */
+
+        verify(appDraft).setAppSettings(settingsCaptor.capture());
+
+        final Map<String, String> writtenSettings = settingsCaptor.getValue();
+        assertEquals("legacy-ikey-value", writtenSettings.get(APPINSIGHTS_INSTRUMENTATION_KEY));
+        assertNull("Connection string must not be written when only instrumentation key is set",
+            writtenSettings.get(APPLICATIONINSIGHTS_CONNECTION_STRING));
+    }
+
+    /**
+     * Verifies that when no explicit App Insights config is set, the task resolves the AI instance and writes its connection string into the app settings.
+     */
+    @Test
+    public void doExecute_withNoExplicitInsightsConfig_looksUpInstanceAndWritesConnectionString() throws Exception {
+        /* GIVEN */
+        final FunctionAppConfig config = buildBaseConfig(); // no appInsightsConnectionString, no appInsightsKey
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Map<String, String>> settingsCaptor = ArgumentCaptor.forClass(Map.class);
+
+        /* WHEN */
+        new CreateOrUpdateFunctionAppTask(config).doExecute();
+
+        /* THEN */
+        verify(appDraft).setAppSettings(settingsCaptor.capture());
+
+        final Map<String, String> writtenSettings = settingsCaptor.getValue();
+        assertEquals(CONNECTION_STRING, writtenSettings.get(APPLICATIONINSIGHTS_CONNECTION_STRING));
+        assertFalse("Instrumentation key must not be written when connection string is resolved from AI instance",
+            writtenSettings.containsKey(APPINSIGHTS_INSTRUMENTATION_KEY));
+    }
+
+    /**
+     * Verifies that when the function app does not yet exist, the connection string is written into the new app's settings.
+     */
+    @Test
+    public void doExecute_createPath_withConnectionString_writesConnectionString() throws Exception {
+        /* GIVEN */
+        azure.when(() -> Azure.az(AzureStorageAccount.class)).thenReturn(azureStorageAccount);
+        when(azureStorageAccount.accounts(SUBSCRIPTION_ID)).thenReturn(storageAccountModule);
+        when(storageAccountModule.get(anyString(), anyString())).thenReturn(storageAccount);
+        when(storageAccount.exists()).thenReturn(true);
+
+        when(appDraft.isDraftForCreating()).thenReturn(true);
+        when(appDraft.exists()).thenReturn(false);
+        when(appDraft.createIfNotExist()).thenReturn(functionApp);
+
+        final FunctionAppConfig config = buildBaseConfig()
+            .appInsightsConnectionString(CONNECTION_STRING);
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Map<String, String>> settingsCaptor = ArgumentCaptor.forClass(Map.class);
+
+        /* WHEN */
+        new CreateOrUpdateFunctionAppTask(config).doExecute();
+
+        /* THEN */
+        verify(appDraft).setAppSettings(settingsCaptor.capture());
+        final Map<String, String> writtenSettings = settingsCaptor.getValue();
+        assertEquals(CONNECTION_STRING, writtenSettings.get(APPLICATIONINSIGHTS_CONNECTION_STRING));
+        assertFalse("Instrumentation key must not be written when connection string is set",
+            writtenSettings.containsKey(APPINSIGHTS_INSTRUMENTATION_KEY));
+    }
+
+    /**
+     * Verifies that when the deployment slot already exists, the connection string is written into the slot's settings.
+     */
+    @Test
+    public void doExecute_updateSlotPath_withConnectionString_writesConnectionString() throws Exception {
+        /* GIVEN */
+        when(appDraft.getAppServicePlan()).thenReturn(appServicePlan);
+        when(appServicePlan.getPricingTier()).thenReturn(pricingTier);
+
+        when(appDraft.slots()).thenReturn(slotModule);
+        when(slotModule.updateOrCreate("staging", RESOURCE_GROUP)).thenReturn(slotDraft);
+        when(slotDraft.exists()).thenReturn(true);
+        when(slotDraft.commit()).thenReturn(deploymentSlot);
+
+        final FunctionAppConfig config = buildBaseConfig();
+        config.deploymentSlotName("staging");
+        config.appInsightsConnectionString(CONNECTION_STRING);
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Map<String, String>> settingsCaptor = ArgumentCaptor.forClass(Map.class);
+
+        /* WHEN */
+        new CreateOrUpdateFunctionAppTask(config).doExecute();
+
+        /* THEN */
+        verify(slotDraft).setAppSettings(settingsCaptor.capture());
+        final Map<String, String> writtenSettings = settingsCaptor.getValue();
+        assertEquals(CONNECTION_STRING, writtenSettings.get(APPLICATIONINSIGHTS_CONNECTION_STRING));
+        assertFalse("Instrumentation key must not be written when connection string is set",
+            writtenSettings.containsKey(APPINSIGHTS_INSTRUMENTATION_KEY));
+    }
+
+    private FunctionAppConfig buildBaseConfig() {
+        return (FunctionAppConfig) new FunctionAppConfig()
+            .appName(APP_NAME)
+            .resourceGroup(RESOURCE_GROUP)
+            .subscriptionId(SUBSCRIPTION_ID)
+            .region(Region.EUROPE_WEST)
+            .runtime(new RuntimeConfig().os(OperatingSystem.LINUX).javaVersion("Java 8"));
+    }
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This PR adds support for Application Insights Connection Strings in the Azure Functions Maven plugin. It addresses the fact that Instrumentation Keys have been deprecated a while ago: https://azure.microsoft.com/en-gb/updates?id=technical-support-for-instrumentation-key-based-global-ingestion-in-application-insights-will-end-on-31-march-2025

Main changes:
- Added a new config option: `appInsightsConnectionString`.
- Wired it through parsing/config (`AbstractFunctionMojo` -> `ConfigParser` -> `FunctionAppConfig` / `ApplicationInsightsConfig`).
- Updated Function App create/update/slot flows to handle `APPLICATIONINSIGHTS_CONNECTION_STRING`.
- Kept `appInsightsKey` support for backward compatibility, but prefer connection string when available.
- Added validation so users cannot set both `appInsightsKey` and `appInsightsConnectionString` explicitly.
- Improved redeploy behavior: if neither key nor connection string is explicitly configured, only the insights instance, deployment can resolve App Insights and migrate to connection-string based wiring.

Does this close any currently open issues?
------------------------------------------
Closes #2562

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
no

Any other comments?
-------------------
Goal here was to improve default behavior for new and redeployed apps without breaking existing users who still rely on `appInsightsKey`.

Has this been tested?
---------------------------
- [x] Tests in this PR
- [x] Actual deployment to Azure Cloud 
